### PR TITLE
build: Export VVL symbols via .def for clang on windows-msvc

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -563,6 +563,12 @@ elseif(MINGW)
     target_sources(vvl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}.def)
     target_compile_options(vvl PRIVATE -Wa,-mbig-obj)
     set_target_properties(vvl PROPERTIES PREFIX "") # remove the prefix "lib" so the manifest json "library_path" matches
+elseif(WIN32)
+    # A GNU-frontend clang targeting *-windows-msvc (i.e. clang/clang++, not
+    # clang-cl) is detected as neither MSVC nor MINGW, so without this branch it
+    # falls through to the ELF --version-script case below, which the Windows
+    # linker (lld-link) rejects. Forward the MSVC-style .def through the driver.
+    target_link_options(vvl PRIVATE LINKER:/DEF:${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}.def)
 elseif(APPLE)
 
 # IOS and APPLE can both be true (FYI)


### PR DESCRIPTION
# build: export VVL symbols via .def for clang targeting windows-msvc

## Problem

Building the validation layers with a GNU-frontend clang targeting
`*-windows-msvc` (i.e. `clang`/`clang++`, not `clang-cl`) fails to link the
`vvl` target:

```
lld-link: error: --version-script is not allowed in non-GNU link mode
```

In `layers/CMakeLists.txt` the export-mechanism is chosen by compiler/platform:

```cmake
if(MSVC)          # /DEF:            (MSVC-style .def)
elseif(MINGW)     # .def as a source
elseif(APPLE)     # -exported_symbols_list
elseif(ANDROID)   # LINKER:--version-script (ELF)
else()            # LINKER:--version-script (ELF)
endif()
```

A GNU-frontend clang targeting the MSVC ABI is **neither** `MSVC` nor `MINGW`
in CMake terms, so it falls through to the final `else()` and is linked with an
ELF version script. That target's linker is `lld-link`, which rejects it.

## Fix

Add a `WIN32 AND NOT MINGW` branch (reached only when `MSVC` is already false)
that forwards the existing MSVC-style `.def` file through the compiler driver
with `LINKER:/DEF:`. lld-link accepts `/DEF:`, and the same `.def` is already
maintained for the MSVC path, so no new export list is introduced. No `/bigobj`
equivalent is needed — clang emits COFF big objects automatically.

```cmake
elseif(WIN32 AND NOT MINGW)
    target_link_options(vvl PRIVATE LINKER:/DEF:${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}.def)
```

## Testing

Verified `vulkan-sdk-1.3.275.0` builds and links `VkLayer_khronos_validation.dll`
with `clang++ --target=x86_64-pc-windows-msvc` + `lld-link` (via vcpkg's
`x64-windows` flow with a clang chainload toolchain). MSVC, MinGW, and the
non-Windows paths are untouched.

This is a build-configuration fix with no change to validation behaviour, so
there is no VU to add a positive/negative test for.
