### PR TITLE
layers: Use dedicated debug macros

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -549,6 +549,14 @@ if (BUILD_SELF_VVL)
     target_compile_definitions(vvl PUBLIC BUILD_SELF_VVL)
 endif()
 
+# Various spots we want to only keep for debug workflows
+target_compile_definitions(vvl PRIVATE
+    $<$<CONFIG:Debug>:
+        VVL_DEBUG_SPIRV;
+        VVL_DEBUG_SUBRESOURCE
+    >
+)
+
 set_target_properties(vvl PROPERTIES OUTPUT_NAME ${LAYER_NAME})
 
 if(MSVC)

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -81,7 +81,7 @@ void Instruction::SetResultTypeIndex() {
 }
 
 void Instruction::UpdateDebugInfo() {
-#ifndef NDEBUG
+#ifdef VVL_DEBUG_SPIRV
     d_opcode_ = std::string(string_SpvOpcode(Opcode()));
     d_length_ = Length();
     d_result_id_ = ResultId();
@@ -331,7 +331,7 @@ void Instruction::Fill(const std::vector<uint32_t>& words) {
 
 void Instruction::UpdateWord(uint32_t index, uint32_t data) {
     words_[index] = data;
-#ifndef NDEBUG
+#ifdef VVL_DEBUG_SPIRV
     d_words_[index] = data;
 #endif
 }

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -143,7 +143,7 @@ class Instruction {
     const uint32_t position_offset_;
     const OperandInfo& operand_info_;
 
-#ifndef NDEBUG
+#ifdef VVL_DEBUG_SPIRV
     // Helping values to make debugging what is happening in a instruction easier
     std::string d_opcode_;
     uint32_t d_length_;

--- a/layers/state_tracker/subresource_adapter.cpp
+++ b/layers/state_tracker/subresource_adapter.cpp
@@ -180,7 +180,7 @@ RangeEncoder::RangeEncoder(const VkImageSubresourceRange& full_range, const Aspe
     PopulateFunctionPointers();
 }
 
-#ifndef NDEBUG
+#ifdef VVL_DEBUG_SUBRESOURCE
 static bool IsValid(const RangeEncoder& encoder, const VkImageSubresourceRange& bounds) {
     const auto& limits = encoder.Limits();
     return (((bounds.aspectMask & limits.aspectMask) == bounds.aspectMask) &&
@@ -607,7 +607,7 @@ ImageRangeGenerator::ImageRangeGenerator(const ImageRangeEncoder& encoder, const
       extent_(),
       base_address_(base_address),
       is_depth_sliced_(is_depth_sliced) {
-#ifndef NDEBUG
+#ifdef VVL_DEBUG_SUBRESOURCE
     assert(IsValid(*encoder_, subres_range_));
 #endif
     if (SubresourceRangeIsEmpty(subres_range)) {
@@ -669,7 +669,7 @@ ImageRangeGenerator::ImageRangeGenerator(const ImageRangeEncoder& encoder, const
       extent_(extent),
       base_address_(base_address),
       is_depth_sliced_(is_depth_sliced) {
-#ifndef NDEBUG
+#ifdef VVL_DEBUG_SUBRESOURCE
     assert(IsValid(*encoder_, subres_range_));
 #endif
 


### PR DESCRIPTION
maybe bad at using Visual Studio and Windows, but found these were not working for me

Gemini suggested to use the "cmake way" and provide a separate define so things Debug and RelWithDebugInfo don't get mixed up