### PR TITLE
Dump: Handle Slang and improve untyped

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "containers/container_utils.h"
 #include "generated/spirv_grammar_helper.h"
 #include "gpu_dump_state.h"
 #include "gpu_dump.h"
@@ -1423,6 +1424,10 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 //
 // You have hit Untyped Pointer territory, brace yourselves!
 //
+static const uint32_t kDynamicIndex = vvl::kNoIndex32;
+static const uint32_t kNoPushData = vvl::kNoIndex32;
+// If there is some math logic to calculate this
+static const uint32_t kPushDataRange = vvl::kNoIndex32 - 1;
 struct HeapAccess {
     VkDescriptorType descriptor_type = VK_DESCRIPTOR_TYPE_MAX_ENUM;
     // These are zero because if not found, it means it is implicitly zero
@@ -1431,35 +1436,78 @@ struct HeapAccess {
     // Might have multidimensional array and need an index for each
     struct Index {
         uint32_t array_stride = 0;
-        uint32_t element = vvl::kNoIndex32;
+        uint32_t element = kDynamicIndex;
+        uint32_t push_data_index = kNoPushData;
 
-        bool operator==(const Index& other) const { return array_stride == other.array_stride && element == other.element; }
+        bool operator==(const Index& other) const {
+            return array_stride == other.array_stride && element == other.element && push_data_index == other.push_data_index;
+        }
+
+        // Required so we can compare std::vector<Index> in tie-breakers
+        bool operator<(const Index& other) const { return element < other.element; }
     };
     std::vector<Index> descriptor_indexes;
 
     // Lets us know this access is done inside a function
     bool function_call = false;
 
+    // Values that are calculated from the above values
+    // (So no reason to apply to the hashing)
+    bool is_array = false;
+    bool is_sampler = false;
+    bool dynamic_index = false;
+    // Zero so dynamic values are first in the sorting
+    VkDeviceSize final_address = 0;
+
+    HeapAccess(const CommandBufferSubState& cb_sub_state, VkDescriptorType descriptor_type, uint32_t heap_offset,
+               std::vector<Index> descriptor_indexes, bool function_call)
+        : descriptor_type(descriptor_type),
+          heap_offset(heap_offset),
+          descriptor_indexes(descriptor_indexes),
+          function_call(function_call),
+          is_array(!descriptor_indexes.empty()),
+          is_sampler(descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLER) {
+        auto heap_range =
+            is_sampler ? cb_sub_state.base.descriptor_heap.sampler_range : cb_sub_state.base.descriptor_heap.resource_range;
+        VkDeviceSize final_offset = heap_offset;
+        for (const auto& descriptor_index : descriptor_indexes) {
+            if (descriptor_index.element == kDynamicIndex) {
+                dynamic_index = true;
+            } else {
+                final_offset += descriptor_index.array_stride * descriptor_index.element;
+            }
+        }
+
+        if (!is_array) {
+            final_address = heap_range.begin + heap_offset;
+        } else if (!dynamic_index) {
+            final_address = heap_range.begin + final_offset;
+        }
+    }
+
     struct compare {
         bool operator()(HeapAccess const& lhs, HeapAccess const& rhs) const {
-            return lhs.descriptor_type == rhs.descriptor_type && lhs.heap_offset == rhs.heap_offset &&
-                   lhs.descriptor_indexes == rhs.descriptor_indexes;
-        }
-    };
-
-    // We don't want duplicate accesses being spammed
-    struct hash {
-        std::size_t operator()(HeapAccess const& access) const {
-            hash_util::HashCombiner hc;
-            hc << access.descriptor_type << access.heap_offset;
-            for (const auto& di : access.descriptor_indexes) {
-                hc << di.array_stride << di.element;
+            // Main thing want to sort by
+            // May change sorting logic here if we find a better way to sort
+            if (lhs.final_address != rhs.final_address) {
+                return lhs.final_address < rhs.final_address;
             }
-            return hc.Value();
+
+            if (lhs.descriptor_type != rhs.descriptor_type) {
+                return lhs.descriptor_type < rhs.descriptor_type;
+            }
+            if (lhs.heap_offset != rhs.heap_offset) {
+                return lhs.heap_offset < rhs.heap_offset;
+            }
+            if (lhs.function_call != rhs.function_call) {
+                return lhs.function_call < rhs.function_call;  // false < true
+            }
+            return lhs.descriptor_indexes < rhs.descriptor_indexes;
         }
     };
 };
-using HeapAccesses = vvl::unordered_set<HeapAccess, HeapAccess::hash, HeapAccess::compare>;
+// <set> because we want
+using HeapAccesses = std::set<HeapAccess, HeapAccess::compare>;
 
 // Tracks all the OpFunction/OpFunctionCall/OpFunctionParameter info we need
 struct FunctionInfo {
@@ -1474,6 +1522,7 @@ struct FunctionInfo {
 };
 
 struct UntypedContext {
+    const CommandBufferSubState& cb_sub_state;
     const vvl::DeviceState& device_state;
     const spirv::Module& module;
     const spirv::EntryPoint& entrypoint;
@@ -1485,8 +1534,10 @@ struct UntypedContext {
 
     FunctionInfo function_info;
 
-    UntypedContext(GpuDump& dev_data, const spirv::Module& module, const spirv::EntryPoint& entrypoint)
-        : device_state(*dev_data.device_state),
+    UntypedContext(const CommandBufferSubState& cb_sub_state, GpuDump& dev_data, const spirv::Module& module,
+                   const spirv::EntryPoint& entrypoint)
+        : cb_sub_state(cb_sub_state),
+          device_state(*dev_data.device_state),
           module(module),
           entrypoint(entrypoint),
           props(dev_data.phys_dev_ext_props.descriptor_heap_props) {
@@ -1507,6 +1558,7 @@ struct UntypedContext {
         }
     }
 
+    uint32_t FindPushDataIndex(const spirv::Instruction& access_inst, uint32_t* out_result);
     void GetUntypedDescriptorIndexes(std::vector<HeapAccess::Index>& out_descriptor_indexes,
                                      std::vector<const spirv::Instruction*>& ac_indexes, const spirv::Instruction& type_array_inst);
     uint32_t GetUntypedArrayStride(uint32_t type_array_id);
@@ -1544,6 +1596,75 @@ uint32_t UntypedContext::GetUntypedArrayStride(uint32_t type_array_id) {
     return module.GetHeapUntypedSize(props, *array_stride_inst);
 }
 
+// This is a quick, low effort attempt to see if we can detect the index into the descriptor is a push data value
+// Anything more than this would require a "proper" solution for static analysis
+uint32_t UntypedContext::FindPushDataIndex(const spirv::Instruction& access_inst, uint32_t* out_result) {
+    uint32_t push_data_index = kNoPushData;
+    if (!entrypoint.push_constant_variable || !entrypoint.push_constant_variable->type_struct_info) {
+        return push_data_index;
+    }
+
+    // support some basic math int operations
+    if (IsValueIn((spv::Op)access_inst.Opcode(), {spv::OpIMul, spv::OpIAdd, spv::OpISub, spv::OpUDiv})) {
+        const spirv::Instruction* operand_0_inst = module.FindDef(access_inst.Word(3));
+        const spirv::Instruction* operand_1_inst = module.FindDef(access_inst.Word(4));
+        uint32_t operand_0_value = 0;
+        uint32_t operand_1_value = 0;
+        const uint32_t operand_0_index = FindPushDataIndex(*operand_0_inst, &operand_0_value);
+        const uint32_t operand_1_index = FindPushDataIndex(*operand_1_inst, &operand_1_value);
+        if (operand_0_index == kNoPushData || operand_1_index == kNoPushData) {
+            return kNoPushData;
+        }
+        if (access_inst.Opcode() == spv::OpIMul) {
+            *out_result = operand_0_value * operand_1_value;
+        } else if (access_inst.Opcode() == spv::OpIAdd) {
+            *out_result = operand_0_value + operand_1_value;
+        } else if (access_inst.Opcode() == spv::OpISub) {
+            *out_result = operand_0_value - operand_1_value;
+        } else if (access_inst.Opcode() == spv::OpUDiv) {
+            *out_result = operand_0_value / operand_1_value;
+        }
+        return (operand_0_index == operand_1_index) ? operand_0_index : kPushDataRange;
+    } else if (access_inst.Opcode() == spv::OpConstant) {
+        // if here, part of a calculation above
+        *out_result = access_inst.GetConstantValue();
+        return kPushDataRange;
+    } else if (access_inst.Opcode() != spv::OpLoad) {
+        return push_data_index;
+    }
+
+    if (module.FindDef(access_inst.TypeId())->Opcode() != spv::OpTypeInt) {
+        return push_data_index;
+    }
+    const spirv::Instruction* access_chain_inst = module.FindDef(access_inst.Word(3));
+    if (access_chain_inst->Opcode() != spv::OpAccessChain) {
+        return push_data_index;
+    }
+    const spirv::Instruction* pc_var = module.FindDef(access_chain_inst->Word(3));
+    if (pc_var->ResultId() != entrypoint.push_constant_variable->id) {
+        return push_data_index;
+    }
+    const spirv::Instruction* pc_member_offset_inst = module.FindDef(access_chain_inst->Word(4));
+    if (pc_member_offset_inst->Opcode() != spv::OpConstant) {
+        return push_data_index;
+    }
+    const uint32_t pc_member_offset = pc_member_offset_inst->GetConstantValue();
+    if (pc_member_offset >= entrypoint.push_constant_variable->type_struct_info->members.size()) {
+        return push_data_index;
+    }
+    const uint32_t pc_offset = entrypoint.push_constant_variable->type_struct_info->members[pc_member_offset].decorations->offset;
+    if (pc_offset == spirv::kInvalidValue) {
+        return push_data_index;
+    }
+    if (pc_offset >= cb_sub_state.push_data_value.size()) {
+        return push_data_index;
+    }
+
+    assert(out_result);
+    *out_result = *((uint32_t*)&cb_sub_state.push_data_value[pc_offset]);
+    return pc_offset;
+}
+
 void UntypedContext::GetUntypedDescriptorIndexes(std::vector<HeapAccess::Index>& out_descriptor_indexes,
                                                  std::vector<const spirv::Instruction*>& ac_indexes,
                                                  const spirv::Instruction& type_array_inst) {
@@ -1552,16 +1673,20 @@ void UntypedContext::GetUntypedDescriptorIndexes(std::vector<HeapAccess::Index>&
 
     const uint32_t array_stride_value = GetUntypedArrayStride(type_array_id);
 
-    uint32_t element = vvl::kNoIndex32;  // dynamic index
+    uint32_t element = kDynamicIndex;
+    uint32_t push_data_index = kNoPushData;
     if (ac_indexes.empty()) {
         element = 0;  // implicit zero if no AC index is found
     } else {
         const spirv::Instruction* element_inst = ac_indexes.back();
         ac_indexes.pop_back();
-        module.GetInt32IfConstant(*element_inst, &element);
+        const bool found = module.GetInt32IfConstant(*element_inst, &element);
+        if (!found) {
+            push_data_index = FindPushDataIndex(*element_inst, &element);
+        }
     }
 
-    out_descriptor_indexes.emplace_back(HeapAccess::Index{array_stride_value, element});
+    out_descriptor_indexes.emplace_back(HeapAccess::Index{array_stride_value, element, push_data_index});
 
     // Keep checking for multidimensional arrays
     const spirv::Instruction* element_type_inst = module.FindDef(type_array_inst.Word(2));
@@ -1629,7 +1754,7 @@ void UntypedContext::AddAccess(const VkDescriptorType descriptor_type, const spi
         GetUntypedDescriptorIndexes(descriptor_indexes, ac_indexes, *base_type_inst);
     }
 
-    accesses[variable_id].insert(HeapAccess{descriptor_type, heap_offset, descriptor_indexes, function_call});
+    accesses[variable_id].insert({cb_sub_state, descriptor_type, heap_offset, descriptor_indexes, function_call});
 }
 
 std::vector<const spirv::Instruction*> UntypedContext::FindFunctionCallers(const spirv::Instruction& func_param_inst) {
@@ -1761,29 +1886,37 @@ bool UntypedContext::Print(std::ostringstream& ss, vvl::CommandBuffer& cb_state)
         auto reserve_range = is_sampler ? cb_state.descriptor_heap.sampler_reserved : cb_state.descriptor_heap.resource_reserved;
 
         for (const HeapAccess& access : it->second) {
-            ss << "    - heap offset: 0x" << std::hex << access.heap_offset;
-            VkDeviceSize final_address = 0;
+            assert(is_sampler == (access.descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLER));
 
-            const bool is_array = !access.descriptor_indexes.empty();
-            if (!is_array) {
+            ss << "    - heap offset: 0x" << std::hex << access.heap_offset;
+
+            if (!access.is_array) {
                 ss << ", single element\n";
-                final_address = heap_range.begin + access.heap_offset;
             } else {
                 ss << ", array stride: ";
                 for (const auto& descriptor_index : access.descriptor_indexes) {
                     ss << "[" << std::dec << descriptor_index.array_stride << "]";
                 }
 
-                VkDeviceSize final_offset = access.heap_offset;
-                bool dynamic_index = false;
                 ss << ", array index: ";
+                // To print multidimensional arrays
                 for (const auto& descriptor_index : access.descriptor_indexes) {
-                    if (descriptor_index.element == vvl::kNoIndex32) {
-                        dynamic_index = true;
+                    if (descriptor_index.element == kDynamicIndex) {
                         ss << "[dynamic]";
                     } else {
                         ss << "[" << std::dec << descriptor_index.element << "]";
-                        final_offset += descriptor_index.array_stride * descriptor_index.element;
+                    }
+                }
+
+                for (const auto& descriptor_index : access.descriptor_indexes) {
+                    if (descriptor_index.element != kDynamicIndex) {
+                        if (descriptor_index.push_data_index == kPushDataRange) {
+                            ss << " (from vkCmdPushDataEXT values)";
+                            break;  // only need once
+                        } else if (descriptor_index.push_data_index != vvl::kNoIndex32) {
+                            ss << " (from vkCmdPushDataEXT[" << descriptor_index.push_data_index << ":"
+                               << descriptor_index.push_data_index + 3 << "])";
+                        }
                     }
                 }
 
@@ -1793,13 +1926,10 @@ bool UntypedContext::Print(std::ostringstream& ss, vvl::CommandBuffer& cb_state)
                 }
 
                 ss << '\n';
-                if (!dynamic_index) {
-                    final_address = heap_range.begin + final_offset;
-                }
             }
 
-            if (final_address != 0) {
-                ss << "      - " << (is_sampler ? "Sampler" : "Resource") << " heap address: 0x" << std::hex << final_address
+            if (access.final_address != 0) {
+                ss << "      - " << (is_sampler ? "Sampler" : "Resource") << " heap address: 0x" << std::hex << access.final_address
                    << '\n';
             }
 
@@ -1808,14 +1938,14 @@ bool UntypedContext::Print(std::ostringstream& ss, vvl::CommandBuffer& cb_state)
                << string_VkDescriptorType(access.descriptor_type) << ")\n";
 
             // if we know the real address, see if invalid
-            if (final_address != vvl::kNoIndex32) {
-                if (final_address > heap_range.end) {
+            if (access.final_address != 0) {
+                if (access.final_address > heap_range.end) {
                     ss << "      - [WARNING] OUT OF BOUNDS - the descriptor is not in the " << (is_sampler ? "sampler" : "resource")
                        << " heap\n";
                     found_warning = true;
                 }
                 if (!reserve_range.empty()) {
-                    vvl::range<VkDeviceAddress> final_range{final_address, final_address + descriptor_size};
+                    vvl::range<VkDeviceAddress> final_range{access.final_address, access.final_address + descriptor_size};
                     if (final_range.intersects(reserve_range)) {
                         ss << "      - [WARNING] RESERVED RANGE - this descriptor overlaps with the reserved range\n";
                         found_warning = true;
@@ -1823,7 +1953,7 @@ bool UntypedContext::Print(std::ostringstream& ss, vvl::CommandBuffer& cb_state)
                 }
 
                 VkDeviceSize required_alignment = GetDescriptorHeapAlignment(props, access.descriptor_type);
-                if (!IsPointerAligned(final_address, required_alignment)) {
+                if (!IsPointerAligned(access.final_address, required_alignment)) {
                     vvl::Field alignment_name = GetDescriptorHeapAlignmentField(access.descriptor_type);
                     ss << "      - [WARNING] MISALIGNED - the descriptor is not aligned to " << String(alignment_name);
                     ss << " (" << std::dec << required_alignment << ")\n";
@@ -1887,7 +2017,7 @@ bool CommandBufferSubState::DumpDescriptorHeapUntyped(std::ostringstream& ss, co
         }
     }
 
-    UntypedContext context(dev_data, *module_state_ptr, *entrypoint_ptr);
+    UntypedContext context(*this, dev_data, *module_state_ptr, *entrypoint_ptr);
 
     for (const spirv::Instruction* memory_access_inst : context.entrypoint.accessible.memory_accesses) {
         // Basically there are 2 flows, images and non-images

--- a/layers/gpu_dump/gpu_dump_state.h
+++ b/layers/gpu_dump/gpu_dump_state.h
@@ -42,6 +42,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordCopyMemoryIndirect(const VkCopyMemoryIndirectInfoKHR& info, const Location& loc) final;
     void RecordCopyMemoryToImageIndirect(const VkCopyMemoryToImageIndirectInfoKHR& info, const Location& loc) final;
 
+    std::vector<uint8_t> push_data_value;
+
   private:
     void DumpDescriptors(const LastBound& last_bound, const Location& loc) const;
     bool DumpDescriptorBuffer(std::ostringstream& ss, const LastBound& last_bound) const;
@@ -76,8 +78,6 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     void DumpDeviceGeneratedCommands(const VkGeneratedCommandsInfoEXT& info, VkPipelineBindPoint bind_point,
                                      const Location& loc) const;
-
-    std::vector<uint8_t> push_data_value;
 };
 
 static inline CommandBufferSubState& SubState(vvl::CommandBuffer& cb) {

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1733,38 +1733,36 @@ uint32_t Module::ResolveConstantSizeOf(const VkPhysicalDeviceDescriptorHeapPrope
     return 0;
 }
 
+static uint32_t ResolveConstantFoldOperand(const Module& module, const Instruction& operand_inst, const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props) {
+    if (operand_inst.Opcode() == spv::OpConstantSizeOfEXT) {
+        return module.ResolveConstantSizeOf(props, operand_inst);
+    } else if (operand_inst.Opcode() == spv::OpSpecConstantOp) {
+        return module.ResolveConstantFoldHeaps(props, operand_inst);
+    }
+    return operand_inst.GetConstantValue();
+}
+
 // if we hit this, its because of OpConstantSizeOfEXT can't be folded (https://godbolt.org/z/3z6Pao4sf)
 // TODO - We will need some sort of internal constant folding here... fun!
 // ... for now lets make assumption only thing people will use here is IMul/IAdd/Isub and just do some folding
+//
+// Slang with -spirv-unified-descriptor-heap-stride will do a OpSelect/OpUGreaterThan to get a max(buffer, image)
 uint32_t Module::ResolveConstantFoldHeaps(const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props,
                                           const spirv::Instruction& spec_constant_op) const {
     assert(spec_constant_op.Opcode() == spv::OpSpecConstantOp);
     const uint32_t spec_op = spec_constant_op.Word(3);
-    if (spec_op != spv::OpIMul && spec_op != spv::OpIAdd && spec_op != spv::OpISub) {
+    if (!IsValueIn((spv::Op)spec_op, {spv::OpIMul, spv::OpIAdd, spv::OpISub, spv::OpUGreaterThan, spv::OpUGreaterThanEqual, spv::OpULessThan, spv::OpULessThanEqual, spv::OpSelect})) {
         assert(false);  // hit another case
         return 0;
     }
 
-    const spirv::Instruction& operand_0_inst = *FindDef(spec_constant_op.Word(4));
-    const spirv::Instruction& operand_1_inst = *FindDef(spec_constant_op.Word(5));
+    const spirv::Instruction* operand_0_inst = FindDef(spec_constant_op.Word(4));
+    const spirv::Instruction* operand_1_inst = FindDef(spec_constant_op.Word(5));
+    const spirv::Instruction* operand_2_inst = spec_constant_op.Length() > 6 ? FindDef(spec_constant_op.Word(6)) : nullptr;
 
-    uint32_t operand_0 = 0;
-    if (operand_0_inst.Opcode() == spv::OpConstantSizeOfEXT) {
-        operand_0 = ResolveConstantSizeOf(props, operand_0_inst);
-    } else if (operand_0_inst.Opcode() == spv::OpSpecConstantOp) {
-        operand_0 = ResolveConstantFoldHeaps(props, operand_0_inst);
-    } else {
-        operand_0 = operand_0_inst.GetConstantValue();
-    }
-
-    uint32_t operand_1 = 0;
-    if (operand_1_inst.Opcode() == spv::OpConstantSizeOfEXT) {
-        operand_1 = ResolveConstantSizeOf(props, operand_1_inst);
-    } else if (operand_1_inst.Opcode() == spv::OpSpecConstantOp) {
-        operand_1 = ResolveConstantFoldHeaps(props, operand_1_inst);
-    } else {
-        operand_1 = operand_1_inst.GetConstantValue();
-    }
+    const uint32_t operand_0 = ResolveConstantFoldOperand(*this, *operand_0_inst, props);
+    const uint32_t operand_1 = ResolveConstantFoldOperand(*this, *operand_1_inst, props);
+    const uint32_t operand_2 = operand_2_inst ? ResolveConstantFoldOperand(*this, *operand_2_inst, props) : 0;
 
     if (spec_op == spv::OpIMul) {
         return operand_0 * operand_1;
@@ -1772,6 +1770,16 @@ uint32_t Module::ResolveConstantFoldHeaps(const VkPhysicalDeviceDescriptorHeapPr
         return operand_0 + operand_1;
     } else if (spec_op == spv::OpISub) {
         return operand_0 - operand_1;
+    } else if (spec_op == spv::OpUGreaterThan) {
+        return operand_0 > operand_1;
+    } else if (spec_op == spv::OpUGreaterThanEqual) {
+        return operand_0 >= operand_1;
+    } else if (spec_op == spv::OpULessThan) {
+        return operand_0 < operand_1;
+    } else if (spec_op == spv::OpULessThanEqual) {
+        return operand_0 <= operand_1;
+    } else if (spec_op == spv::OpSelect) {
+        return operand_0 != 0 ? operand_1 : operand_2;
     }
     assert(false);
     return 0;

--- a/tests/unit/descriptor_heap_untyped_positive.cpp
+++ b/tests/unit/descriptor_heap_untyped_positive.cpp
@@ -1721,12 +1721,14 @@ TEST_F(PositiveDescriptorHeapUntyped, SlangBasicBuffer) {
     RETURN_IF_SKIP(InitUntypedDescriptorHeap());
 
     vkt::DescriptorHeap desc_heap(*this);
-    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize * 2);
+    // Because of -spirv-unified-descriptor-heap-stride
+    const VkDeviceSize resource_stride = std::max(heap_props.imageDescriptorSize, heap_props.bufferDescriptorSize);
+    desc_heap.CreateResourceHeap(resource_stride * 2);
 
     vkt::Buffer buffer_0(*m_device, 256, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
     vkt::Buffer buffer_1(*m_device, 256, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
-    desc_heap.WriteBufferDescriptor(buffer_0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    desc_heap.WriteBufferDescriptor(buffer_1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    desc_heap.WriteBufferDescriptorAtOffset(buffer_0.AddressRange(), VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 0);
+    desc_heap.WriteBufferDescriptorAtOffset(buffer_1.AddressRange(), VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, resource_stride);
 
     // Heap support not yet in any release build
     //   will need -capability spvDescriptorHeapEXT -spirv-unified-descriptor-heap-stride

--- a/tests/unit/descriptor_heap_untyped_positive.cpp
+++ b/tests/unit/descriptor_heap_untyped_positive.cpp
@@ -275,6 +275,312 @@ TEST_F(PositiveDescriptorHeapUntyped, ImageAndSampler) {
     }
 }
 
+TEST_F(PositiveDescriptorHeapUntyped, ImageAndSamplerSlang) {
+    TEST_DESCRIPTION("called without -spirv-unified-descriptor-heap-stride");
+    AddRequiredExtensions(VK_KHR_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::computeDerivativeGroupQuads);
+    RETURN_IF_SKIP(InitUntypedDescriptorHeap());
+    InitRenderTarget();
+
+    const VkDeviceSize resource_stride = std::max(heap_props.imageDescriptorSize, heap_props.bufferDescriptorSize);
+    const uint32_t image_index = 8;
+    const uint32_t buffer_index = 1;
+
+    const VkDeviceSize image_offset = heap_props.imageDescriptorSize * image_index;
+    const VkDeviceSize buffer_offset = heap_props.bufferDescriptorSize * buffer_index;
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(resource_stride * 10);
+
+    vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
+    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    desc_heap.WriteBufferDescriptorAtOffset(buffer.AddressRange(), VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_offset);
+    desc_heap.WriteImageDescriptorAtOffset(image, image_offset);
+
+    desc_heap.CreateSamplerHeap(heap_props.samplerDescriptorSize);
+    desc_heap.WriteSamplerDescriptor();
+
+    // struct SSBO { float4 data; };
+    // struct PushConstants {
+    //     uint buffer_index;
+    //     uint image_index;
+    // };
+    // [[vk::push_constant]] PushConstants g_Push;
+    // [shader("compute")]
+    // [numthreads(2, 2, 1)]
+    // void main() {
+    //     Texture2D<float4> heapTexture = ResourceDescriptorHeap[g_Push.image_index];
+    //     SamplerState heapSampler = SamplerDescriptorHeap[0];
+    //     float4 sampleColor = heapTexture.Sample(heapSampler, float2(0.5f, 0.5f));
+    //     RWStructuredBuffer<SSBO> heapBuffer = ResourceDescriptorHeap[g_Push.buffer_index];
+    //     heapBuffer[0].data = sampleColor;
+    // }
+    char const* cs_source = R"(
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpCapability ComputeDerivativeGroupQuadsKHR
+               OpCapability Shader
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_compute_shader_derivatives"
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %slang_resourceHeap %slang_samplerHeap %g_Push
+               OpExecutionMode %main DerivativeGroupQuadsKHR
+               OpExecutionMode %main LocalSize 2 2 1
+               OpDecorate %PushConstants_std430 Block
+               OpMemberDecorate %PushConstants_std430 0 Offset 0
+               OpMemberDecorate %PushConstants_std430 1 Offset 4
+               OpDecorateId %_runtimearr_19 ArrayStrideIdEXT %20
+               OpDecorate %slang_resourceHeap BuiltIn ResourceHeapEXT
+               OpDecorateId %_runtimearr_28 ArrayStrideIdEXT %29
+               OpDecorate %slang_samplerHeap BuiltIn SamplerHeapEXT
+               OpDecorateId %_runtimearr_47 ArrayStrideIdEXT %48
+               OpMemberDecorate %SSBO_std430 0 Offset 0
+               OpDecorate %_runtimearr_SSBO_std430 ArrayStride 16
+               OpDecorate %RWStructuredBuffer Block
+               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+               OpDecorate %_ptr_StorageBuffer_SSBO_std430 ArrayStride 16
+               OpDecorate %_ptr_StorageBuffer_v4float ArrayStride 16
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%PushConstants_std430 = OpTypeStruct %uint %uint
+%_ptr_PushConstant_PushConstants_std430 = OpTypePointer PushConstant %PushConstants_std430
+        %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+%_ptr_PushConstant_uint = OpTypePointer PushConstant %uint
+     %uint_0 = OpConstant %uint 0
+      %float = OpTypeFloat 32
+         %19 = OpTypeImage %float 2D 2 0 0 1 Unknown
+         %20 = OpConstantSizeOfEXT %uint %19
+%_runtimearr_19 = OpTypeRuntimeArray %19
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+         %28 = OpTypeSampler
+         %29 = OpConstantSizeOfEXT %uint %28
+%_runtimearr_28 = OpTypeRuntimeArray %28
+         %34 = OpTypeSampledImage %19
+    %v4float = OpTypeVector %float 4
+    %v2float = OpTypeVector %float 2
+  %float_0_5 = OpConstant %float 0.5
+         %39 = OpConstantComposite %v2float %float_0_5 %float_0_5
+      %int_0 = OpConstant %int 0
+         %47 = OpTypeBufferEXT StorageBuffer
+         %48 = OpConstantSizeOfEXT %uint %47
+%_runtimearr_47 = OpTypeRuntimeArray %47
+%SSBO_std430 = OpTypeStruct %v4float
+%_runtimearr_SSBO_std430 = OpTypeRuntimeArray %SSBO_std430
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_SSBO_std430
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+%_ptr_StorageBuffer_SSBO_std430 = OpTypePointer StorageBuffer %SSBO_std430
+%_ptr_StorageBuffer_v4float = OpTypePointer StorageBuffer %v4float
+     %g_Push = OpVariable %_ptr_PushConstant_PushConstants_std430 PushConstant
+%slang_resourceHeap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+%slang_samplerHeap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+       %main = OpFunction %void None %3
+          %4 = OpLabel
+         %12 = OpAccessChain %_ptr_PushConstant_uint %g_Push %int_1
+         %13 = OpLoad %uint %12
+         %23 = OpUntypedAccessChainKHR %_ptr_UniformConstant %_runtimearr_19 %slang_resourceHeap %13
+         %25 = OpLoad %19 %23
+         %31 = OpUntypedAccessChainKHR %_ptr_UniformConstant %_runtimearr_28 %slang_samplerHeap %uint_0
+         %33 = OpLoad %28 %31
+         %35 = OpSampledImage %34 %25 %33
+  %__sampled = OpImageSampleImplicitLod %v4float %35 %39 None
+         %43 = OpAccessChain %_ptr_PushConstant_uint %g_Push %int_0
+         %44 = OpLoad %uint %43
+         %50 = OpUntypedAccessChainKHR %_ptr_UniformConstant %_runtimearr_47 %slang_resourceHeap %44
+         %55 = OpBufferPointerEXT %_ptr_StorageBuffer_RWStructuredBuffer %50
+         %57 = OpAccessChain %_ptr_StorageBuffer_SSBO_std430 %55 %int_0 %int_0
+         %59 = OpAccessChain %_ptr_StorageBuffer_v4float %57 %int_0
+               OpStore %59 %__sampled
+               OpReturn
+               OpFunctionEnd
+    )";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, nullptr, SPV_SOURCE_ASM);
+
+    m_command_buffer.Begin();
+    m_command_buffer.PushData(0, 4, &buffer_index);
+    m_command_buffer.PushData(4, 4, &image_index);
+
+    m_command_buffer.TransitionLayout(image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+    VkClearColorValue color = {{0.2f, 0.4f, 0.6f, 0.8f}};
+    VkImageSubresourceRange sub_range = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 1u, 0u, 1u};
+    vk::CmdClearColorImage(m_command_buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &color, 1u, &sub_range);
+
+    m_command_buffer.TransitionLayout(image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    desc_heap.BindResourceHeap(m_command_buffer);
+    desc_heap.BindSamplerHeap(m_command_buffer);
+    vk::CmdDispatch(m_command_buffer, 1u, 1u, 1u);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+
+    if (!IsPlatformMockICD()) {
+        float* data = static_cast<float*>(buffer.Memory().Map());
+        for (uint32_t i = 0; i < 4; ++i) {
+            ASSERT_EQ(data[i], color.float32[i]);
+        }
+    }
+}
+
+TEST_F(PositiveDescriptorHeapUntyped, ImageAndSamplerSlangUnified) {
+    TEST_DESCRIPTION("called with -spirv-unified-descriptor-heap-stride");
+    AddRequiredExtensions(VK_KHR_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::computeDerivativeGroupQuads);
+    RETURN_IF_SKIP(InitUntypedDescriptorHeap());
+    InitRenderTarget();
+
+    const VkDeviceSize resource_stride = std::max(heap_props.imageDescriptorSize, heap_props.bufferDescriptorSize);
+    const uint32_t image_index = 1;
+    const uint32_t buffer_index = 2;
+
+    const VkDeviceSize image_offset = resource_stride * image_index;
+    const VkDeviceSize buffer_offset = resource_stride * buffer_index;
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(resource_stride * 4);
+
+    vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
+    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    desc_heap.WriteBufferDescriptorAtOffset(buffer.AddressRange(), VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_offset);
+    desc_heap.WriteImageDescriptorAtOffset(image, image_offset);
+
+    desc_heap.CreateSamplerHeap(heap_props.samplerDescriptorSize);
+    desc_heap.WriteSamplerDescriptor();
+
+    // struct SSBO { float4 data; };
+    // struct PushConstants {
+    //     uint buffer_index;
+    //     uint image_index;
+    // };
+    // [[vk::push_constant]] PushConstants g_Push;
+    // [shader("compute")]
+    // [numthreads(2, 2, 1)]
+    // void main() {
+    //     Texture2D<float4> heapTexture = ResourceDescriptorHeap[g_Push.image_index];
+    //     SamplerState heapSampler = SamplerDescriptorHeap[0];
+    //     float4 sampleColor = heapTexture.Sample(heapSampler, float2(0.5f, 0.5f));
+    //     RWStructuredBuffer<SSBO> heapBuffer = ResourceDescriptorHeap[g_Push.buffer_index];
+    //     heapBuffer[0].data = sampleColor;
+    // }
+    char const* cs_source = R"(
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpCapability ComputeDerivativeGroupQuadsKHR
+               OpCapability Shader
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_compute_shader_derivatives"
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %slang_resourceHeap %slang_samplerHeap %g_Push
+               OpExecutionMode %main DerivativeGroupQuadsKHR
+               OpExecutionMode %main LocalSize 2 2 1
+               OpDecorate %PushConstants_std430 Block
+               OpMemberDecorate %PushConstants_std430 0 Offset 0
+               OpMemberDecorate %PushConstants_std430 1 Offset 4
+               OpDecorateId %_runtimearr_19 ArrayStrideIdEXT %25
+               OpDecorate %slang_resourceHeap BuiltIn ResourceHeapEXT
+               OpDecorateId %_runtimearr_33 ArrayStrideIdEXT %34
+               OpDecorate %slang_samplerHeap BuiltIn SamplerHeapEXT
+               OpDecorateId %_runtimearr_52 ArrayStrideIdEXT %25
+               OpMemberDecorate %SSBO_std430 0 Offset 0
+               OpDecorate %_runtimearr_SSBO_std430 ArrayStride 16
+               OpDecorate %RWStructuredBuffer Block
+               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+               OpDecorate %_ptr_StorageBuffer_SSBO_std430 ArrayStride 16
+               OpDecorate %_ptr_StorageBuffer_v4float ArrayStride 16
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%PushConstants_std430 = OpTypeStruct %uint %uint
+%_ptr_PushConstant_PushConstants_std430 = OpTypePointer PushConstant %PushConstants_std430
+        %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+%_ptr_PushConstant_uint = OpTypePointer PushConstant %uint
+     %uint_0 = OpConstant %uint 0
+      %float = OpTypeFloat 32
+         %19 = OpTypeImage %float 2D 2 0 0 1 Unknown
+         %20 = OpTypeBufferEXT Uniform
+         %21 = OpConstantSizeOfEXT %uint %19
+         %22 = OpConstantSizeOfEXT %uint %20
+       %bool = OpTypeBool
+         %24 = OpSpecConstantOp %bool UGreaterThan %21 %22
+         %25 = OpSpecConstantOp %uint Select %24 %21 %22
+%_runtimearr_19 = OpTypeRuntimeArray %19
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+         %33 = OpTypeSampler
+         %34 = OpConstantSizeOfEXT %uint %33
+%_runtimearr_33 = OpTypeRuntimeArray %33
+         %39 = OpTypeSampledImage %19
+    %v4float = OpTypeVector %float 4
+    %v2float = OpTypeVector %float 2
+  %float_0_5 = OpConstant %float 0.5
+         %44 = OpConstantComposite %v2float %float_0_5 %float_0_5
+      %int_0 = OpConstant %int 0
+         %52 = OpTypeBufferEXT StorageBuffer
+%_runtimearr_52 = OpTypeRuntimeArray %52
+%SSBO_std430 = OpTypeStruct %v4float
+%_runtimearr_SSBO_std430 = OpTypeRuntimeArray %SSBO_std430
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_SSBO_std430
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+%_ptr_StorageBuffer_SSBO_std430 = OpTypePointer StorageBuffer %SSBO_std430
+%_ptr_StorageBuffer_v4float = OpTypePointer StorageBuffer %v4float
+     %g_Push = OpVariable %_ptr_PushConstant_PushConstants_std430 PushConstant
+%slang_resourceHeap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+%slang_samplerHeap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+       %main = OpFunction %void None %3
+          %4 = OpLabel
+         %12 = OpAccessChain %_ptr_PushConstant_uint %g_Push %int_1
+         %13 = OpLoad %uint %12
+         %28 = OpUntypedAccessChainKHR %_ptr_UniformConstant %_runtimearr_19 %slang_resourceHeap %13
+         %30 = OpLoad %19 %28
+         %36 = OpUntypedAccessChainKHR %_ptr_UniformConstant %_runtimearr_33 %slang_samplerHeap %uint_0
+         %38 = OpLoad %33 %36
+         %40 = OpSampledImage %39 %30 %38
+  %__sampled = OpImageSampleImplicitLod %v4float %40 %44 None
+         %48 = OpAccessChain %_ptr_PushConstant_uint %g_Push %int_0
+         %49 = OpLoad %uint %48
+         %54 = OpUntypedAccessChainKHR %_ptr_UniformConstant %_runtimearr_52 %slang_resourceHeap %49
+         %59 = OpBufferPointerEXT %_ptr_StorageBuffer_RWStructuredBuffer %54
+         %61 = OpAccessChain %_ptr_StorageBuffer_SSBO_std430 %59 %int_0 %int_0
+         %63 = OpAccessChain %_ptr_StorageBuffer_v4float %61 %int_0
+               OpStore %63 %__sampled
+               OpReturn
+               OpFunctionEnd
+    )";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, nullptr, SPV_SOURCE_ASM);
+
+    m_command_buffer.Begin();
+    m_command_buffer.PushData(0, 4, &buffer_index);
+    m_command_buffer.PushData(4, 4, &image_index);
+
+    m_command_buffer.TransitionLayout(image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+    VkClearColorValue color = {{0.2f, 0.4f, 0.6f, 0.8f}};
+    VkImageSubresourceRange sub_range = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 1u, 0u, 1u};
+    vk::CmdClearColorImage(m_command_buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &color, 1u, &sub_range);
+
+    m_command_buffer.TransitionLayout(image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    desc_heap.BindResourceHeap(m_command_buffer);
+    desc_heap.BindSamplerHeap(m_command_buffer);
+    vk::CmdDispatch(m_command_buffer, 1u, 1u, 1u);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+
+    if (!IsPlatformMockICD()) {
+        float* data = static_cast<float*>(buffer.Memory().Map());
+        for (uint32_t i = 0; i < 4; ++i) {
+            ASSERT_EQ(data[i], color.float32[i]);
+        }
+    }
+}
+
 TEST_F(PositiveDescriptorHeapUntyped, StorageImage) {
     RETURN_IF_SKIP(InitUntypedDescriptorHeap());
     InitRenderTarget();
@@ -1408,5 +1714,109 @@ TEST_F(PositiveDescriptorHeapUntyped, BufferAsFunctionParameter) {
         if (!IsPlatformMockICD()) {
             ASSERT_EQ(data[0], 22);
         }
+    }
+}
+
+TEST_F(PositiveDescriptorHeapUntyped, SlangBasicBuffer) {
+    RETURN_IF_SKIP(InitUntypedDescriptorHeap());
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize * 2);
+
+    vkt::Buffer buffer_0(*m_device, 256, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
+    vkt::Buffer buffer_1(*m_device, 256, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
+    desc_heap.WriteBufferDescriptor(buffer_0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    desc_heap.WriteBufferDescriptor(buffer_1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+
+    // Heap support not yet in any release build
+    //   will need -capability spvDescriptorHeapEXT -spirv-unified-descriptor-heap-stride
+    // struct PushConstants {
+    //     uint index;
+    // };
+    // [[vk::push_constant]] PushConstants g_Push;
+    //
+    // [shader("compute")]
+    // [numthreads(1, 1, 1)]
+    // void main(uint3 dispatchThreadID : SV_DispatchThreadID) {
+    //     RWStructuredBuffer<uint> outBuffer = ResourceDescriptorHeap[g_Push.index];
+    //     outBuffer[0] = 42 + g_Push.index;
+    // }
+    char const* cs_source = R"(
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpCapability Shader
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %slang_resourceHeap %g_Push
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %PushConstants_std430 Block
+               OpMemberDecorate %PushConstants_std430 0 Offset 0
+               OpDecorateId %_runtimearr_18 ArrayStrideIdEXT %26
+               OpDecorate %slang_resourceHeap BuiltIn ResourceHeapEXT
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpDecorate %RWStructuredBuffer Block
+               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+               OpDecorate %_ptr_StorageBuffer_uint ArrayStride 4
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%PushConstants_std430 = OpTypeStruct %uint
+%_ptr_PushConstant_PushConstants_std430 = OpTypePointer PushConstant %PushConstants_std430
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_PushConstant_uint = OpTypePointer PushConstant %uint
+         %18 = OpTypeBufferEXT StorageBuffer
+      %float = OpTypeFloat 32
+         %20 = OpTypeImage %float 2D 2 0 0 1 Unknown
+         %21 = OpTypeBufferEXT Uniform
+         %22 = OpConstantSizeOfEXT %uint %20
+         %23 = OpConstantSizeOfEXT %uint %21
+       %bool = OpTypeBool
+         %25 = OpSpecConstantOp %bool UGreaterThan %22 %23
+         %26 = OpSpecConstantOp %uint Select %25 %22 %23
+%_runtimearr_18 = OpTypeRuntimeArray %18
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_uint
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+    %uint_42 = OpConstant %uint 42
+     %g_Push = OpVariable %_ptr_PushConstant_PushConstants_std430 PushConstant
+%slang_resourceHeap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+       %main = OpFunction %void None %3
+          %4 = OpLabel
+         %12 = OpAccessChain %_ptr_PushConstant_uint %g_Push %int_0
+         %13 = OpLoad %uint %12
+         %29 = OpUntypedAccessChainKHR %_ptr_UniformConstant %_runtimearr_18 %slang_resourceHeap %13
+         %34 = OpBufferPointerEXT %_ptr_StorageBuffer_RWStructuredBuffer %29
+         %36 = OpAccessChain %_ptr_StorageBuffer_uint %34 %int_0 %int_0
+         %37 = OpLoad %uint %12
+         %38 = OpIAdd %uint %uint_42 %37
+               OpStore %36 %38
+               OpReturn
+               OpFunctionEnd
+    )";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, nullptr, SPV_SOURCE_ASM);
+
+    m_command_buffer.Begin();
+    uint32_t index = 0;
+    m_command_buffer.PushData(0, sizeof(uint32_t), &index);
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+
+    index = 1;
+    m_command_buffer.PushData(0, sizeof(uint32_t), &index);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+
+    if (!IsPlatformMockICD()) {
+        uint32_t* data = static_cast<uint32_t*>(buffer_0.Memory().Map());
+        ASSERT_EQ(data[0], 42);
+        data = static_cast<uint32_t*>(buffer_1.Memory().Map());
+        ASSERT_EQ(data[0], 43);
     }
 }

--- a/tests/unit/gpu_av_descriptor_heap.cpp
+++ b/tests/unit/gpu_av_descriptor_heap.cpp
@@ -3351,7 +3351,9 @@ TEST_F(NegativeGpuAVDescriptorHeap, HashingNoDescriptorUntypedSlang) {
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}));
 
     vkt::DescriptorHeap desc_heap(*this);
-    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize * 4);
+    // Because of -spirv-unified-descriptor-heap-stride
+    const VkDeviceSize resource_stride = std::max(heap_props.imageDescriptorSize, heap_props.bufferDescriptorSize);
+    desc_heap.CreateResourceHeap(resource_stride * 4);
 
     // Same shader as PositiveDescriptorHeapUntyped.SlangBasicBuffer
     char const* cs_source = R"(

--- a/tests/unit/gpu_av_descriptor_heap.cpp
+++ b/tests/unit/gpu_av_descriptor_heap.cpp
@@ -3344,6 +3344,88 @@ TEST_F(NegativeGpuAVDescriptorHeap, HashingWrongDescriptorUntyped) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeGpuAVDescriptorHeap, HashingNoDescriptorUntypedSlang) {
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    const VkLayerSettingEXT layer_setting{OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}));
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize * 4);
+
+    // Same shader as PositiveDescriptorHeapUntyped.SlangBasicBuffer
+    char const* cs_source = R"(
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpCapability Shader
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %slang_resourceHeap %g_Push
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %PushConstants_std430 Block
+               OpMemberDecorate %PushConstants_std430 0 Offset 0
+               OpDecorateId %_runtimearr_18 ArrayStrideIdEXT %26
+               OpDecorate %slang_resourceHeap BuiltIn ResourceHeapEXT
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpDecorate %RWStructuredBuffer Block
+               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+               OpDecorate %_ptr_StorageBuffer_uint ArrayStride 4
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%PushConstants_std430 = OpTypeStruct %uint
+%_ptr_PushConstant_PushConstants_std430 = OpTypePointer PushConstant %PushConstants_std430
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_PushConstant_uint = OpTypePointer PushConstant %uint
+         %18 = OpTypeBufferEXT StorageBuffer
+      %float = OpTypeFloat 32
+         %20 = OpTypeImage %float 2D 2 0 0 1 Unknown
+         %21 = OpTypeBufferEXT Uniform
+         %22 = OpConstantSizeOfEXT %uint %20
+         %23 = OpConstantSizeOfEXT %uint %21
+       %bool = OpTypeBool
+         %25 = OpSpecConstantOp %bool UGreaterThan %22 %23
+         %26 = OpSpecConstantOp %uint Select %25 %22 %23
+%_runtimearr_18 = OpTypeRuntimeArray %18
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_uint
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+    %uint_42 = OpConstant %uint 42
+     %g_Push = OpVariable %_ptr_PushConstant_PushConstants_std430 PushConstant
+%slang_resourceHeap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+       %main = OpFunction %void None %3
+          %4 = OpLabel
+         %12 = OpAccessChain %_ptr_PushConstant_uint %g_Push %int_0
+         %13 = OpLoad %uint %12
+         %29 = OpUntypedAccessChainKHR %_ptr_UniformConstant %_runtimearr_18 %slang_resourceHeap %13
+         %34 = OpBufferPointerEXT %_ptr_StorageBuffer_RWStructuredBuffer %29
+         %36 = OpAccessChain %_ptr_StorageBuffer_uint %34 %int_0 %int_0
+         %37 = OpLoad %uint %12
+         %38 = OpIAdd %uint %uint_42 %37
+               OpStore %36 %38
+               OpReturn
+               OpFunctionEnd
+    )";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, nullptr, SPV_SOURCE_ASM);
+
+    m_command_buffer.Begin();
+    uint32_t index = 2;
+    m_command_buffer.PushData(0, sizeof(uint32_t), &index);
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredError("UNASSIGNED-DescriptorHeap-No-Descriptor");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeGpuAVDescriptorHeap, HashingNoDescriptorCombinedImageSampler) {
     const VkLayerSettingEXT layer_setting{OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}));

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -1587,8 +1587,59 @@ TEST_F(NegativeGpuDump, DescriptorHeapBindingCount) {
     m_command_buffer.End();
 }
 
-// TODO - Handle proper support
-TEST_F(NegativeGpuDump, DISABLED_UntypedPointersMultiDimensional) {
+TEST_F(NegativeGpuDump, DescriptorHeapUntypedPointersPushDataIndex) {
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitDescriptorHeap());
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(8192);
+
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "Alignment not reliable on MockICD";
+    }
+
+    const char* cs_source = R"glsl(
+        #version 450
+        #extension GL_EXT_descriptor_heap : require
+        #extension GL_EXT_nonuniform_qualifier : require
+        layout(descriptor_heap) buffer Heap { uint x; } heap[];
+        layout(push_constant) uniform PushConstant {
+            uint pc_0;
+            layout(offset = 32) uint pc_1;
+            uint pc_2; // offset 36
+        };
+        void main() {
+            heap[0].x = 0;
+            heap[pc_0].x = 1;
+            heap[pc_1].x = 2;
+            heap[pc_0 + pc_2].x = 3;
+            heap[pc_0 * pc_2 + pc_1].x = 4;
+            heap[pc_0 + 1].x = 5;
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_3, nullptr);
+
+    m_command_buffer.Begin();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+
+    uint8_t unused[40];
+    m_command_buffer.PushData(0, 40, unused);  // avoid 11376
+    uint32_t pc_0 = 2;
+    uint32_t pc_1 = 1;
+    uint32_t pc_2 = 3;
+    m_command_buffer.PushData(0, sizeof(uint32_t), &pc_0);
+    m_command_buffer.PushData(32, sizeof(uint32_t), &pc_1);
+    m_command_buffer.PushData(36, sizeof(uint32_t), &pc_2);
+    m_errorMonitor->SetDesiredInfo("array index: [1] (from vkCmdPushDataEXT[32:35])");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeGpuDump, UntypedPointersMultiDimensional) {
     TEST_DESCRIPTION("https://gitlab.khronos.org/spirv/SPIR-V/-/issues/942");
     AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
@@ -1655,7 +1706,9 @@ TEST_F(NegativeGpuDump, DISABLED_UntypedPointersMultiDimensional) {
 
     vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_3, nullptr, SPV_SOURCE_ASM);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_errorMonitor->SetDesiredInfo("array index: [1][2]");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }
 


### PR DESCRIPTION
1. Handle Slang new descriptor heaps
2. Dump now both sorts (by heap address) and prints out any known indexes into the heap found by the push data (since we know the value at draw time!!!)

example

```
- Shader descriptors:
  [VK_SHADER_STAGE_COMPUTE_BIT] VkShaderModule 0x50000000005
  - [Resource Heap, variable "resource_heap"] accesses detected:
    - heap offset: 0x0, array stride: [64], array index: [0]
      - Resource heap address: 0x300000000
      - descriptor size: 64 (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
    - heap offset: 0x0, array stride: [64], array index: [1] (from vkCmdPushDataEXT[32:35])
      - Resource heap address: 0x300000040
      - descriptor size: 64 (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
    - heap offset: 0x0, array stride: [64], array index: [2] (from vkCmdPushDataEXT[0:3])
      - Resource heap address: 0x300000080
```