### PR TITLE
sync: Stop using SyncOpBase::Validate for renderpass

### DIFF
--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -1313,9 +1313,9 @@ void CommandBufferAccessContext::RecordClearAttachment(ResourceUsageTag tag, con
 
 QueueId CommandBufferAccessContext::GetQueueId() const { return kQueueIdInvalid; }
 
-ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(vvl::Func command, const vvl::RenderPass& rp_state,
-                                                                   const VkRect2D& render_area,
-                                                                   const std::vector<const vvl::ImageView*>& attachment_views) {
+ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(
+    vvl::Func command, const vvl::RenderPass& rp_state, const VkRect2D& render_area,
+    const std::vector<std::shared_ptr<const vvl::ImageView>>& attachment_views) {
     // Create an access context the current renderpass.
     const auto barrier_tag = NextCommandTag(command, SubCommandType::kSubpassTransition, 0);
     AddCommandHandle(barrier_tag, rp_state.Handle());

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -221,8 +221,8 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     RenderPassAccessContext *GetCurrentRenderPassContext() { return current_renderpass_context_; }
     const RenderPassAccessContext *GetCurrentRenderPassContext() const { return current_renderpass_context_; }
     uint32_t GetCurrentRenderPassInstanceId() const { return current_render_pass_instance_id_; }
-    ResourceUsageTag RecordBeginRenderPass(vvl::Func command, const vvl::RenderPass &rp_state, const VkRect2D &render_area,
-                                           const std::vector<const vvl::ImageView *> &attachment_views);
+    ResourceUsageTag RecordBeginRenderPass(vvl::Func command, const vvl::RenderPass& rp_state, const VkRect2D& render_area,
+                                           const std::vector<std::shared_ptr<const vvl::ImageView>>& attachment_views);
 
     bool ValidateBeginRendering(const ErrorObject &error_obj, BeginRenderingCmdState &cmd_state) const;
     void RecordBeginRendering(BeginRenderingCmdState &cmd_state, const Location &loc);

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -858,60 +858,11 @@ SyncOpBeginRenderPass::SyncOpBeginRenderPass(vvl::Func command, const SyncValida
     renderpass_begin_info_ = vku::safe_VkRenderPassBeginInfo(&render_pass_begin_info);
     auto fb_state = sync_state.Get<vvl::Framebuffer>(render_pass_begin_info.framebuffer);
     if (fb_state) {
-        shared_attachments_ = sync_state.device_state->GetAttachmentViews(*renderpass_begin_info_.ptr(), *fb_state);
-        // TODO: Revisit this when all attachment validation is through SyncOps to see if we can discard the plain pointer copy
-        // Note that this a safe to presist as long as shared_attachments is not cleared
-        attachments_.reserve(shared_attachments_.size());
-        for (const auto& attachment : shared_attachments_) {
-            attachments_.emplace_back(attachment.get());
-        }
+        attachments_ = sync_state.device_state->GetAttachmentViews(*renderpass_begin_info_.ptr(), *fb_state);
     }
     if (p_subpass_begin_info) {
         subpass_begin_info_ = vku::safe_VkSubpassBeginInfo(p_subpass_begin_info);
     }
-}
-
-bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext& cb_context) const {
-    // Check if any of the layout transitions are hazardous.... but we don't have the renderpass context to work with, so we
-    bool skip = false;
-
-    if (!rp_state_) {
-        return skip;
-    }
-    const vvl::RenderPass& rp_state = *rp_state_.get();
-
-    const uint32_t subpass = 0;
-    const uint32_t view_mask = rp_state_->create_info.pSubpasses[0].viewMask;
-
-    // Construct the state to validate against (since validation is const and RecordCmdBeginRenderPass hasn't happened yet).
-    // TODO: investigate if using nullptr in InitFrom is safe (this just follows the initial implementation - it assumes
-    // that array of subpass dependencies won't be indexed, but it's not obvious).
-    AccessContext temp_context(cb_context.GetSyncState());
-
-    temp_context.InitFrom(subpass, cb_context.GetQueueFlags(), rp_state.subpass_dependency_infos, nullptr,
-                          cb_context.GetCurrentAccessContext());
-
-    // Validate attachment operations
-    if (attachments_.empty()) return skip;
-    const auto& render_area = renderpass_begin_info_.renderArea;
-    const uint32_t render_pass_instance_id = cb_context.GetCurrentRenderPassInstanceId();
-
-    // Since the isn't a valid RenderPassAccessContext until Record, needs to create the view/generator list... we could limit this
-    // by predicating on whether subpass 0 uses the attachment if it is too expensive to create the full list redundantly here.
-    // More broadly we could look at thread specific state shared between Validate and Record as is done for other heavyweight
-    // operations (though it's currently a messy approach)
-    const AttachmentViewGenVector view_gens = RenderPassAccessContext::CreateAttachmentViewGen(render_area, attachments_);
-    skip |= RenderPassAccessContext::ValidateLayoutTransitions(cb_context, temp_context, rp_state, render_pass_instance_id, subpass,
-                                                               view_mask, view_gens, command_);
-
-    // Validate load operations if there were no layout transition hazards
-    if (!skip) {
-        RenderPassAccessContext::RecordLayoutTransitions(rp_state, subpass, view_gens, kInvalidTag, temp_context);
-        skip |= RenderPassAccessContext::ValidateLoadOperation(cb_context, temp_context, rp_state, render_pass_instance_id, subpass,
-                                                               view_mask, view_gens, command_);
-    }
-
-    return skip;
 }
 
 ResourceUsageTag SyncOpBeginRenderPass::Record(CommandBufferAccessContext& cb_context) {
@@ -945,23 +896,7 @@ void SyncOpBeginRenderPass::ReplayRecord(CommandExecutionContext& exec_context, 
 
 SyncOpNextSubpass::SyncOpNextSubpass(vvl::Func command, const SyncValidator& sync_state,
                                      const VkSubpassBeginInfo* pSubpassBeginInfo, const VkSubpassEndInfo* pSubpassEndInfo)
-    : SyncOpBase(command) {
-    if (pSubpassBeginInfo) {
-        subpass_begin_info_.initialize(pSubpassBeginInfo);
-    }
-    if (pSubpassEndInfo) {
-        subpass_end_info_.initialize(pSubpassEndInfo);
-    }
-}
-
-bool SyncOpNextSubpass::Validate(const CommandBufferAccessContext& cb_context) const {
-    bool skip = false;
-    const auto* renderpass_context = cb_context.GetCurrentRenderPassContext();
-    if (!renderpass_context) return skip;
-
-    skip |= renderpass_context->ValidateNextSubpass(cb_context, command_);
-    return skip;
-}
+    : SyncOpBase(command) {}
 
 ResourceUsageTag SyncOpNextSubpass::Record(CommandBufferAccessContext& cb_context) {
     return cb_context.RecordNextSubpass(command_);
@@ -983,22 +918,10 @@ bool SyncOpNextSubpass::ReplayValidate(ReplayState& replay, ResourceUsageTag rec
 void SyncOpNextSubpass::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
     // All the needed replay state changes (for the layout transition, and context update) have to happen in ReplayValidate
 }
+
 SyncOpEndRenderPass::SyncOpEndRenderPass(vvl::Func command, const SyncValidator& sync_state,
                                          const VkSubpassEndInfo* pSubpassEndInfo)
-    : SyncOpBase(command) {
-    if (pSubpassEndInfo) {
-        subpass_end_info_.initialize(pSubpassEndInfo);
-    }
-}
-
-bool SyncOpEndRenderPass::Validate(const CommandBufferAccessContext& cb_context) const {
-    bool skip = false;
-    const auto* renderpass_context = cb_context.GetCurrentRenderPassContext();
-
-    if (!renderpass_context) return skip;
-    skip |= renderpass_context->ValidateEndRenderPass(cb_context, command_);
-    return skip;
-}
+    : SyncOpBase(command) {}
 
 ResourceUsageTag SyncOpEndRenderPass::Record(CommandBufferAccessContext& cb_context) {
     return cb_context.RecordEndRenderPass(command_);

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -288,9 +288,6 @@ class SyncOpBeginRenderPass : public SyncOpBase {
   public:
     SyncOpBeginRenderPass(vvl::Func command, const SyncValidator& sync_state, const VkRenderPassBeginInfo& render_pass_begin_info,
                           const VkSubpassBeginInfo* p_subpass_begin_info);
-    ~SyncOpBeginRenderPass() override = default;
-
-    bool Validate(const CommandBufferAccessContext& cb_context) const;
 
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context) override;
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
@@ -300,8 +297,7 @@ class SyncOpBeginRenderPass : public SyncOpBase {
   protected:
     vku::safe_VkRenderPassBeginInfo renderpass_begin_info_;
     vku::safe_VkSubpassBeginInfo subpass_begin_info_;
-    std::vector<std::shared_ptr<const vvl::ImageView>> shared_attachments_;
-    std::vector<const vvl::ImageView *> attachments_;
+    std::vector<std::shared_ptr<const vvl::ImageView>> attachments_;
     std::shared_ptr<const vvl::RenderPass> rp_state_;
     const RenderPassAccessContext *rp_context_;
 };
@@ -310,32 +306,19 @@ class SyncOpNextSubpass : public SyncOpBase {
   public:
     SyncOpNextSubpass(vvl::Func command, const SyncValidator &sync_state, const VkSubpassBeginInfo *pSubpassBeginInfo,
                       const VkSubpassEndInfo *pSubpassEndInfo);
-    ~SyncOpNextSubpass() override = default;
-
-    bool Validate(const CommandBufferAccessContext& cb_context) const;
 
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context) override;
     bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const override;
     void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const override;
-
-  protected:
-    vku::safe_VkSubpassBeginInfo subpass_begin_info_;
-    vku::safe_VkSubpassEndInfo subpass_end_info_;
 };
 
 class SyncOpEndRenderPass : public SyncOpBase {
   public:
     SyncOpEndRenderPass(vvl::Func command, const SyncValidator &sync_state, const VkSubpassEndInfo *pSubpassEndInfo);
-    ~SyncOpEndRenderPass() override = default;
-
-    bool Validate(const CommandBufferAccessContext& cb_context) const;
 
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context) override;
     bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const override;
     void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const override;
-
-  protected:
-    vku::safe_VkSubpassEndInfo subpass_end_info_;
 };
 
 // Allow keep track of the exec contexts replay state

--- a/layers/sync/sync_render_pass.cpp
+++ b/layers/sync/sync_render_pass.cpp
@@ -893,20 +893,20 @@ void RenderPassAccessContext::RecordLoadOperations(const ResourceUsageTag tag) {
 }
 
 AttachmentViewGenVector RenderPassAccessContext::CreateAttachmentViewGen(
-    const VkRect2D& render_area, const std::vector<const vvl::ImageView*>& attachment_views) {
+    const VkRect2D& render_area, const std::vector<std::shared_ptr<const vvl::ImageView>>& attachment_views) {
     AttachmentViewGenVector view_gens;
     VkExtent3D extent = CastTo3D(render_area.extent);
     VkOffset3D offset = CastTo3D(render_area.offset);
     view_gens.reserve(attachment_views.size());
-    for (const auto* view : attachment_views) {
-        view_gens.emplace_back(view, offset, extent);
+    for (const auto& view : attachment_views) {
+        view_gens.emplace_back(view.get(), offset, extent);
     }
     return view_gens;
 }
 
 RenderPassAccessContext::RenderPassAccessContext(const vvl::RenderPass& rp_state, const VkRect2D& render_area,
                                                  VkQueueFlags queue_flags,
-                                                 const std::vector<const vvl::ImageView*>& attachment_views,
+                                                 const std::vector<std::shared_ptr<const vvl::ImageView>>& attachment_views,
                                                  const AccessContext& external_context, uint32_t render_pass_instance_id)
     : rp_state_(&rp_state),
       attachment_views_(CreateAttachmentViewGen(render_area, attachment_views)),

--- a/layers/sync/sync_render_pass.h
+++ b/layers/sync/sync_render_pass.h
@@ -88,13 +88,13 @@ using AttachmentViewGenVector = std::vector<AttachmentViewGen>;
 
 class RenderPassAccessContext {
   public:
-    static AttachmentViewGenVector CreateAttachmentViewGen(const VkRect2D& render_area,
-                                                           const std::vector<const vvl::ImageView*>& attachment_views);
+    static AttachmentViewGenVector CreateAttachmentViewGen(
+        const VkRect2D& render_area, const std::vector<std::shared_ptr<const vvl::ImageView>>& attachment_views);
     RenderPassAccessContext()
         : rp_state_(nullptr), external_context_(nullptr), render_pass_instance_id_(vvl::kNoIndex32), current_subpass_(0) {}
     RenderPassAccessContext(const vvl::RenderPass& rp_state, const VkRect2D& render_area, VkQueueFlags queue_flags,
-                            const std::vector<const vvl::ImageView*>& attachment_views, const AccessContext& external_context,
-                            uint32_t render_pass_instance_id);
+                            const std::vector<std::shared_ptr<const vvl::ImageView>>& attachment_views,
+                            const AccessContext& external_context, uint32_t render_pass_instance_id);
 
     static bool ValidateLayoutTransitions(const CommandBufferAccessContext& cb_context, const AccessContext& access_context,
                                           const vvl::RenderPass& rp_state, uint32_t render_pass_instance_id, uint32_t subpass,

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -25,6 +25,7 @@
 #include "sync/sync_image.h"
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/ray_tracing_state.h"
+#include "state_tracker/render_pass_state.h"
 #include "utils/convert_utils.h"
 #include "utils/image_utils.h"
 #include "utils/ray_tracing_utils.h"
@@ -712,10 +713,57 @@ void SyncValidator::PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore s
 bool SyncValidator::ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                             const VkSubpassBeginInfo* pSubpassBeginInfo, const ErrorObject& error_obj) const {
     bool skip = false;
-    if (pRenderPassBegin) {
-        const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-        SyncOpBeginRenderPass sync_op(error_obj.location.function, *this, *pRenderPassBegin, pSubpassBeginInfo);
-        skip |= sync_op.Validate(GetAccessContext(*cb_state));
+    if (!pRenderPassBegin) {
+        return skip;
+    }
+    auto rp_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
+    if (!rp_state) {
+        return skip;
+    }
+    auto fb_state = Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
+    if (!fb_state) {
+        return skip;
+    }
+
+    const std::vector<std::shared_ptr<const vvl::ImageView>> attachments =
+        device_state->GetAttachmentViews(*pRenderPassBegin, *fb_state);
+    if (attachments.empty()) {
+        return skip;
+    }
+
+    const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
+    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+
+    const uint32_t subpass_zero = 0;
+    const uint32_t view_mask = rp_state->create_info.pSubpasses[0].viewMask;
+
+    // Construct the state to validate against (since validation is const and RecordCmdBeginRenderPass hasn't happened yet).
+    AccessContext temp_context(cb_context.GetSyncState());
+
+    // TODO: investigate if using nullptr in InitFrom is safe (this just follows the initial implementation - it assumes
+    // that array of subpass dependencies won't be indexed, but it's not obvious).
+    temp_context.InitFrom(subpass_zero, cb_context.GetQueueFlags(), rp_state->subpass_dependency_infos, nullptr,
+                          cb_context.GetCurrentAccessContext());
+
+    // Validate attachment operations
+    const uint32_t render_pass_instance_id = cb_context.GetCurrentRenderPassInstanceId();
+
+    // Since the isn't a valid RenderPassAccessContext until Record, needs to create the view/generator list.
+    // We could limit this by predicating on whether subpass 0 uses the attachment if it is too expensive
+    // to create the full list redundantly here. More broadly we could look at thread specific state shared
+    // between Validate and Record as is done for other heavyweight operations.
+    const AttachmentViewGenVector view_gens =
+        RenderPassAccessContext::CreateAttachmentViewGen(pRenderPassBegin->renderArea, attachments);
+
+    // Check if any of the layout transitions are hazardous
+    skip |= RenderPassAccessContext::ValidateLayoutTransitions(cb_context, temp_context, *rp_state, render_pass_instance_id,
+                                                               subpass_zero, view_mask, view_gens, error_obj.location.function);
+
+    // Validate load operations if there were no layout transition hazards
+    if (!skip) {
+        RenderPassAccessContext::RecordLayoutTransitions(*rp_state, subpass_zero, view_gens, kInvalidTag, temp_context);
+        skip |= RenderPassAccessContext::ValidateLoadOperation(cb_context, temp_context, *rp_state, render_pass_instance_id,
+                                                               subpass_zero, view_mask, view_gens, error_obj.location.function);
     }
     return skip;
 }
@@ -742,10 +790,15 @@ bool SyncValidator::PreCallValidateCmdBeginRenderPass2KHR(VkCommandBuffer comman
 
 bool SyncValidator::ValidateCmdNextSubpass(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                            const VkSubpassEndInfo* pSubpassEndInfo, const ErrorObject& error_obj) const {
+    bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    SyncOpNextSubpass sync_op(error_obj.location.function, *this, pSubpassBeginInfo, pSubpassEndInfo);
-    return sync_op.Validate(cb_context);
+    const RenderPassAccessContext* renderpass_context = cb_context.GetCurrentRenderPassContext();
+    if (!renderpass_context) {
+        return skip;
+    }
+    skip |= renderpass_context->ValidateNextSubpass(cb_context, error_obj.location.function);
+    return skip;
 }
 
 bool SyncValidator::PreCallValidateCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
@@ -767,25 +820,25 @@ bool SyncValidator::PreCallValidateCmdNextSubpass2(VkCommandBuffer commandBuffer
     return ValidateCmdNextSubpass(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, error_obj);
 }
 
-bool SyncValidator::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
-                                             const ErrorObject& error_obj) const {
+bool SyncValidator::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     bool skip = false;
-
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-
-    SyncOpEndRenderPass sync_op(error_obj.location.function, *this, pSubpassEndInfo);
-    skip |= sync_op.Validate(cb_context);
+    const RenderPassAccessContext* renderpass_context = cb_context.GetCurrentRenderPassContext();
+    if (!renderpass_context) {
+        return skip;
+    }
+    skip |= renderpass_context->ValidateEndRenderPass(cb_context, error_obj.location.function);
     return skip;
 }
 
 bool SyncValidator::PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
-    return ValidateCmdEndRenderPass(commandBuffer, nullptr, error_obj);
+    return ValidateCmdEndRenderPass(commandBuffer, error_obj);
 }
 
 bool SyncValidator::PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
                                                      const ErrorObject& error_obj) const {
-    return ValidateCmdEndRenderPass(commandBuffer, pSubpassEndInfo, error_obj);
+    return ValidateCmdEndRenderPass(commandBuffer, error_obj);
 }
 
 bool SyncValidator::PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -204,8 +204,7 @@ class SyncValidator : public vvl::DeviceProxy {
     bool PreCallValidateCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo *pSubpassBeginInfo,
                                            const VkSubpassEndInfo *pSubpassEndInfo, const ErrorObject &error_obj) const override;
 
-    bool ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
-                                  const ErrorObject &error_obj) const;
+    bool ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const;
     bool PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const override;
     bool PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
                                              const ErrorObject &error_obj) const override;


### PR DESCRIPTION
This finishes `SyncOpBase::Validate` refactor started here  https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12703. This function was removed from the interface and things became simpler. The next step is to check SyncOpBase::Record.