### PR TITLE
dh: Only report error if limit not hit

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor_buffer.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_buffer.cpp
@@ -129,6 +129,12 @@ bool BindingInfo::ValidateDescriptor(std::ostringstream& ss, GpuDump& dev_data) 
 
     const auto& descriptor_hashing = *dev_data.device_state->descriptor_hashing;
 
+    ReadLockGuard guard(descriptor_hashing.map_lock);
+    if (descriptor_hashing.table.limit_reported) {
+        // If hit limit, likely to detect false positives
+        return false;
+    }
+
     // For VK_EXT_descriptor_buffer where each descriptor type might be a different size.
     //
     // For example, if a UBO is 32 bytes, but an image is 64 bytes:
@@ -147,8 +153,6 @@ bool BindingInfo::ValidateDescriptor(std::ostringstream& ss, GpuDump& dev_data) 
             check_larger_sizes = false;
         }
     }
-
-    ReadLockGuard guard(descriptor_hashing.map_lock);
 
     uint64_t key = descriptor_hashing.Hash(descriptor_bytes.data(), size);
     const vvl::DescriptorHashTable::Entry* entry = descriptor_hashing.table.Find(key);

--- a/layers/gpu_dump/gpu_dump_descriptor_buffer.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_buffer.cpp
@@ -76,6 +76,7 @@ struct SetInfo {
     bool embedded;
     uint32_t index;          // set of the descriptor
     uint32_t binding_index;  // into pBindingInfos[]
+    VkDeviceSize binding_offset;  // pBindingInfos[binding_index].offset
     VkBufferUsageFlagBits2 buffer_usage_flags;
     vvl::range<VkDeviceAddress> range;
     const vvl::DescriptorSetLayout* dsl;
@@ -89,7 +90,8 @@ struct SetInfo {
         if (embedded) {
             ss << "    - Embedded Sampler";
         } else {
-            ss << "    - size: " << range.size() << " bytes, range: " << string_range_hex(range);
+            ss << "    - offset: " << std::dec << binding_offset << ", size: " << range.size()
+               << " bytes, range: " << string_range_hex(range);
         }
         if (binding_index != vvl::kNoIndex32) {
             // Only print if there are multiple bindings
@@ -355,13 +357,13 @@ bool CommandBufferSubState::DumpDescriptorBuffer(std::ostringstream& ss, const L
                 }
 
                 uint32_t binding_index = vvl::kNoIndex32;
+                VkDeviceSize binding_offset = descriptor_buffer_binding->offset;
                 vvl::range<VkDeviceAddress> set_range;
 
                 const bool embedded = descriptor_buffer_binding->embedded != vvl::kNoIndex32;
                 if (!embedded) {
                     const VkDeviceAddress start_address =
-                        cb_state.descriptor_buffer.binding_info[descriptor_buffer_binding->index].address +
-                        descriptor_buffer_binding->offset;
+                        cb_state.descriptor_buffer.binding_info[descriptor_buffer_binding->index].address + binding_offset;
                     const VkDeviceSize dsl_size = dsl->GetLayoutSizeInBytes();
                     set_range = {start_address, start_address + dsl_size};
 
@@ -376,7 +378,8 @@ bool CommandBufferSubState::DumpDescriptorBuffer(std::ostringstream& ss, const L
                     usage_flags = binding_usage_flags[binding_index];
                 }
 
-                set_info = &sorted_sets.emplace_back(SetInfo{embedded, var_set, binding_index, usage_flags, set_range, dsl, {}});
+                set_info = &sorted_sets.emplace_back(
+                    SetInfo{embedded, var_set, binding_index, binding_offset, usage_flags, set_range, dsl, {}});
             }
 
             // To variables might be the same set/binding if doing descriptor indexing aliasing

--- a/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
@@ -418,6 +418,11 @@ std::string WarnInfo::ValidateDescriptor(VkDeviceAddress address, bool from_reso
     }
     const VkDeviceSize descriptor_size = from_resource ? dump.descriptor_size : dump.sampler_descriptor_size;
     const auto& descriptor_hashing = *dump.dev_data.device_state->descriptor_hashing;
+    ReadLockGuard guard(descriptor_hashing.map_lock);
+    if (descriptor_hashing.table.limit_reported) {
+        // If hit limit, likely to detect false positives
+        return "";
+    }
 
     // For VK_EXT_descriptor_heap where each descriptor type might be a different size.
     //
@@ -439,7 +444,6 @@ std::string WarnInfo::ValidateDescriptor(VkDeviceAddress address, bool from_reso
             check_larger_sizes = false;
         }
     }
-    ReadLockGuard guard(descriptor_hashing.map_lock);
 
     uint64_t key = descriptor_hashing.Hash(descriptor_bytes.data(), descriptor_size);
     const vvl::DescriptorHashTable::Entry* entry = descriptor_hashing.table.Find(key);

--- a/layers/gpuav/instrumentation/descriptor_checks_buffer.cpp
+++ b/layers/gpuav/instrumentation/descriptor_checks_buffer.cpp
@@ -191,6 +191,12 @@ void RegisterDescriptorChecksBufferValidation(Validator& gpuav, CommandBufferSub
                     if (GetErrorGroup(error_record) != kErrorGroup_InstDescriptorBuffer) {
                         return error_found;
                     }
+                    ReadLockGuard guard(gpuav.device_state->descriptor_hashing->map_lock);
+                    if (gpuav.device_state->descriptor_hashing->table.limit_reported) {
+                        // If we have hit the limit, we are likely going to spam errors and want them to see
+                        // the DESCRIPTOR-HASHING-LIMIT only instead
+                        return error_found;
+                    }
                     error_found = true;
 
                     std::ostringstream ss;
@@ -213,7 +219,6 @@ void RegisterDescriptorChecksBufferValidation(Validator& gpuav, CommandBufferSub
                         } break;
                         case kErrorSubCode_DescriptorBuffer_DescriptorHashing_Wrong: {
                             const uint32_t slot_index = error_record[kInst_LogError_ParameterOffset_0];
-                            ReadLockGuard guard(gpuav.device_state->descriptor_hashing->map_lock);
                             const auto& entry = gpuav.device_state->descriptor_hashing->table.slots[slot_index].entry;
                             ss << "is accessing the  descriptor buffer but there is a descriptor there of the wrong type: \n";
                             entry.Describe(*gpuav.device_state, ss);

--- a/layers/gpuav/instrumentation/descriptor_checks_heap.cpp
+++ b/layers/gpuav/instrumentation/descriptor_checks_heap.cpp
@@ -396,25 +396,32 @@ void RegisterDescriptorChecksHeapValidation(Validator& gpuav, CommandBufferSubSt
                         out_vuid_msg = vvl::CreateActionVuid(loc.function, action_vuid);
                         error_found = true;
                     } break;
-                    case kErrorSubCode_DescriptorHeap_DescriptorHashing_None: {
-                        const uint32_t descriptor_index = error_record[kInst_LogError_ParameterOffset_0];
-                        ss << "descriptor index " << std::dec << descriptor_index << " is accessing the "
-                           << (is_sampler ? "sampler" : "resource") << " heap at offset 0x" << std::hex << offset << " (address 0x"
-                           << heap_address << ") but there is no valid descriptor at that location.\n";
-                        out_vuid_msg = "UNASSIGNED-DescriptorHeap-No-Descriptor";
-                        error_found = true;
-                    } break;
+                    case kErrorSubCode_DescriptorHeap_DescriptorHashing_None:
                     case kErrorSubCode_DescriptorHeap_DescriptorHashing_Wrong: {
-                        // We trade the descriptor_index for getting the slot_index to find what descriptor this was
-                        const uint32_t slot_index = error_record[kInst_LogError_ParameterOffset_0];
                         ReadLockGuard guard(gpuav.device_state->descriptor_hashing->map_lock);
-                        const auto& entry = gpuav.device_state->descriptor_hashing->table.slots[slot_index].entry;
+                        if (gpuav.device_state->descriptor_hashing->table.limit_reported) {
+                            // If we have hit the limit, we are likely going to spam errors and want them to see
+                            // the DESCRIPTOR-HASHING-LIMIT only instead
+                            return error_found;
+                        }
 
-                        ss << "is accessing the " << (is_sampler ? "sampler" : "resource") << " heap at offset 0x" << std::hex
-                           << offset << " (address 0x" << heap_address << ") but there is a descriptor there of the wrong type: \n";
-                        entry.Describe(*gpuav.device_state, ss);
-                        ss << '\n';
-                        out_vuid_msg = "UNASSIGNED-DescriptorHeap-Wrong-DescriptorType";
+                        if (error_sub_code == kErrorSubCode_DescriptorHeap_DescriptorHashing_None) {
+                            const uint32_t descriptor_index = error_record[kInst_LogError_ParameterOffset_0];
+                            ss << "descriptor index " << std::dec << descriptor_index << " is accessing the "
+                               << (is_sampler ? "sampler" : "resource") << " heap at offset 0x" << std::hex << offset
+                               << " (address 0x" << heap_address << ") but there is no valid descriptor at that location.\n";
+                            out_vuid_msg = "UNASSIGNED-DescriptorHeap-No-Descriptor";
+                        } else {
+                            // We trade the descriptor_index for getting the slot_index to find what descriptor this was
+                            const uint32_t slot_index = error_record[kInst_LogError_ParameterOffset_0];
+                            const auto& entry = gpuav.device_state->descriptor_hashing->table.slots[slot_index].entry;
+                            ss << "is accessing the " << (is_sampler ? "sampler" : "resource") << " heap at offset 0x" << std::hex
+                               << offset << " (address 0x" << heap_address
+                               << ") but there is a descriptor there of the wrong type: \n";
+                            entry.Describe(*gpuav.device_state, ss);
+                            ss << '\n';
+                            out_vuid_msg = "UNASSIGNED-DescriptorHeap-Wrong-DescriptorType";
+                        }
                         error_found = true;
                     } break;
                 }


### PR DESCRIPTION
If you hit the limit for our descriptor hashing map capacity, we don't add the new key and this means we will start reporting false positives

I want them the user to see the `DESCRIPTOR-HASHING-LIMIT` error and it will be hard if we pollute it with more errors