### PR TITLE
gpuav: Remove auto error_found bool

### DIFF
--- a/layers/gpuav/instrumentation/descriptor_checks_buffer.cpp
+++ b/layers/gpuav/instrumentation/descriptor_checks_buffer.cpp
@@ -197,7 +197,6 @@ void RegisterDescriptorChecksBufferValidation(Validator& gpuav, CommandBufferSub
                         // the DESCRIPTOR-HASHING-LIMIT only instead
                         return error_found;
                     }
-                    error_found = true;
 
                     std::ostringstream ss;
 

--- a/layers/gpuav/instrumentation/descriptor_checks_classic.cpp
+++ b/layers/gpuav/instrumentation/descriptor_checks_classic.cpp
@@ -142,7 +142,6 @@ void RegisterDescriptorChecksClassicValidation(Validator& gpuav, CommandBufferSu
             if (GetErrorGroup(error_record) != kErrorGroup_InstDescriptorIndexingOOB) {
                 return error_found;
             }
-            error_found = true;
 
             std::ostringstream strm;
 

--- a/layers/gpuav/instrumentation/descriptor_checks_heap.cpp
+++ b/layers/gpuav/instrumentation/descriptor_checks_heap.cpp
@@ -139,7 +139,6 @@ void RegisterDescriptorChecksHeapValidation(Validator& gpuav, CommandBufferSubSt
                 if (GetErrorGroup(error_record) != kErrorGroup_InstDescriptorHeap) {
                     return error_found;
                 }
-                error_found = true;
 
                 std::ostringstream ss;
 


### PR DESCRIPTION
small follow up of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12729

we set `error_found` in each

```
const uint32_t error_sub_code = GetSubError(error_record);
switch (error_sub_code) {
```

case, so no need to set once at the start (as it provides false positives when we don't have a real error)