### PR TITLE
sync: Stop using SyncOpBase::Record for events

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -411,6 +411,8 @@ vvl_sources = [
   "layers/sync/sync_common.h",
   "layers/sync/sync_error_messages.cpp",
   "layers/sync/sync_error_messages.h",
+  "layers/sync/sync_event.cpp",
+  "layers/sync/sync_event.h",
   "layers/sync/sync_hazard_detection.cpp",
   "layers/sync/sync_image.cpp",
   "layers/sync/sync_image.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -500,6 +500,8 @@ target_sources(vvl PRIVATE
     sync/sync_common.h
     sync/sync_error_messages.cpp
     sync/sync_error_messages.h
+    sync/sync_event.cpp
+    sync/sync_event.h
     sync/sync_hazard_detection.cpp
     sync/sync_image.cpp
     sync/sync_image.h

--- a/layers/sync/sync_barrier.cpp
+++ b/layers/sync/sync_barrier.cpp
@@ -16,6 +16,9 @@
  */
 
 #include "sync_barrier.h"
+#include "sync_validation.h"
+#include "state_tracker/image_state.h"
+#include "utils/image_utils.h"
 #include "utils/sync_utils.h"
 #include <vulkan/utility/vk_struct_helper.hpp>
 
@@ -213,6 +216,160 @@ size_t SyncBarrier::Hash() const {
     hc << dst_exec_scope.Hash();
     dst_access_scope.HashCombine(hc);
     return hc.Value();
+}
+
+BarrierSet::BarrierSet(const SyncValidator& sync_state, VkQueueFlags queue_flags, const VkDependencyInfo& dep_info) {
+    const ExecScopes stage_masks = sync_utils::GetExecScopes(dep_info);
+    src_exec_scope = SyncExecScope::MakeSrc(queue_flags, stage_masks.src);
+    dst_exec_scope = SyncExecScope::MakeDst(queue_flags, stage_masks.dst);
+
+    MakeMemoryBarriers(queue_flags, dep_info);
+    MakeBufferMemoryBarriers(sync_state, queue_flags, dep_info.bufferMemoryBarrierCount, dep_info.pBufferMemoryBarriers);
+    MakeImageMemoryBarriers(sync_state, queue_flags, dep_info.imageMemoryBarrierCount, dep_info.pImageMemoryBarriers,
+                            sync_state.device_state->extensions);
+}
+
+BarrierSet::BarrierSet(const SyncValidator& sync_state, const SyncExecScope& src_exec_scope, const SyncExecScope& dst_exec_scope,
+                       uint32_t memory_barrier_count, const VkMemoryBarrier* memory_barriers, uint32_t buffer_barrier_count,
+                       const VkBufferMemoryBarrier* buffer_barriers, uint32_t image_barrier_count,
+                       const VkImageMemoryBarrier* image_barriers)
+    : src_exec_scope(src_exec_scope), dst_exec_scope(dst_exec_scope) {
+    MakeMemoryBarriers(src_exec_scope, dst_exec_scope, memory_barrier_count, memory_barriers);
+    MakeBufferMemoryBarriers(sync_state, src_exec_scope, dst_exec_scope, buffer_barrier_count, buffer_barriers);
+    MakeImageMemoryBarriers(sync_state, src_exec_scope, dst_exec_scope, image_barrier_count, image_barriers,
+                            sync_state.device_state->extensions);
+}
+
+void BarrierSet::MakeMemoryBarriers(const SyncExecScope& src, const SyncExecScope& dst, uint32_t barrier_count,
+                                    const VkMemoryBarrier* barriers) {
+    memory_barriers.reserve(std::max<uint32_t>(1, barrier_count));
+    for (const VkMemoryBarrier& barrier : vvl::make_span(barriers, barrier_count)) {
+        SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
+        memory_barriers.emplace_back(sync_barrier);
+    }
+
+    // Ensure we have a barrier that handles execution dependencies.
+    // NOTE: the reason to have execution barrier is explained in details in the comment for Sync2
+    // MakeMemoryBarriers overload. The Sync1 implementation is much simpler since execution scopes
+    // are the same for all barriers.
+    if (barrier_count == 0) {
+        memory_barriers.emplace_back(SyncBarrier(src, dst));
+    }
+    single_exec_scope = true;
+    execution_dependency_barrier_count = (barrier_count == 0) ? 1 : 0;
+}
+
+void BarrierSet::MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependencyInfo& dep_info) {
+    // Collect unique execution dependencies from buffer and image barriers.
+    //
+    // NOTE: the reason to collect execution dependencies in addition to original buffer/image
+    // barriers is because syncval applies buffer/image barriers to the memory ranges defined
+    // by the resource. But execution dependency can affect any resource/memory range, not
+    // only the one specified by the barrier. For example, execution dependency synchronizes
+    // all READ accesses that are in scope. To emulate this behavior we collect unique
+    // execution dependencies and apply them to all memory accesses (don't specify access mask).
+    small_vector<std::pair<VkPipelineStageFlags2, VkPipelineStageFlags2>, 4> buffer_image_barrier_exec_deps;
+    for (const VkBufferMemoryBarrier2& buffer_barrier :
+         vvl::make_span(dep_info.pBufferMemoryBarriers, dep_info.bufferMemoryBarrierCount)) {
+        const auto src_dst = std::make_pair(buffer_barrier.srcStageMask, buffer_barrier.dstStageMask);
+        if (!buffer_image_barrier_exec_deps.Contains(src_dst)) {
+            buffer_image_barrier_exec_deps.emplace_back(src_dst);
+        }
+    }
+    for (const VkImageMemoryBarrier2& image_barrier :
+         vvl::make_span(dep_info.pImageMemoryBarriers, dep_info.imageMemoryBarrierCount)) {
+        const auto src_dst = std::make_pair(image_barrier.srcStageMask, image_barrier.dstStageMask);
+        if (!buffer_image_barrier_exec_deps.Contains(src_dst)) {
+            buffer_image_barrier_exec_deps.emplace_back(src_dst);
+        }
+    }
+
+    memory_barriers.reserve(dep_info.memoryBarrierCount + buffer_image_barrier_exec_deps.size());
+
+    // Add global memory barriers specified in VkDependencyInfo
+    for (const VkMemoryBarrier2& barrier : vvl::make_span(dep_info.pMemoryBarriers, dep_info.memoryBarrierCount)) {
+        auto src = SyncExecScope::MakeSrc(queue_flags, barrier.srcStageMask);
+        auto dst = SyncExecScope::MakeDst(queue_flags, barrier.dstStageMask);
+        memory_barriers.emplace_back(SyncBarrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask));
+    }
+    // Add execution dependencies from buffer and image barriers
+    for (const auto& src_dst : buffer_image_barrier_exec_deps) {
+        auto src = SyncExecScope::MakeSrc(queue_flags, src_dst.first);
+        auto dst = SyncExecScope::MakeDst(queue_flags, src_dst.second);
+        memory_barriers.emplace_back(SyncBarrier(src, dst));
+    }
+    single_exec_scope = false;
+    execution_dependency_barrier_count = (uint32_t)buffer_image_barrier_exec_deps.size();
+}
+
+void BarrierSet::MakeBufferMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
+                                          uint32_t barrier_count, const VkBufferMemoryBarrier* barriers) {
+    buffer_barriers.reserve(barrier_count);
+    for (const VkBufferMemoryBarrier& barrier : vvl::make_span(barriers, barrier_count)) {
+        if (auto buffer = sync_state.Get<vvl::Buffer>(barrier.buffer)) {
+            const auto range = MakeRange(*buffer, barrier.offset, barrier.size);
+            const SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
+            buffer_barriers.emplace_back(buffer, sync_barrier, range);
+        }
+    }
+}
+
+void BarrierSet::MakeBufferMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
+                                          const VkBufferMemoryBarrier2* barriers) {
+    buffer_barriers.reserve(barrier_count);
+    for (const VkBufferMemoryBarrier2& barrier : vvl::make_span(barriers, barrier_count)) {
+        auto src = SyncExecScope::MakeSrc(queue_flags, barrier.srcStageMask);
+        auto dst = SyncExecScope::MakeDst(queue_flags, barrier.dstStageMask);
+        if (auto buffer = sync_state.Get<vvl::Buffer>(barrier.buffer)) {
+            const auto range = MakeRange(*buffer, barrier.offset, barrier.size);
+            const SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
+            buffer_barriers.emplace_back(buffer, sync_barrier, range);
+        }
+    }
+}
+
+void BarrierSet::MakeImageMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
+                                         uint32_t barrier_count, const VkImageMemoryBarrier* barriers,
+                                         const DeviceExtensions& extensions) {
+    image_barriers.reserve(barrier_count);
+    for (const auto [index, barrier] : vvl::enumerate(barriers, barrier_count)) {
+        if (auto image = sync_state.Get<vvl::Image>(barrier.image)) {
+            auto subresource_range = image->NormalizeSubresourceRange(barrier.subresourceRange);
+
+            // VK_REMAINING_ARRAY_LAYERS for sliced 3d image in the context of layout transition means image's depth extent.
+            if (barrier.subresourceRange.layerCount == VK_REMAINING_ARRAY_LAYERS &&
+                CanTransitionDepthSlices(extensions, image->GetImageType(), image->create_flags)) {
+                subresource_range.layerCount = image->GetExtent().depth - subresource_range.baseArrayLayer;
+            }
+
+            const SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
+            const bool layout_transition = barrier.oldLayout != barrier.newLayout;
+            image_barriers.emplace_back(image, sync_barrier, subresource_range, layout_transition, index);
+        }
+    }
+}
+
+void BarrierSet::MakeImageMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
+                                         const VkImageMemoryBarrier2* barriers, const DeviceExtensions& extensions) {
+    image_barriers.reserve(barrier_count);
+    for (const auto [index, barrier] : vvl::enumerate(barriers, barrier_count)) {
+        auto src = SyncExecScope::MakeSrc(queue_flags, barrier.srcStageMask);
+        auto dst = SyncExecScope::MakeDst(queue_flags, barrier.dstStageMask);
+        auto image = sync_state.Get<vvl::Image>(barrier.image);
+        if (image) {
+            auto subresource_range = image->NormalizeSubresourceRange(barrier.subresourceRange);
+
+            // VK_REMAINING_ARRAY_LAYERS for sliced 3d image in the context of layout transition means image's depth extent.
+            if (barrier.subresourceRange.layerCount == VK_REMAINING_ARRAY_LAYERS &&
+                CanTransitionDepthSlices(extensions, image->GetImageType(), image->create_flags)) {
+                subresource_range.layerCount = image->GetExtent().depth - subresource_range.baseArrayLayer;
+            }
+
+            const SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
+            const bool layout_transition = barrier.oldLayout != barrier.newLayout;
+            image_barriers.emplace_back(image, sync_barrier, subresource_range, layout_transition, index);
+        }
+    }
 }
 
 }  // namespace syncval

--- a/layers/sync/sync_barrier.h
+++ b/layers/sync/sync_barrier.h
@@ -19,7 +19,11 @@
 
 #include "sync/sync_common.h"
 
+struct DeviceExtensions;
+
 namespace syncval {
+
+class SyncValidator;
 
 struct SyncExecScope {
     // The xxxStageMask parameter passed by the caller
@@ -60,11 +64,74 @@ struct SyncBarrier {
     SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst_exec, const AllAccess&);
     SyncBarrier(const SyncExecScope& src_exec, VkAccessFlags2 src_access_mask, const SyncExecScope& dst_exec,
                 VkAccessFlags2 dst_access_mask);
-    SyncBarrier(VkQueueFlags queue_flags, const VkSubpassDependency2 &barrier);
-    SyncBarrier(const std::vector<SyncBarrier> &barriers);
+    SyncBarrier(VkQueueFlags queue_flags, const VkSubpassDependency2& barrier);
+    SyncBarrier(const std::vector<SyncBarrier>& barriers);
 
-    bool operator==(const SyncBarrier &other) const;
+    bool operator==(const SyncBarrier& other) const;
     size_t Hash() const;
+};
+
+struct SyncBufferBarrier {
+    std::shared_ptr<const vvl::Buffer> buffer;
+    SyncBarrier barrier;
+    AccessRange range;
+
+    SyncBufferBarrier(const std::shared_ptr<const vvl::Buffer>& buffer, const SyncBarrier& barrier, const AccessRange& range)
+        : buffer(buffer), barrier(barrier), range(range) {}
+};
+
+struct SyncImageBarrier {
+    std::shared_ptr<const vvl::Image> image;
+    SyncBarrier barrier;
+    VkImageSubresourceRange subresource_range;
+    bool layout_transition;
+    uint32_t barrier_index;
+    uint32_t handle_index = vvl::kNoIndex32;
+
+    SyncImageBarrier(const std::shared_ptr<const vvl::Image>& image, const SyncBarrier& barrier,
+                     const VkImageSubresourceRange& subresource_range, bool layout_transition, uint32_t barrier_index)
+        : image(image),
+          barrier(barrier),
+          subresource_range(subresource_range),
+          layout_transition(layout_transition),
+          barrier_index(barrier_index) {}
+};
+
+struct BarrierSet {
+    SyncExecScope src_exec_scope;
+    SyncExecScope dst_exec_scope;
+    std::vector<SyncBarrier> memory_barriers;
+    std::vector<SyncBufferBarrier> buffer_barriers;
+    std::vector<SyncImageBarrier> image_barriers;
+
+    bool single_exec_scope = false;
+
+    // The numbers of additional global barriers introduced to track execution dependencies
+    // defined by image and buffer barriers, or a single execution dependencies when a sync1
+    // barrier command specifies no barriers (only exec scopes). Used for statistics tracking.
+    uint32_t execution_dependency_barrier_count = 0;
+
+    BarrierSet() = default;
+    BarrierSet(const SyncValidator& sync_state, VkQueueFlags queue_flags, const VkDependencyInfo& dep_info);
+    BarrierSet(const SyncValidator& sync_state, const SyncExecScope& src_exec_scope, const SyncExecScope& dst_exec_scope,
+               uint32_t memory_barrier_count, const VkMemoryBarrier* memory_barriers, uint32_t buffer_barrier_count,
+               const VkBufferMemoryBarrier* buffer_barriers, uint32_t image_barrier_count,
+               const VkImageMemoryBarrier* image_barriers);
+
+  private:
+    void MakeMemoryBarriers(const SyncExecScope& src, const SyncExecScope& dst, uint32_t barrier_count,
+                            const VkMemoryBarrier* barriers);
+    void MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependencyInfo& dep_info);
+
+    void MakeBufferMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
+                                  uint32_t barrier_count, const VkBufferMemoryBarrier* barriers);
+    void MakeBufferMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
+                                  const VkBufferMemoryBarrier2* barriers);
+
+    void MakeImageMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
+                                 uint32_t barrier_count, const VkImageMemoryBarrier* barriers, const DeviceExtensions& extensions);
+    void MakeImageMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
+                                 const VkImageMemoryBarrier2* barriers, const DeviceExtensions& extensions);
 };
 
 // Defines the source scope of the barrier.
@@ -84,11 +151,11 @@ struct BarrierScope {
     // value, so (access_tag < scope_tag) evaluates to true for non event code.
     ResourceUsageTag scope_tag = kInvalidTag;
 
-    BarrierScope(const SyncBarrier &barrier, QueueId scope_queue = kQueueIdInvalid, ResourceUsageTag scope_tag = kInvalidTag);
+    BarrierScope(const SyncBarrier& barrier, QueueId scope_queue = kQueueIdInvalid, ResourceUsageTag scope_tag = kInvalidTag);
 };
 
 struct SemaphoreScope : SyncExecScope {
-    SemaphoreScope(QueueId qid, const SyncExecScope &exec_scope) : SyncExecScope(exec_scope), queue(qid) {}
+    SemaphoreScope(QueueId qid, const SyncExecScope& exec_scope) : SyncExecScope(exec_scope), queue(qid) {}
     SemaphoreScope() = default;
     QueueId queue;
 };

--- a/layers/sync/sync_event.cpp
+++ b/layers/sync/sync_event.cpp
@@ -1,0 +1,325 @@
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sync_event.h"
+#include "sync_access_context.h"
+#include "sync_image.h"
+#include "sync_validation.h"
+#include "state_tracker/buffer_state.h"
+#include "utils/image_utils.h"
+
+namespace syncval {
+
+// Range generators for to allow event scope filtration to be limited to the top of the resource access traversal pipeline
+//
+// Note: there is no "begin/end" or reset facility.  These are each written as "one time through" generators.
+//
+// Usage:
+//  Constructor() -- initializes the generator to point to the begin of the space declared.
+//  *  -- the current range of the generator empty signfies end
+//  ++ -- advance to the next non-empty range (or end)
+
+// Generate the ranges that are the intersection of range and the entries in the RangeMap
+class MapRangesRangeGenerator {
+  public:
+    // Default constructed is safe to dereference for "empty" test, but for no other operation.
+    MapRangesRangeGenerator() {
+        // Default construction *must* be empty range
+        assert(current_.empty());
+    }
+    MapRangesRangeGenerator(const AccessMap& filter, const AccessRange& range)
+        : range_(range), map_(&filter), map_pos_(), current_() {
+        SeekBegin();
+    }
+    MapRangesRangeGenerator(const MapRangesRangeGenerator& from) = default;
+
+    const AccessRange& operator*() const { return current_; }
+    const AccessRange* operator->() const { return &current_; }
+    MapRangesRangeGenerator& operator++() {
+        ++map_pos_;
+        UpdateCurrent();
+        return *this;
+    }
+
+  protected:
+    void UpdateCurrent() {
+        if (map_pos_ != map_->end()) {
+            current_ = range_ & map_pos_->first;
+        } else {
+            current_ = {};
+        }
+    }
+    void SeekBegin() {
+        map_pos_ = map_->LowerBound(range_.begin);
+        UpdateCurrent();
+    }
+
+    const AccessRange range_;
+    const AccessMap* map_ = nullptr;
+    AccessMap::const_iterator map_pos_;
+    AccessRange current_;
+};
+using EventSimpleRangeGenerator = MapRangesRangeGenerator;
+
+// Generate the ranges that are the intersection of the RangeGen ranges and the entries in the FilterMap
+template <typename RangeGen>
+class FilteredGeneratorGenerator {
+  public:
+    // Default constructed is safe to dereference for "empty" test, but for no other operation.
+    FilteredGeneratorGenerator() : filter_(nullptr), gen_(), filter_pos_(), current_() {
+        // Default construction for KeyType *must* be empty range
+        assert(current_.empty());
+    }
+    FilteredGeneratorGenerator(const AccessMap& filter, RangeGen& gen) : filter_(&filter), gen_(gen), filter_pos_(), current_() {
+        SeekBegin();
+    }
+    FilteredGeneratorGenerator(const FilteredGeneratorGenerator& from) = default;
+    const AccessRange& operator*() const { return current_; }
+    const AccessRange* operator->() const { return &current_; }
+    FilteredGeneratorGenerator& operator++() {
+        AccessRange gen_range = GenRange();
+        AccessRange filter_range = FilterRange();
+        current_ = {};
+        while (gen_range.non_empty() && filter_range.non_empty() && current_.empty()) {
+            if (gen_range.end > filter_range.end) {
+                // if the generated range is beyond the filter_range, advance the filter range
+                filter_range = AdvanceFilter();
+            } else {
+                gen_range = AdvanceGen();
+            }
+            current_ = gen_range & filter_range;
+        }
+        return *this;
+    }
+
+    bool operator==(const FilteredGeneratorGenerator& other) const { return current_ == other.current_; }
+
+  private:
+    AccessRange AdvanceFilter() {
+        ++filter_pos_;
+        auto filter_range = FilterRange();
+        assert(filter_range.valid());
+        if (filter_range.valid()) {
+            FastForwardGen(filter_range);
+        }
+        return filter_range;
+    }
+    AccessRange AdvanceGen() {
+        ++gen_;
+        auto gen_range = GenRange();
+        if (gen_range.valid()) {
+            FastForwardFilter(gen_range);
+        }
+        return gen_range;
+    }
+
+    AccessRange FilterRange() const { return (filter_pos_ != filter_->end()) ? filter_pos_->first : AccessRange{}; }
+    AccessRange GenRange() const { return *gen_; }
+
+    AccessRange FastForwardFilter(const AccessRange& range) {
+        auto filter_range = FilterRange();
+        int retry_count = 0;
+        const static int kRetryLimit = 2;  // TODO -- determine whether this limit is optimal
+        while (!filter_range.empty() && (filter_range.end <= range.begin)) {
+            if (retry_count < kRetryLimit) {
+                ++filter_pos_;
+                filter_range = FilterRange();
+                retry_count++;
+            } else {
+                // Okay we've tried walking, do a seek.
+                filter_pos_ = filter_->LowerBound(range.begin);
+                break;
+            }
+        }
+        return FilterRange();
+    }
+
+    // TODO: Consider adding "seek" (or an absolute bound "get" to range generators to make this walk
+    // faster.
+    AccessRange FastForwardGen(const AccessRange& range) {
+        auto gen_range = GenRange();
+        while (!gen_range.empty() && (gen_range.end <= range.begin)) {
+            ++gen_;
+            gen_range = GenRange();
+        }
+        return gen_range;
+    }
+
+    void SeekBegin() {
+        auto gen_range = GenRange();
+        if (gen_range.empty()) {
+            current_ = {};
+            filter_pos_ = filter_->end();
+        } else {
+            filter_pos_ = filter_->LowerBound(gen_range.begin);
+            current_ = gen_range & FilterRange();
+        }
+    }
+
+    const AccessMap* filter_ = nullptr;
+    RangeGen gen_;
+    AccessMap::const_iterator filter_pos_;
+    AccessRange current_;
+};
+
+using EventImageRangeGenerator = FilteredGeneratorGenerator<subresource_adapter::ImageRangeGenerator>;
+
+// Need to restrict to only valid exec and access scope for this event
+static SyncBarrier RestrictToEvent(const SyncBarrier& barrier, const SyncEventState& sync_event) {
+    SyncBarrier result = barrier;
+    result.src_exec_scope.exec_scope = sync_event.scope.exec_scope & barrier.src_exec_scope.exec_scope;
+    result.src_access_scope = sync_event.scope.stage_mask_accesses & barrier.src_access_scope;
+    return result;
+}
+
+void ApplyWaitEvents(CommandExecutionContext& exec_context, const std::vector<std::shared_ptr<const vvl::Event>>& events,
+                     vvl::span<const BarrierSet> barrier_sets, ResourceUsageTag tag, vvl::Func command) {
+    // Unlike PipelineBarrier, WaitEvent is *not* limited to accesses within the current subpass (if any) and thus needs to import
+    // all accesses. Can instead import for all first_scopes, or a union of them, if this becomes a performance/memory issue,
+    // but with no idea of the performance of the union, nor of whether it even matters... take the simplest approach here,
+
+    AccessContext& access_context = exec_context.GetCurrentAccessContext();
+    SyncEventsContext& events_context = exec_context.GetEventsContext();
+    const QueueId queue_id = exec_context.GetQueueId();
+
+    access_context.ResolveAllSubpassDependencies();
+
+    assert(barrier_sets.size() == 1 || (barrier_sets.size() == events.size()));
+
+    // Apply markup action.
+    // The markup action does not change any access state but it can trim the access map according to the
+    // provided range and creates infill ranges if necessary (for layout transitions). The purpose of all
+    // this is to ensure that after markup action the topology of access map ranges is finalized for the
+    // duration of barrier application (so we can cache pointers to specific access states with a goal
+    // to apply pending barriers in the end).
+    //
+    // NOTE: event's global barriers can split() access map because EventSimpleRangeGenerator filters kFullRange.
+    // That's why, in contrast to SyncOpPipelineBarrier, we need apply markup action also to global barriers.
+    // TODO: need a test that demonstrates this (when doing some work on syncval events)
+    size_t barrier_set_index = 0;
+    size_t barrier_set_incr = (barrier_sets.size() == 1) ? 0 : 1;
+    for (auto& event_shared : events) {
+        if (!event_shared) {
+            continue;
+        }
+        auto* sync_event = events_context.GetFromShared(event_shared);
+        if (!sync_event->first_scope) {
+            continue;  // [core validation check]
+        }
+
+        sync_event->last_command = command;
+        sync_event->last_command_tag = tag;
+
+        const auto& barrier_set = barrier_sets[barrier_set_index];
+        for (const SyncBufferBarrier& barrier : barrier_set.buffer_barriers) {
+            if (SimpleBinding(*barrier.buffer)) {
+                const VkDeviceSize base_address = ResourceBaseAddress(*barrier.buffer);
+                const AccessRange range = barrier.range + base_address;
+                EventSimpleRangeGenerator filtered_range_gen(sync_event->FirstScope(), range);
+                ApplyMarkupFunctor markup_action(false);
+                access_context.UpdateMemoryAccessState(markup_action, filtered_range_gen);
+            }
+        }
+        for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
+            const auto& sub_state = SubState(*barrier.image);
+            const bool can_transition_depth_slices = CanTransitionDepthSlices(
+                exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+            ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
+            EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
+            ApplyMarkupFunctor markup_action(barrier.layout_transition);
+            access_context.UpdateMemoryAccessState(markup_action, filtered_range_gen);
+        }
+        auto global_barriers_range_gen = EventSimpleRangeGenerator(sync_event->FirstScope(), kFullRange);
+        ApplyMarkupFunctor markup_action(false);
+        access_context.UpdateMemoryAccessState(markup_action, global_barriers_range_gen);
+        barrier_set_index += barrier_set_incr;
+    }
+
+    // Apply barriers independently and store the result in the pending object.
+    PendingBarriers pending_barriers;
+    barrier_set_index = 0;
+    barrier_set_incr = (barrier_sets.size() == 1) ? 0 : 1;
+    for (auto& event_shared : events) {
+        if (!event_shared.get()) {
+            continue;
+        }
+        auto* sync_event = events_context.GetFromShared(event_shared);
+        if (!sync_event->first_scope) {
+            continue;  // [core validation check]
+        }
+
+        const auto& barrier_set = barrier_sets[barrier_set_index];
+        const auto& dst = barrier_set.dst_exec_scope;
+
+        // These apply barriers one at a time as the are restricted to the resource ranges specified per each barrier,
+        // but do not update the dependency chain information (but set the "pending" state) // s.t. the order independence
+        // of the barriers is maintained.
+
+        for (const SyncBufferBarrier& barrier : barrier_set.buffer_barriers) {
+            if (SimpleBinding(*barrier.buffer)) {
+                const SyncBarrier event_barrier = RestrictToEvent(barrier.barrier, *sync_event);
+                const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
+                CollectBarriersFunctor collect_barriers(access_context, barrier_scope, event_barrier, false, vvl::kNoIndex32,
+                                                        pending_barriers);
+
+                const VkDeviceSize base_address = ResourceBaseAddress(*barrier.buffer);
+                const AccessRange range = barrier.range + base_address;
+                EventSimpleRangeGenerator range_gen(sync_event->FirstScope(), range);
+
+                access_context.UpdateMemoryAccessState(collect_barriers, range_gen);
+            }
+        }
+        for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
+            const SyncBarrier event_barrier = RestrictToEvent(barrier.barrier, *sync_event);
+            const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
+            CollectBarriersFunctor collect_barriers(access_context, barrier_scope, event_barrier, barrier.layout_transition,
+                                                    barrier.handle_index, pending_barriers);
+
+            const auto& sub_state = SubState(*barrier.image);
+            const bool can_transition_depth_slices = CanTransitionDepthSlices(
+                exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+            ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
+            EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
+
+            access_context.UpdateMemoryAccessState(collect_barriers, filtered_range_gen);
+        }
+        // TODO: because each iteration applies functor to the same range, investigate if it is
+        // beneficial for the functor to support multiple barriers, so we traverse access map once.
+        auto global_range_gen = EventSimpleRangeGenerator(sync_event->FirstScope(), kFullRange);
+        for (const auto& barrier : barrier_set.memory_barriers) {
+            const SyncBarrier event_barrier = RestrictToEvent(barrier, *sync_event);
+            const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
+            CollectBarriersFunctor collect_barriers(access_context, barrier_scope, event_barrier, false, vvl::kNoIndex32,
+                                                    pending_barriers);
+
+            auto range_gen = global_range_gen;  // intentional copy
+            access_context.UpdateMemoryAccessState(collect_barriers, range_gen);
+        }
+
+        // Apply the global barrier to the event itself (for race condition tracking)
+        // Events don't happen at a stage, so we need to store the unexpanded ALL_COMMANDS if set for inter-event-calls
+        sync_event->barriers = dst.stage_mask & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+        sync_event->barriers |= dst.exec_scope;
+
+        barrier_set_index += barrier_set_incr;
+    }
+
+    // Update access states with collected barriers
+    pending_barriers.Apply(tag);
+}
+
+}  // namespace syncval

--- a/layers/sync/sync_event.h
+++ b/layers/sync/sync_event.h
@@ -1,0 +1,37 @@
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "sync_barrier.h"
+#include "containers/span.h"
+#include "generated/error_location_helper.h"
+#include <memory>
+#include <vector>
+
+namespace vvl {
+class Event;
+}
+
+class CommandExecutionContext;
+
+namespace syncval {
+
+void ApplyWaitEvents(CommandExecutionContext& exec_context, const std::vector<std::shared_ptr<const vvl::Event>>& events,
+                     vvl::span<const BarrierSet> barrier_sets, ResourceUsageTag tag, vvl::Func command);
+
+}  // namespace syncval

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -19,6 +19,7 @@
 #include "sync/sync_render_pass.h"
 #include "sync/sync_access_context.h"
 #include "sync/sync_command_buffer.h"
+#include "sync/sync_event.h"
 #include "sync/sync_image.h"
 #include "sync/sync_validation.h"
 
@@ -33,327 +34,6 @@ using vvl::Func;
 
 namespace syncval {
 
-// Range generators for to allow event scope filtration to be limited to the top of the resource access traversal pipeline
-//
-// Note: there is no "begin/end" or reset facility.  These are each written as "one time through" generators.
-//
-// Usage:
-//  Constructor() -- initializes the generator to point to the begin of the space declared.
-//  *  -- the current range of the generator empty signfies end
-//  ++ -- advance to the next non-empty range (or end)
-
-// Generate the ranges that are the intersection of range and the entries in the RangeMap
-class MapRangesRangeGenerator {
-  public:
-    // Default constructed is safe to dereference for "empty" test, but for no other operation.
-    MapRangesRangeGenerator() {
-        // Default construction *must* be empty range
-        assert(current_.empty());
-    }
-    MapRangesRangeGenerator(const AccessMap& filter, const AccessRange& range)
-        : range_(range), map_(&filter), map_pos_(), current_() {
-        SeekBegin();
-    }
-    MapRangesRangeGenerator(const MapRangesRangeGenerator& from) = default;
-
-    const AccessRange& operator*() const { return current_; }
-    const AccessRange* operator->() const { return &current_; }
-    MapRangesRangeGenerator& operator++() {
-        ++map_pos_;
-        UpdateCurrent();
-        return *this;
-    }
-
-    bool operator==(const MapRangesRangeGenerator& other) const { return current_ == other.current_; }
-
-  protected:
-    void UpdateCurrent() {
-        if (map_pos_ != map_->end()) {
-            current_ = range_ & map_pos_->first;
-        } else {
-            current_ = {};
-        }
-    }
-    void SeekBegin() {
-        map_pos_ = map_->LowerBound(range_.begin);
-        UpdateCurrent();
-    }
-
-    // Adding this functionality here, to avoid gratuitous Base:: qualifiers in the derived class
-    // Note: Not exposed in this classes public interface to encourage using a consistent ++/empty generator semantic
-    template <typename Pred>
-    MapRangesRangeGenerator& PredicatedIncrement(Pred& pred) {
-        do {
-            ++map_pos_;
-        } while (map_pos_ != map_->end() && map_pos_->first.intersects(range_) && !pred(map_pos_));
-        UpdateCurrent();
-        return *this;
-    }
-
-    const AccessRange range_;
-    const AccessMap* map_ = nullptr;
-    AccessMap::const_iterator map_pos_;
-    AccessRange current_;
-};
-using EventSimpleRangeGenerator = MapRangesRangeGenerator;
-
-// Generate the ranges that are the intersection of the RangeGen ranges and the entries in the FilterMap
-template <typename RangeGen>
-class FilteredGeneratorGenerator {
-  public:
-    // Default constructed is safe to dereference for "empty" test, but for no other operation.
-    FilteredGeneratorGenerator() : filter_(nullptr), gen_(), filter_pos_(), current_() {
-        // Default construction for KeyType *must* be empty range
-        assert(current_.empty());
-    }
-    FilteredGeneratorGenerator(const AccessMap& filter, RangeGen& gen) : filter_(&filter), gen_(gen), filter_pos_(), current_() {
-        SeekBegin();
-    }
-    FilteredGeneratorGenerator(const FilteredGeneratorGenerator& from) = default;
-    const AccessRange& operator*() const { return current_; }
-    const AccessRange* operator->() const { return &current_; }
-    FilteredGeneratorGenerator& operator++() {
-        AccessRange gen_range = GenRange();
-        AccessRange filter_range = FilterRange();
-        current_ = {};
-        while (gen_range.non_empty() && filter_range.non_empty() && current_.empty()) {
-            if (gen_range.end > filter_range.end) {
-                // if the generated range is beyond the filter_range, advance the filter range
-                filter_range = AdvanceFilter();
-            } else {
-                gen_range = AdvanceGen();
-            }
-            current_ = gen_range & filter_range;
-        }
-        return *this;
-    }
-
-    bool operator==(const FilteredGeneratorGenerator& other) const { return current_ == other.current_; }
-
-  private:
-    AccessRange AdvanceFilter() {
-        ++filter_pos_;
-        auto filter_range = FilterRange();
-        assert(filter_range.valid());
-        if (filter_range.valid()) {
-            FastForwardGen(filter_range);
-        }
-        return filter_range;
-    }
-    AccessRange AdvanceGen() {
-        ++gen_;
-        auto gen_range = GenRange();
-        if (gen_range.valid()) {
-            FastForwardFilter(gen_range);
-        }
-        return gen_range;
-    }
-
-    AccessRange FilterRange() const { return (filter_pos_ != filter_->end()) ? filter_pos_->first : AccessRange{}; }
-    AccessRange GenRange() const { return *gen_; }
-
-    AccessRange FastForwardFilter(const AccessRange& range) {
-        auto filter_range = FilterRange();
-        int retry_count = 0;
-        const static int kRetryLimit = 2;  // TODO -- determine whether this limit is optimal
-        while (!filter_range.empty() && (filter_range.end <= range.begin)) {
-            if (retry_count < kRetryLimit) {
-                ++filter_pos_;
-                filter_range = FilterRange();
-                retry_count++;
-            } else {
-                // Okay we've tried walking, do a seek.
-                filter_pos_ = filter_->LowerBound(range.begin);
-                break;
-            }
-        }
-        return FilterRange();
-    }
-
-    // TODO: Consider adding "seek" (or an absolute bound "get" to range generators to make this walk
-    // faster.
-    AccessRange FastForwardGen(const AccessRange& range) {
-        auto gen_range = GenRange();
-        while (!gen_range.empty() && (gen_range.end <= range.begin)) {
-            ++gen_;
-            gen_range = GenRange();
-        }
-        return gen_range;
-    }
-
-    void SeekBegin() {
-        auto gen_range = GenRange();
-        if (gen_range.empty()) {
-            current_ = {};
-            filter_pos_ = filter_->end();
-        } else {
-            filter_pos_ = filter_->LowerBound(gen_range.begin);
-            current_ = gen_range & FilterRange();
-        }
-    }
-
-    const AccessMap* filter_ = nullptr;
-    RangeGen gen_;
-    AccessMap::const_iterator filter_pos_;
-    AccessRange current_;
-};
-
-using EventImageRangeGenerator = FilteredGeneratorGenerator<subresource_adapter::ImageRangeGenerator>;
-
-BarrierSet::BarrierSet(const SyncValidator& sync_state, VkQueueFlags queue_flags, const VkDependencyInfo& dep_info) {
-    const ExecScopes stage_masks = sync_utils::GetExecScopes(dep_info);
-    src_exec_scope = SyncExecScope::MakeSrc(queue_flags, stage_masks.src);
-    dst_exec_scope = SyncExecScope::MakeDst(queue_flags, stage_masks.dst);
-
-    MakeMemoryBarriers(queue_flags, dep_info);
-    MakeBufferMemoryBarriers(sync_state, queue_flags, dep_info.bufferMemoryBarrierCount, dep_info.pBufferMemoryBarriers);
-    MakeImageMemoryBarriers(sync_state, queue_flags, dep_info.imageMemoryBarrierCount, dep_info.pImageMemoryBarriers,
-                            sync_state.device_state->extensions);
-}
-
-BarrierSet::BarrierSet(const SyncValidator& sync_state, const SyncExecScope& src_exec_scope, const SyncExecScope& dst_exec_scope,
-                       uint32_t memory_barrier_count, const VkMemoryBarrier* memory_barriers, uint32_t buffer_barrier_count,
-                       const VkBufferMemoryBarrier* buffer_barriers, uint32_t image_barrier_count,
-                       const VkImageMemoryBarrier* image_barriers)
-    : src_exec_scope(src_exec_scope), dst_exec_scope(dst_exec_scope) {
-    MakeMemoryBarriers(src_exec_scope, dst_exec_scope, memory_barrier_count, memory_barriers);
-    MakeBufferMemoryBarriers(sync_state, src_exec_scope, dst_exec_scope, buffer_barrier_count, buffer_barriers);
-    MakeImageMemoryBarriers(sync_state, src_exec_scope, dst_exec_scope, image_barrier_count, image_barriers,
-                            sync_state.device_state->extensions);
-}
-
-void BarrierSet::MakeMemoryBarriers(const SyncExecScope& src, const SyncExecScope& dst, uint32_t barrier_count,
-                                    const VkMemoryBarrier* barriers) {
-    memory_barriers.reserve(std::max<uint32_t>(1, barrier_count));
-    for (const VkMemoryBarrier& barrier : vvl::make_span(barriers, barrier_count)) {
-        SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
-        memory_barriers.emplace_back(sync_barrier);
-    }
-
-    // Ensure we have a barrier that handles execution dependencies.
-    // NOTE: the reason to have execution barrier is explained in details in the comment for Sync2
-    // MakeMemoryBarriers overload. The Sync1 implementation is much simpler since execution scopes
-    // are the same for all barriers.
-    if (barrier_count == 0) {
-        memory_barriers.emplace_back(SyncBarrier(src, dst));
-    }
-    single_exec_scope = true;
-    execution_dependency_barrier_count = (barrier_count == 0) ? 1 : 0;
-}
-
-void BarrierSet::MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependencyInfo& dep_info) {
-    // Collect unique execution dependencies from buffer and image barriers.
-    //
-    // NOTE: the reason to collect execution dependencies in addition to original buffer/image
-    // barriers is because syncval applies buffer/image barriers to the memory ranges defined
-    // by the resource. But execution dependency can affect any resource/memory range, not
-    // only the one specified by the barrier. For example, execution dependency synchronizes
-    // all READ accesses that are in scope. To emulate this behavior we collect unique
-    // execution dependencies and apply them to all memory accesses (don't specify access mask).
-    small_vector<std::pair<VkPipelineStageFlags2, VkPipelineStageFlags2>, 4> buffer_image_barrier_exec_deps;
-    for (const VkBufferMemoryBarrier2& buffer_barrier :
-         vvl::make_span(dep_info.pBufferMemoryBarriers, dep_info.bufferMemoryBarrierCount)) {
-        const auto src_dst = std::make_pair(buffer_barrier.srcStageMask, buffer_barrier.dstStageMask);
-        if (!buffer_image_barrier_exec_deps.Contains(src_dst)) {
-            buffer_image_barrier_exec_deps.emplace_back(src_dst);
-        }
-    }
-    for (const VkImageMemoryBarrier2& image_barrier :
-         vvl::make_span(dep_info.pImageMemoryBarriers, dep_info.imageMemoryBarrierCount)) {
-        const auto src_dst = std::make_pair(image_barrier.srcStageMask, image_barrier.dstStageMask);
-        if (!buffer_image_barrier_exec_deps.Contains(src_dst)) {
-            buffer_image_barrier_exec_deps.emplace_back(src_dst);
-        }
-    }
-
-    memory_barriers.reserve(dep_info.memoryBarrierCount + buffer_image_barrier_exec_deps.size());
-
-    // Add global memory barriers specified in VkDependencyInfo
-    for (const VkMemoryBarrier2& barrier : vvl::make_span(dep_info.pMemoryBarriers, dep_info.memoryBarrierCount)) {
-        auto src = SyncExecScope::MakeSrc(queue_flags, barrier.srcStageMask);
-        auto dst = SyncExecScope::MakeDst(queue_flags, barrier.dstStageMask);
-        memory_barriers.emplace_back(SyncBarrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask));
-    }
-    // Add execution dependencies from buffer and image barriers
-    for (const auto& src_dst : buffer_image_barrier_exec_deps) {
-        auto src = SyncExecScope::MakeSrc(queue_flags, src_dst.first);
-        auto dst = SyncExecScope::MakeDst(queue_flags, src_dst.second);
-        memory_barriers.emplace_back(SyncBarrier(src, dst));
-    }
-    single_exec_scope = false;
-    execution_dependency_barrier_count = (uint32_t)buffer_image_barrier_exec_deps.size();
-}
-
-void BarrierSet::MakeBufferMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
-                                          uint32_t barrier_count, const VkBufferMemoryBarrier* barriers) {
-    buffer_barriers.reserve(barrier_count);
-    for (const VkBufferMemoryBarrier& barrier : vvl::make_span(barriers, barrier_count)) {
-        if (auto buffer = sync_state.Get<vvl::Buffer>(barrier.buffer)) {
-            const auto range = MakeRange(*buffer, barrier.offset, barrier.size);
-            const SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
-            buffer_barriers.emplace_back(buffer, sync_barrier, range);
-        }
-    }
-}
-
-void BarrierSet::MakeBufferMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
-                                          const VkBufferMemoryBarrier2* barriers) {
-    buffer_barriers.reserve(barrier_count);
-    for (const VkBufferMemoryBarrier2& barrier : vvl::make_span(barriers, barrier_count)) {
-        auto src = SyncExecScope::MakeSrc(queue_flags, barrier.srcStageMask);
-        auto dst = SyncExecScope::MakeDst(queue_flags, barrier.dstStageMask);
-        if (auto buffer = sync_state.Get<vvl::Buffer>(barrier.buffer)) {
-            const auto range = MakeRange(*buffer, barrier.offset, barrier.size);
-            const SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
-            buffer_barriers.emplace_back(buffer, sync_barrier, range);
-        }
-    }
-}
-
-void BarrierSet::MakeImageMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
-                                         uint32_t barrier_count, const VkImageMemoryBarrier* barriers,
-                                         const DeviceExtensions& extensions) {
-    image_barriers.reserve(barrier_count);
-    for (const auto [index, barrier] : vvl::enumerate(barriers, barrier_count)) {
-        if (auto image = sync_state.Get<vvl::Image>(barrier.image)) {
-            auto subresource_range = image->NormalizeSubresourceRange(barrier.subresourceRange);
-
-            // VK_REMAINING_ARRAY_LAYERS for sliced 3d image in the context of layout transition means image's depth extent.
-            if (barrier.subresourceRange.layerCount == VK_REMAINING_ARRAY_LAYERS &&
-                CanTransitionDepthSlices(extensions, image->GetImageType(), image->create_flags)) {
-                subresource_range.layerCount = image->GetExtent().depth - subresource_range.baseArrayLayer;
-            }
-
-            const SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
-            const bool layout_transition = barrier.oldLayout != barrier.newLayout;
-            image_barriers.emplace_back(image, sync_barrier, subresource_range, layout_transition, index);
-        }
-    }
-}
-
-void BarrierSet::MakeImageMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
-                                         const VkImageMemoryBarrier2* barriers, const DeviceExtensions& extensions) {
-    image_barriers.reserve(barrier_count);
-    for (const auto [index, barrier] : vvl::enumerate(barriers, barrier_count)) {
-        auto src = SyncExecScope::MakeSrc(queue_flags, barrier.srcStageMask);
-        auto dst = SyncExecScope::MakeDst(queue_flags, barrier.dstStageMask);
-        auto image = sync_state.Get<vvl::Image>(barrier.image);
-        if (image) {
-            auto subresource_range = image->NormalizeSubresourceRange(barrier.subresourceRange);
-
-            // VK_REMAINING_ARRAY_LAYERS for sliced 3d image in the context of layout transition means image's depth extent.
-            if (barrier.subresourceRange.layerCount == VK_REMAINING_ARRAY_LAYERS &&
-                CanTransitionDepthSlices(extensions, image->GetImageType(), image->create_flags)) {
-                subresource_range.layerCount = image->GetExtent().depth - subresource_range.baseArrayLayer;
-            }
-
-            const SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
-            const bool layout_transition = barrier.oldLayout != barrier.newLayout;
-            image_barriers.emplace_back(image, sync_barrier, subresource_range, layout_transition, index);
-        }
-    }
-}
-
 SyncOpPipelineBarrier::SyncOpPipelineBarrier(BarrierSet&& barrier_set) : barrier_set_(std::move(barrier_set)) {}
 
 void SyncOpPipelineBarrier::ReplayRecord(CommandExecutionContext& exec_context, const ResourceUsageTag exec_tag) const {
@@ -367,271 +47,24 @@ bool SyncOpPipelineBarrier::ReplayValidate(ReplayState& replay, ResourceUsageTag
     return replay.DetectFirstUseHazard(first_use_range);
 }
 
-SyncOpWaitEvents::SyncOpWaitEvents(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags,
-                                   uint32_t eventCount, const VkEvent* pEvents, VkPipelineStageFlags srcStageMask,
-                                   VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount,
-                                   const VkMemoryBarrier* pMemoryBarriers, uint32_t bufferMemoryBarrierCount,
-                                   const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
-                                   const VkImageMemoryBarrier* pImageMemoryBarriers)
-    : SyncOpBase(command), barrier_sets_(1) {
-    const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, srcStageMask);
-    const SyncExecScope dst_exec_scope = SyncExecScope::MakeDst(queue_flags, dstStageMask);
-    barrier_sets_[0] = BarrierSet(sync_state, src_exec_scope, dst_exec_scope, memoryBarrierCount, pMemoryBarriers,
-                                  bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
-    MakeEventsList(sync_state, eventCount, pEvents);
-}
-
-SyncOpWaitEvents::SyncOpWaitEvents(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags,
-                                   uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfo)
-    : SyncOpBase(command), barrier_sets_(eventCount) {
-    for (uint32_t i = 0; i < eventCount; i++) {
-        barrier_sets_[i] = BarrierSet(sync_state, queue_flags, pDependencyInfo[i]);
-    }
-    MakeEventsList(sync_state, eventCount, pEvents);
-}
-
-ResourceUsageTag SyncOpWaitEvents::Record(CommandBufferAccessContext& cb_context) {
-    const ResourceUsageTag tag = cb_context.NextCommandTag(command_);
-    ReplayRecord(cb_context, tag);
-    return tag;
-}
-
-// Need to restrict to only valid exec and access scope for this event
-static SyncBarrier RestrictToEvent(const SyncBarrier& barrier, const SyncEventState& sync_event) {
-    SyncBarrier result = barrier;
-    result.src_exec_scope.exec_scope = sync_event.scope.exec_scope & barrier.src_exec_scope.exec_scope;
-    result.src_access_scope = sync_event.scope.stage_mask_accesses & barrier.src_access_scope;
-    return result;
-}
-
-void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
-    // Unlike PipelineBarrier, WaitEvent is *not* limited to accesses within the current subpass (if any) and thus needs to import
-    // all accesses. Can instead import for all first_scopes, or a union of them, if this becomes a performance/memory issue,
-    // but with no idea of the performance of the union, nor of whether it even matters... take the simplest approach here,
-
-    AccessContext& access_context = exec_context.GetCurrentAccessContext();
-    SyncEventsContext& events_context = exec_context.GetEventsContext();
-    const QueueId queue_id = exec_context.GetQueueId();
-
-    access_context.ResolveAllSubpassDependencies();
-
-    assert(barrier_sets_.size() == 1 || (barrier_sets_.size() == events_.size()));
-
-    // Apply markup action.
-    // The markup action does not change any access state but it can trim the access map according to the
-    // provided range and creates infill ranges if necessary (for layout transitions). The purpose of all
-    // this is to ensure that after markup action the topology of access map ranges is finalized for the
-    // duration of barrier application (so we can cache pointers to specific access states with a goal
-    // to apply pending barriers in the end).
-    //
-    // NOTE: event's global barriers can split() access map because EventSimpleRangeGenerator filters kFullRange.
-    // That's why, in contrast to SyncOpPipelineBarrier, we need apply markup action also to global barriers.
-    // TODO: need a test that demonstrates this (when doing some work on syncval events)
-    size_t barrier_set_index = 0;
-    size_t barrier_set_incr = (barrier_sets_.size() == 1) ? 0 : 1;
-    for (auto& event_shared : events_) {
-        if (!event_shared) {
-            continue;
-        }
-        auto* sync_event = events_context.GetFromShared(event_shared);
-        if (!sync_event->first_scope) {
-            continue;  // [core validation check]
-        }
-
-        sync_event->last_command = command_;
-        sync_event->last_command_tag = exec_tag;
-
-        const auto& barrier_set = barrier_sets_[barrier_set_index];
-        for (const SyncBufferBarrier& barrier : barrier_set.buffer_barriers) {
-            if (SimpleBinding(*barrier.buffer)) {
-                const VkDeviceSize base_address = ResourceBaseAddress(*barrier.buffer);
-                const AccessRange range = barrier.range + base_address;
-                EventSimpleRangeGenerator filtered_range_gen(sync_event->FirstScope(), range);
-                ApplyMarkupFunctor markup_action(false);
-                access_context.UpdateMemoryAccessState(markup_action, filtered_range_gen);
-            }
-        }
-        for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
-            const auto& sub_state = SubState(*barrier.image);
-            const bool can_transition_depth_slices = CanTransitionDepthSlices(
-                exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
-            ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
-            EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
-            ApplyMarkupFunctor markup_action(barrier.layout_transition);
-            access_context.UpdateMemoryAccessState(markup_action, filtered_range_gen);
-        }
-        auto global_barriers_range_gen = EventSimpleRangeGenerator(sync_event->FirstScope(), kFullRange);
-        ApplyMarkupFunctor markup_action(false);
-        access_context.UpdateMemoryAccessState(markup_action, global_barriers_range_gen);
-        barrier_set_index += barrier_set_incr;
-    }
-
-    // Apply barriers independently and store the result in the pending object.
-    PendingBarriers pending_barriers;
-    barrier_set_index = 0;
-    barrier_set_incr = (barrier_sets_.size() == 1) ? 0 : 1;
-    for (auto& event_shared : events_) {
-        if (!event_shared.get()) {
-            continue;
-        }
-        auto* sync_event = events_context.GetFromShared(event_shared);
-        if (!sync_event->first_scope) {
-            continue;  // [core validation check]
-        }
-
-        const auto& barrier_set = barrier_sets_[barrier_set_index];
-        const auto& dst = barrier_set.dst_exec_scope;
-
-        // These apply barriers one at a time as the are restricted to the resource ranges specified per each barrier,
-        // but do not update the dependency chain information (but set the "pending" state) // s.t. the order independence
-        // of the barriers is maintained.
-
-        for (const SyncBufferBarrier& barrier : barrier_set.buffer_barriers) {
-            if (SimpleBinding(*barrier.buffer)) {
-                const SyncBarrier event_barrier = RestrictToEvent(barrier.barrier, *sync_event);
-                const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
-                CollectBarriersFunctor collect_barriers(access_context, barrier_scope, event_barrier, false, vvl::kNoIndex32,
-                                                        pending_barriers);
-
-                const VkDeviceSize base_address = ResourceBaseAddress(*barrier.buffer);
-                const AccessRange range = barrier.range + base_address;
-                EventSimpleRangeGenerator range_gen(sync_event->FirstScope(), range);
-
-                access_context.UpdateMemoryAccessState(collect_barriers, range_gen);
-            }
-        }
-        for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
-            const SyncBarrier event_barrier = RestrictToEvent(barrier.barrier, *sync_event);
-            const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
-            CollectBarriersFunctor collect_barriers(access_context, barrier_scope, event_barrier, barrier.layout_transition,
-                                                    barrier.handle_index, pending_barriers);
-
-            const auto& sub_state = SubState(*barrier.image);
-            const bool can_transition_depth_slices = CanTransitionDepthSlices(
-                exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
-            ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
-            EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
-
-            access_context.UpdateMemoryAccessState(collect_barriers, filtered_range_gen);
-        }
-        // TODO: because each iteration applies functor to the same range, investigate if it is
-        // beneficial for the functor to support multiple barriers, so we traverse access map once.
-        auto global_range_gen = EventSimpleRangeGenerator(sync_event->FirstScope(), kFullRange);
-        for (const auto& barrier : barrier_set.memory_barriers) {
-            const SyncBarrier event_barrier = RestrictToEvent(barrier, *sync_event);
-            const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
-            CollectBarriersFunctor collect_barriers(access_context, barrier_scope, event_barrier, false, vvl::kNoIndex32,
-                                                    pending_barriers);
-
-            auto range_gen = global_range_gen;  // intentional copy
-            access_context.UpdateMemoryAccessState(collect_barriers, range_gen);
-        }
-
-        // Apply the global barrier to the event itself (for race condition tracking)
-        // Events don't happen at a stage, so we need to store the unexpanded ALL_COMMANDS if set for inter-event-calls
-        sync_event->barriers = dst.stage_mask & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-        sync_event->barriers |= dst.exec_scope;
-
-        barrier_set_index += barrier_set_incr;
-    }
-
-    // Update access states with collected barriers
-    pending_barriers.Apply(exec_tag);
-}
-
-bool SyncOpWaitEvents::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    return replay.GetExecutionContext().GetSyncState().ValidateCmdWaitEvents(
-        replay.GetExecutionContext(), events_, barrier_sets_, replay.GetBaseTag() + recorded_tag, Location(command_));
-}
-
-void SyncOpWaitEvents::MakeEventsList(const SyncValidator& sync_state, uint32_t event_count, const VkEvent* events) {
-    events_.reserve(event_count);
-    for (uint32_t event_index = 0; event_index < event_count; event_index++) {
-        events_.emplace_back(sync_state.Get<vvl::Event>(events[event_index]));
-    }
-}
-
-SyncOpResetEvent::SyncOpResetEvent(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags, VkEvent event,
-                                   VkPipelineStageFlags2 stageMask)
-    : SyncOpBase(command), event_(sync_state.Get<vvl::Event>(event)), exec_scope_(SyncExecScope::MakeSrc(queue_flags, stageMask)) {}
-
-
-ResourceUsageTag SyncOpResetEvent::Record(CommandBufferAccessContext& cb_context) {
-    const ResourceUsageTag tag = cb_context.NextCommandTag(command_);
-    ReplayRecord(cb_context, tag);
-    return tag;
-}
-
-bool SyncOpResetEvent::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    return replay.GetExecutionContext().GetSyncState().ValidateCmdResetEvent(
-        replay.GetExecutionContext(), event_, exec_scope_, replay.GetBaseTag() + recorded_tag, Location(command_));
-}
-
-void SyncOpResetEvent::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
-    SyncEventsContext& events_context = exec_context.GetEventsContext();
-
-    auto* sync_event = events_context.GetFromShared(event_);
-    if (!sync_event) {
-        return;
-    }
-
-    // Update the event state
-    sync_event->last_command = command_;
-    sync_event->last_command_tag = exec_tag;
-    sync_event->unsynchronized_set = vvl::Func::Empty;
-    sync_event->ResetFirstScope();
-    sync_event->barriers = 0U;
-}
-
-SyncOpSetEvent::SyncOpSetEvent(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags, VkEvent event,
-                               VkPipelineStageFlags2 stageMask, const AccessContext* access_context)
-    : SyncOpBase(command),
-      event_(sync_state.Get<vvl::Event>(event)),
-      src_exec_scope_(SyncExecScope::MakeSrc(queue_flags, stageMask)) {
-    // Snapshot the current access_context for later inspection at wait time.
-    // NOTE: This appears brute force, but given that we only save a "first-last" model of access history, the current
-    //       access context (include barrier state for chaining) won't necessarily contain the needed information at Wait
-    //       or Submit time reference.
-    if (access_context) {
-        auto new_context = std::make_shared<AccessContext>(sync_state);
-        new_context->InitFrom(*access_context);
-        recorded_context_ = new_context;
-    }
-}
-
-SyncOpSetEvent::SyncOpSetEvent(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags, VkEvent event,
-                               const VkDependencyInfo& dep_info, const AccessContext* access_context)
-    : SyncOpBase(command),
-      event_(sync_state.Get<vvl::Event>(event)),
-      src_exec_scope_(SyncExecScope::MakeSrc(queue_flags, sync_utils::GetExecScopes(dep_info).src)) {
-    if (access_context) {
-        auto new_context = std::make_shared<AccessContext>(sync_state);
-        new_context->InitFrom(*access_context);
-        recorded_context_ = new_context;
-    }
-}
+SyncOpSetEvent::SyncOpSetEvent(std::shared_ptr<const vvl::Event>&& event, const SyncExecScope& src_exec_scope,
+                               std::shared_ptr<const AccessContext>&& src_access_context, const Location& loc)
+    : SyncOpBase(loc.function),
+      event_(std::move(event)),
+      recorded_context_(std::move(src_access_context)),
+      src_exec_scope_(src_exec_scope) {}
 
 bool SyncOpSetEvent::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    return replay.GetExecutionContext().GetSyncState().ValidateCmdSetEvent(replay.GetExecutionContext(), event_, src_exec_scope_,
-                                                                           replay.GetBaseTag() + recorded_tag, Location(command_));
-}
-
-ResourceUsageTag SyncOpSetEvent::Record(CommandBufferAccessContext& cb_context) {
-    const ResourceUsageTag tag = cb_context.NextCommandTag(command_);
-    SyncEventsContext& events_context = cb_context.GetEventsContext();
-    const QueueId queue_id = cb_context.GetQueueId();
-    assert(recorded_context_);
-    if (recorded_context_) {
-        DoRecord(queue_id, tag, recorded_context_, events_context);
-    }
-    return tag;
+    CommandExecutionContext& exec_context = replay.GetExecutionContext();
+    const SyncValidator& validator = exec_context.GetSyncState();
+    const ResourceUsageTag exec_tag = replay.GetBaseTag() + recorded_tag;
+    return validator.ValidateCmdSetEvent(exec_context, event_, src_exec_scope_, exec_tag, Location(command_));
 }
 
 void SyncOpSetEvent::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
     // Create a copy of the current context, and merge in the state snapshot at record set event time
     // Note: we mustn't change the recorded context copy, as a given CB could be submitted more than once (in generaL)
 
-    SyncEventsContext& events_context = exec_context.GetEventsContext();
     AccessContext& access_context = exec_context.GetCurrentAccessContext();
     const QueueId queue_id = exec_context.GetQueueId();
 
@@ -640,36 +73,39 @@ void SyncOpSetEvent::ReplayRecord(CommandExecutionContext& exec_context, Resourc
     merged_context->InitFrom(access_context);
     merged_context->ResolveFromContext(QueueTagOffsetBarrierAction(queue_id, exec_tag), *recorded_context_);
     merged_context->TrimAndClearFirstAccess();  // Ensure the copy is minimal and normalized
-    DoRecord(queue_id, exec_tag, merged_context, events_context);
+
+    const SyncValidator& validator = exec_context.GetSyncState();
+    validator.ApplySetEvent(exec_context, event_, src_exec_scope_, merged_context, exec_tag, command_);
 }
 
-void SyncOpSetEvent::DoRecord(QueueId queue_id, ResourceUsageTag tag, const std::shared_ptr<const AccessContext>& access_context,
-                              SyncEventsContext& events_context) const {
-    auto* sync_event = events_context.GetFromShared(event_);
-    if (!sync_event) {
-        return;
-    }
+SyncOpResetEvent::SyncOpResetEvent(std::shared_ptr<const vvl::Event>&& event, const SyncExecScope& exec_scope, const Location& loc)
+    : SyncOpBase(loc.function), event_(std::move(event)), exec_scope_(exec_scope) {}
 
-    // What happens with two SetEvent is that one cannot know what group of operations will be waited for.
-    // Given:
-    //     Stuff1; SetEvent; Stuff2; SetEvent; WaitEvents;
-    // WaitEvents cannot know which of Stuff1, Stuff2, or both has completed execution.
+bool SyncOpResetEvent::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
+    CommandExecutionContext& exec_context = replay.GetExecutionContext();
+    const SyncValidator& validator = exec_context.GetSyncState();
+    const ResourceUsageTag exec_tag = replay.GetBaseTag() + recorded_tag;
+    return validator.ValidateCmdResetEvent(exec_context, event_, exec_scope_, exec_tag, Location(command_));
+}
 
-    if (!sync_event->HasBarrier(src_exec_scope_.stage_mask, src_exec_scope_.exec_scope)) {
-        sync_event->unsynchronized_set = sync_event->last_command;
-        sync_event->ResetFirstScope();
-    } else if (!sync_event->first_scope) {
-        // We only set the scope if there isn't one
-        sync_event->scope = src_exec_scope_;
+void SyncOpResetEvent::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
+    const SyncValidator& validator = exec_context.GetSyncState();
+    validator.ApplyResetEvent(exec_context, event_, exec_tag, command_);
+}
 
-        // Save the shared_ptr to copy of the access_context present at set time (sent us by the caller)
-        sync_event->first_scope = access_context;
-        sync_event->unsynchronized_set = vvl::Func::Empty;
-        sync_event->first_scope_tag = tag;
-    }
-    sync_event->last_command = command_;
-    sync_event->last_command_tag = tag;
-    sync_event->barriers = 0U;
+SyncOpWaitEvents::SyncOpWaitEvents(std::vector<std::shared_ptr<const vvl::Event>>&& events, std::vector<BarrierSet>&& barrier_sets,
+                                   const Location& loc)
+    : SyncOpBase(loc.function), events_(std::move(events)), barrier_sets_(std::move(barrier_sets)) {}
+
+void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
+    ApplyWaitEvents(exec_context, events_, barrier_sets_, exec_tag, command_);
+}
+
+bool SyncOpWaitEvents::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
+    CommandExecutionContext& exec_context = replay.GetExecutionContext();
+    const SyncValidator& validator = exec_context.GetSyncState();
+    const ResourceUsageTag exec_tag = replay.GetBaseTag() + recorded_tag;
+    return validator.ValidateCmdWaitEvents(exec_context, events_, barrier_sets_, exec_tag, Location(command_));
 }
 
 SyncOpBeginRenderPass::SyncOpBeginRenderPass(vvl::Func command, const SyncValidator& sync_state,
@@ -921,9 +357,7 @@ void SyncEventsContext::AddReferencedTags(ResourceUsageTagSet& referenced) const
     }
 }
 
-SyncEventState::SyncEventState(const SyncEventState::EventPointer& event_state) : SyncEventState() {
-    event = event_state;
-}
+SyncEventState::SyncEventState(const SyncEventState::EventPointer& event_state) : SyncEventState() { event = event_state; }
 
 void SyncEventState::ResetFirstScope() {
     first_scope.reset();

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -56,29 +56,29 @@ struct SyncEventState {
           scope(),
           first_scope_tag() {}
 
-    SyncEventState(const SyncEventState &) = default;
-    SyncEventState(SyncEventState &&) = default;
+    SyncEventState(const SyncEventState&) = default;
+    SyncEventState(SyncEventState&&) = default;
 
-    SyncEventState(const SyncEventState::EventPointer &event_state);
+    SyncEventState(const SyncEventState::EventPointer& event_state);
 
     void ResetFirstScope();
-    const AccessContext::ScopeMap &FirstScope() const { return first_scope->GetAccessMap(); }
+    const AccessContext::ScopeMap& FirstScope() const { return first_scope->GetAccessMap(); }
     bool HasBarrier(VkPipelineStageFlags2 stageMask, VkPipelineStageFlags2 exec_scope) const;
-    void AddReferencedTags(ResourceUsageTagSet &referenced) const;
+    void AddReferencedTags(ResourceUsageTagSet& referenced) const;
 };
 
 class SyncEventsContext {
   public:
-    using Map = vvl::unordered_map<const vvl::Event *, std::shared_ptr<SyncEventState>>;
+    using Map = vvl::unordered_map<const vvl::Event*, std::shared_ptr<SyncEventState>>;
     using iterator = Map::iterator;
     using const_iterator = Map::const_iterator;
 
-    SyncEventState *GetFromShared(const SyncEventState::EventPointer &event_state) {
+    SyncEventState* GetFromShared(const SyncEventState::EventPointer& event_state) {
         const auto find_it = map_.find(event_state.get());
         if (find_it == map_.end()) {
             if (!event_state.get()) return nullptr;
 
-            const auto *event_plain_ptr = event_state.get();
+            const auto* event_plain_ptr = event_state.get();
             auto sync_state = std::make_shared<SyncEventState>(event_state);
             auto insert_pair = map_.emplace(event_plain_ptr, sync_state);
             return insert_pair.first->second.get();
@@ -94,10 +94,10 @@ class SyncEventsContext {
         return find_it->second.get();
     }
 
-    void ApplyBarrier(const SyncExecScope &src, const SyncExecScope &dst, ResourceUsageTag tag);
+    void ApplyBarrier(const SyncExecScope& src, const SyncExecScope& dst, ResourceUsageTag tag);
     void ApplyTaggedWait(VkQueueFlags queue_flags, ResourceUsageTag tag);
 
-    void Destroy(const vvl::Event *event_state) {
+    void Destroy(const vvl::Event* event_state) {
         auto sync_it = map_.find(event_state);
         if (sync_it != map_.end()) {
             map_.erase(sync_it);
@@ -105,74 +105,11 @@ class SyncEventsContext {
     }
     void Clear() { map_.clear(); }
 
-    SyncEventsContext &DeepCopy(const SyncEventsContext &from);
-    void AddReferencedTags(ResourceUsageTagSet &referenced) const;
+    SyncEventsContext& DeepCopy(const SyncEventsContext& from);
+    void AddReferencedTags(ResourceUsageTagSet& referenced) const;
 
   private:
     Map map_;
-};
-
-struct SyncBufferBarrier {
-    std::shared_ptr<const vvl::Buffer> buffer;
-    SyncBarrier barrier;
-    AccessRange range;
-
-    SyncBufferBarrier(const std::shared_ptr<const vvl::Buffer> &buffer, const SyncBarrier &barrier, const AccessRange &range)
-        : buffer(buffer), barrier(barrier), range(range) {}
-};
-
-struct SyncImageBarrier {
-    std::shared_ptr<const vvl::Image> image;
-    SyncBarrier barrier;
-    VkImageSubresourceRange subresource_range;
-    bool layout_transition;
-    uint32_t barrier_index;
-    uint32_t handle_index = vvl::kNoIndex32;
-
-    SyncImageBarrier(const std::shared_ptr<const vvl::Image> &image, const SyncBarrier &barrier,
-                           const VkImageSubresourceRange &subresource_range, bool layout_transition, uint32_t barrier_index)
-        : image(image),
-          barrier(barrier),
-          subresource_range(subresource_range),
-          layout_transition(layout_transition),
-          barrier_index(barrier_index) {}
-};
-
-struct BarrierSet {
-    SyncExecScope src_exec_scope;
-    SyncExecScope dst_exec_scope;
-    std::vector<SyncBarrier> memory_barriers;
-    std::vector<SyncBufferBarrier> buffer_barriers;
-    std::vector<SyncImageBarrier> image_barriers;
-
-    bool single_exec_scope = false;
-
-    // The numbers of additional global barriers introduced to track execution dependencies
-    // defined by image and buffer barriers, or a single execution dependencies when a sync1
-    // barrier command specifies no barriers (only exec scopes). Used for statistics tracking.
-    uint32_t execution_dependency_barrier_count = 0;
-
-    BarrierSet() = default;
-    BarrierSet(const SyncValidator& sync_state, VkQueueFlags queue_flags, const VkDependencyInfo& dep_info);
-    BarrierSet(const SyncValidator& sync_state, const SyncExecScope& src_exec_scope, const SyncExecScope& dst_exec_scope,
-               uint32_t memory_barrier_count, const VkMemoryBarrier* memory_barriers, uint32_t buffer_barrier_count,
-               const VkBufferMemoryBarrier* buffer_barriers, uint32_t image_barrier_count,
-               const VkImageMemoryBarrier* image_barriers);
-
-  private:
-    void MakeMemoryBarriers(const SyncExecScope& src, const SyncExecScope& dst, uint32_t barrier_count,
-                            const VkMemoryBarrier* barriers);
-    void MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependencyInfo& dep_info);
-
-    void MakeBufferMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
-                                  uint32_t barrier_count, const VkBufferMemoryBarrier* barriers);
-    void MakeBufferMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
-                                  const VkBufferMemoryBarrier2* barriers);
-
-    void MakeImageMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
-                                 uint32_t barrier_count, const VkImageMemoryBarrier* barriers, const DeviceExtensions& extensions);
-    void MakeImageMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
-                                 const VkImageMemoryBarrier2* barriers, const DeviceExtensions& extensions);
 };
 
 class SyncOpBase {
@@ -197,38 +134,23 @@ class SyncOpPipelineBarrier : public SyncOpBase {
     BarrierSet barrier_set_;
 };
 
-class SyncOpWaitEvents : public SyncOpBase {
+class SyncOpSetEvent : public SyncOpBase {
   public:
-    SyncOpWaitEvents(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags, uint32_t eventCount,
-                     const VkEvent *pEvents, VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-                     uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers, uint32_t bufferMemoryBarrierCount,
-                     const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
-                     const VkImageMemoryBarrier *pImageMemoryBarriers);
-
-    SyncOpWaitEvents(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags, uint32_t eventCount,
-                     const VkEvent *pEvents, const VkDependencyInfo *pDependencyInfo);
-
-    ResourceUsageTag Record(CommandBufferAccessContext& cb_context);
-    bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const override;
+    SyncOpSetEvent(std::shared_ptr<const vvl::Event>&& event, const SyncExecScope& src_exec_scope,
+                   std::shared_ptr<const AccessContext>&& src_access_context, const Location& loc);
+    bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
+    void ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const override;
 
   private:
-    void DoRecord(CommandExecutionContext &ex_context, const ResourceUsageTag base_tag) const;
-    void MakeEventsList(const SyncValidator &sync_state, uint32_t event_count, const VkEvent *events);
-
-    // TODO PHASE2 This is the wrong thing to use for "replay".. as the event state will have moved on since the record
-    // TODO PHASE2 May need to capture by value w.r.t. "first use" or build up in calling/enqueue context through replay.
-    std::vector<std::shared_ptr<const vvl::Event>> events_;
-
-    std::vector<BarrierSet> barrier_sets_;
+    std::shared_ptr<const vvl::Event> event_;
+    // Snapshot of the command buffer's access context at set event time
+    std::shared_ptr<const AccessContext> recorded_context_;
+    SyncExecScope src_exec_scope_;
 };
 
 class SyncOpResetEvent : public SyncOpBase {
   public:
-    SyncOpResetEvent(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags, VkEvent event,
-                     VkPipelineStageFlags2 stageMask);
-
-    ResourceUsageTag Record(CommandBufferAccessContext& cb_context);
+    SyncOpResetEvent(std::shared_ptr<const vvl::Event>&& event, const SyncExecScope& exec_scope, const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
     void ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const override;
 
@@ -237,24 +159,19 @@ class SyncOpResetEvent : public SyncOpBase {
     SyncExecScope exec_scope_;
 };
 
-class SyncOpSetEvent : public SyncOpBase {
+class SyncOpWaitEvents : public SyncOpBase {
   public:
-    SyncOpSetEvent(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags, VkEvent event,
-                   VkPipelineStageFlags2 stageMask, const AccessContext *access_context);
-    SyncOpSetEvent(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags, VkEvent event,
-                   const VkDependencyInfo &dep_info, const AccessContext *access_context);
-
-    ResourceUsageTag Record(CommandBufferAccessContext& cb_context);
-    bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const override;
+    SyncOpWaitEvents(std::vector<std::shared_ptr<const vvl::Event>>&& events, std::vector<BarrierSet>&& barrier_sets,
+                     const Location& loc);
+    bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
+    void ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const override;
 
   private:
-    void DoRecord(QueueId queue_id, ResourceUsageTag recorded_tag, const std::shared_ptr<const AccessContext>& access_context,
-                  SyncEventsContext& events_context) const;
-    std::shared_ptr<const vvl::Event> event_;
-    // The Access context of the command buffer at record set event time.
-    std::shared_ptr<const AccessContext> recorded_context_;
-    SyncExecScope src_exec_scope_;
+    // TODO PHASE2 This is the wrong thing to use for "replay".. as the event state will have moved on since the record
+    // TODO PHASE2 May need to capture by value w.r.t. "first use" or build up in calling/enqueue context through replay.
+    std::vector<std::shared_ptr<const vvl::Event>> events_;
+
+    std::vector<BarrierSet> barrier_sets_;
 };
 
 class SyncOpBeginRenderPass : public SyncOpBase {
@@ -272,26 +189,26 @@ class SyncOpBeginRenderPass : public SyncOpBase {
     vku::safe_VkSubpassBeginInfo subpass_begin_info_;
     std::vector<std::shared_ptr<const vvl::ImageView>> attachments_;
     std::shared_ptr<const vvl::RenderPass> rp_state_;
-    const RenderPassAccessContext *rp_context_;
+    const RenderPassAccessContext* rp_context_;
 };
 
 class SyncOpNextSubpass : public SyncOpBase {
   public:
-    SyncOpNextSubpass(vvl::Func command, const SyncValidator &sync_state, const VkSubpassBeginInfo *pSubpassBeginInfo,
-                      const VkSubpassEndInfo *pSubpassEndInfo);
+    SyncOpNextSubpass(vvl::Func command, const SyncValidator& sync_state, const VkSubpassBeginInfo* pSubpassBeginInfo,
+                      const VkSubpassEndInfo* pSubpassEndInfo);
 
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context);
-    bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const override;
+    bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
+    void ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const override;
 };
 
 class SyncOpEndRenderPass : public SyncOpBase {
   public:
-    SyncOpEndRenderPass(vvl::Func command, const SyncValidator &sync_state, const VkSubpassEndInfo *pSubpassEndInfo);
+    SyncOpEndRenderPass(vvl::Func command, const SyncValidator& sync_state, const VkSubpassEndInfo* pSubpassEndInfo);
 
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context);
-    bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const override;
+    bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
+    void ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const override;
 };
 
 // Allow keep track of the exec contexts replay state
@@ -300,38 +217,38 @@ class ReplayState {
     // A minimal subset of the functionality present in the RenderPassAccessContext. Since the accesses are recorded in the
     // first_use information of the recorded access contexts, s.t. all we need to support is the barrier/resolve operations
     struct RenderPassReplayState {
-        AccessContext *Begin(VkQueueFlags queue_flags, const SyncOpBeginRenderPass &begin_op_,
-                             const AccessContext &external_context);
-        AccessContext *Next();
-        void End(AccessContext &external_context);
+        AccessContext* Begin(VkQueueFlags queue_flags, const SyncOpBeginRenderPass& begin_op_,
+                             const AccessContext& external_context);
+        AccessContext* Next();
+        void End(AccessContext& external_context);
         vvl::span<AccessContext> GetSubpassContexts();
 
-        const SyncOpBeginRenderPass *begin_op = nullptr;
-        const AccessContext *replay_context = nullptr;
+        const SyncOpBeginRenderPass* begin_op = nullptr;
+        const AccessContext* replay_context = nullptr;
         uint32_t subpass = VK_SUBPASS_EXTERNAL;
         std::unique_ptr<AccessContext[]> subpass_contexts;
     };
 
     bool ValidateFirstUse();
-    bool DetectFirstUseHazard(const ResourceUsageRange &first_use_range) const;
+    bool DetectFirstUseHazard(const ResourceUsageRange& first_use_range) const;
 
-    ReplayState(CommandExecutionContext &exec_context, const CommandBufferAccessContext &recorded_context,
-                const ErrorObject &error_object, uint32_t index, ResourceUsageTag base_tag);
+    ReplayState(CommandExecutionContext& exec_context, const CommandBufferAccessContext& recorded_context,
+                const ErrorObject& error_object, uint32_t index, ResourceUsageTag base_tag);
 
-    CommandExecutionContext &GetExecutionContext() const { return exec_context_; }
+    CommandExecutionContext& GetExecutionContext() const { return exec_context_; }
     ResourceUsageTag GetBaseTag() const { return base_tag_; }
 
-    AccessContext *ReplayStateRenderPassBegin(VkQueueFlags queue_flags, const SyncOpBeginRenderPass &begin_op,
-                                              const AccessContext &external_context);
-    AccessContext *ReplayStateRenderPassNext();
-    void ReplayStateRenderPassEnd(AccessContext &external_context);
+    AccessContext* ReplayStateRenderPassBegin(VkQueueFlags queue_flags, const SyncOpBeginRenderPass& begin_op,
+                                              const AccessContext& external_context);
+    AccessContext* ReplayStateRenderPassNext();
+    void ReplayStateRenderPassEnd(AccessContext& external_context);
 
   protected:
-    const AccessContext *GetRecordedAccessContext() const;
+    const AccessContext* GetRecordedAccessContext() const;
 
-    CommandExecutionContext &exec_context_;
-    const CommandBufferAccessContext &recorded_context_;
-    const ErrorObject &error_obj_;
+    CommandExecutionContext& exec_context_;
+    const CommandBufferAccessContext& recorded_context_;
+    const ErrorObject& error_obj_;
     const uint32_t index_;
     const ResourceUsageTag base_tag_;
     RenderPassReplayState rp_replay_;

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -22,6 +22,7 @@
 
 #include "sync/sync_error_messages.h"
 #include "sync/sync_validation.h"
+#include "sync/sync_event.h"
 #include "sync/sync_image.h"
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/ray_tracing_state.h"
@@ -2284,16 +2285,64 @@ bool SyncValidator::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, Vk
     return ValidateCmdSetEvent(cb_context, event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex, error_obj.location);
 }
 
+void SyncValidator::ApplySetEvent(CommandExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+                                  const SyncExecScope& src_exec_scope,
+                                  const std::shared_ptr<const AccessContext>& src_access_context, ResourceUsageTag tag,
+                                  vvl::Func command) const {
+    SyncEventsContext& events_context = exec_context.GetEventsContext();
+    SyncEventState* sync_event = events_context.GetFromShared(event);
+    if (!sync_event) {
+        return;
+    }
+
+    // What happens with two SetEvent is that one cannot know what group of operations will be waited for.
+    // Given:
+    //     Stuff1; SetEvent; Stuff2; SetEvent; WaitEvents;
+    // WaitEvents cannot know which of Stuff1, Stuff2, or both has completed execution.
+
+    if (!sync_event->HasBarrier(src_exec_scope.stage_mask, src_exec_scope.exec_scope)) {
+        sync_event->unsynchronized_set = sync_event->last_command;
+        sync_event->ResetFirstScope();
+    } else if (!sync_event->first_scope) {
+        // We only set the scope if there isn't one
+        sync_event->scope = src_exec_scope;
+
+        // Save the shared_ptr to copy of the access_context present at set time (sent us by the caller)
+        sync_event->first_scope = src_access_context;
+        sync_event->unsynchronized_set = vvl::Func::Empty;
+        sync_event->first_scope_tag = tag;
+    }
+    sync_event->last_command = command;
+    sync_event->last_command_tag = tag;
+    sync_event->barriers = 0;
+}
+
+void SyncValidator::RecordCmdSetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
+                                      const SyncExecScope& src_exec_scope, const Location& loc) const {
+    const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
+
+    // Snapshot the current access_context for later inspection at wait time.
+    // NOTE: This appears brute force, but given that we only save a "first-last" model
+    // of access history, the current access context (include barrier state for chaining)
+    // won't necessarily contain the needed information at Wait or Submit time reference.
+    auto src_access_context = std::make_shared<AccessContext>(*this);
+    src_access_context->InitFrom(cb_context.GetCurrentAccessContext());
+
+    ApplySetEvent(cb_context, event, src_exec_scope, src_access_context, tag, loc.function);
+
+    auto sync_op = std::make_shared<SyncOpSetEvent>(std::move(event), src_exec_scope, std::move(src_access_context), loc);
+    cb_context.AddSyncOp(tag, std::move(sync_op));
+}
+
 void SyncValidator::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                               const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
 
-    auto sync_op = std::make_shared<SyncOpSetEvent>(record_obj.location.function, *this, queue_flags, event, stageMask,
-                                                    &cb_context.GetCurrentAccessContext());
-    const ResourceUsageTag tag = sync_op->Record(cb_context);
-    cb_context.AddSyncOp(tag, std::move(sync_op));
+    auto event_state = Get<vvl::Event>(event);
+    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+    const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, stageMask);
+    RecordCmdSetEvent(cb_context, std::move(event_state), src_exec_scope, record_obj.location);
 }
 
 bool SyncValidator::PreCallValidateCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
@@ -2309,9 +2358,10 @@ bool SyncValidator::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, V
     }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+
     auto event_state = Get<vvl::Event>(event);
-    const SyncExecScope src_exec_scope =
-        SyncExecScope::MakeSrc(cb_context.GetQueueFlags(), sync_utils::GetExecScopes(*pDependencyInfo).src);
+    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+    const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, sync_utils::GetExecScopes(*pDependencyInfo).src);
     return ValidateCmdSetEvent(cb_context, event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex, error_obj.location);
 }
 
@@ -2327,12 +2377,11 @@ void SyncValidator::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, Vk
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
 
-    auto sync_op = std::make_shared<SyncOpSetEvent>(record_obj.location.function, *this, queue_flags, event, *pDependencyInfo,
-                                                    &cb_context.GetCurrentAccessContext());
-    const ResourceUsageTag tag = sync_op->Record(cb_context);
-    cb_context.AddSyncOp(tag, std::move(sync_op));
+    auto event_state = Get<vvl::Event>(event);
+    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+    const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, sync_utils::GetExecScopes(*pDependencyInfo).src);
+    RecordCmdSetEvent(cb_context, std::move(event_state), src_exec_scope, record_obj.location);
 }
 
 bool SyncValidator::ValidateCmdResetEvent(const CommandExecutionContext& exec_context,
@@ -2365,15 +2414,37 @@ bool SyncValidator::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, 
     return ValidateCmdResetEvent(cb_context, event_state, exec_scope, ResourceUsageRecord::kMaxIndex, error_obj.location);
 }
 
+void SyncValidator::ApplyResetEvent(CommandExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+                                    ResourceUsageTag tag, vvl::Func command) const {
+    SyncEventsContext& events_context = exec_context.GetEventsContext();
+    SyncEventState* sync_event = events_context.GetFromShared(event);
+    if (!sync_event) {
+        return;
+    }
+    sync_event->last_command = command;
+    sync_event->last_command_tag = tag;
+    sync_event->unsynchronized_set = vvl::Func::Empty;
+    sync_event->ResetFirstScope();
+    sync_event->barriers = 0;
+}
+
+void SyncValidator::RecordCmdResetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
+                                        const SyncExecScope& exec_scope, const Location& loc) const {
+    const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
+    ApplyResetEvent(cb_context, event, tag, loc.function);
+    auto sync_op = std::make_shared<SyncOpResetEvent>(std::move(event), exec_scope, loc);
+    cb_context.AddSyncOp(tag, std::move(sync_op));
+}
+
 void SyncValidator::PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                                 const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
 
-    auto sync_op = std::make_shared<SyncOpResetEvent>(record_obj.location.function, *this, queue_flags, event, stageMask);
-    const ResourceUsageTag tag = sync_op->Record(cb_context);
-    cb_context.AddSyncOp(tag, std::move(sync_op));
+    auto event_state = Get<vvl::Event>(event);
+    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+    const SyncExecScope exec_scope = SyncExecScope::MakeSrc(queue_flags, stageMask);
+    RecordCmdResetEvent(cb_context, std::move(event_state), exec_scope, record_obj.location);
 }
 
 bool SyncValidator::PreCallValidateCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
@@ -2399,11 +2470,11 @@ void SyncValidator::PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, 
                                                  const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
 
-    auto sync_op = std::make_shared<SyncOpResetEvent>(record_obj.location.function, *this, queue_flags, event, stageMask);
-    const ResourceUsageTag tag = sync_op->Record(cb_context);
-    cb_context.AddSyncOp(tag, std::move(sync_op));
+    auto event_state = Get<vvl::Event>(event);
+    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+    const SyncExecScope exec_scope = SyncExecScope::MakeSrc(queue_flags, stageMask);
+    RecordCmdResetEvent(cb_context, std::move(event_state), exec_scope, record_obj.location);
 }
 
 bool SyncValidator::ValidateCmdWaitEvents(const CommandExecutionContext& exec_context,
@@ -2509,8 +2580,8 @@ bool SyncValidator::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, 
                                                  const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
 
+    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
     const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, srcStageMask);
     const SyncExecScope dst_exec_scope = SyncExecScope::MakeDst(queue_flags, dstStageMask);
     const BarrierSet barrier_set =
@@ -2526,6 +2597,15 @@ bool SyncValidator::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, 
                                  error_obj.location);
 }
 
+void SyncValidator::RecordCmdWaitEvents(CommandBufferAccessContext& cb_context,
+                                        std::vector<std::shared_ptr<const vvl::Event>>&& events,
+                                        std::vector<BarrierSet>&& barrier_sets, const Location& loc) const {
+    const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
+    ApplyWaitEvents(cb_context, events, barrier_sets, tag, loc.function);
+    auto sync_op = std::make_shared<SyncOpWaitEvents>(std::move(events), std::move(barrier_sets), loc);
+    cb_context.AddSyncOp(tag, std::move(sync_op));
+}
+
 void SyncValidator::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                                 VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
                                                 uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
@@ -2535,13 +2615,20 @@ void SyncValidator::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, u
                                                 const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
 
-    auto sync_op = std::make_shared<SyncOpWaitEvents>(
-        record_obj.location.function, *this, queue_flags, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount,
-        pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
-    const ResourceUsageTag tag = sync_op->Record(cb_context);
-    cb_context.AddSyncOp(tag, std::move(sync_op));
+    std::vector<std::shared_ptr<const vvl::Event>> events(eventCount);
+    for (uint32_t i = 0; i < eventCount; i++) {
+        events[i] = Get<vvl::Event>(pEvents[i]);
+    }
+
+    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+    const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, srcStageMask);
+    const SyncExecScope dst_exec_scope = SyncExecScope::MakeDst(queue_flags, dstStageMask);
+    std::vector<BarrierSet> barrier_sets;
+    barrier_sets.emplace_back(*this, src_exec_scope, dst_exec_scope, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount,
+                              pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
+
+    RecordCmdWaitEvents(cb_context, std::move(events), std::move(barrier_sets), record_obj.location);
 }
 
 bool SyncValidator::PreCallValidateCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
@@ -2563,18 +2650,16 @@ bool SyncValidator::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer,
     }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
-
-    std::vector<BarrierSet> barrier_sets(eventCount);
-    for (uint32_t i = 0; i < eventCount; i++) {
-        barrier_sets[i] = BarrierSet(*this, queue_flags, pDependencyInfos[i]);
-    }
 
     std::vector<std::shared_ptr<const vvl::Event>> events(eventCount);
     for (uint32_t i = 0; i < eventCount; i++) {
         events[i] = Get<vvl::Event>(pEvents[i]);
     }
-
+    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+    std::vector<BarrierSet> barrier_sets(eventCount);
+    for (uint32_t i = 0; i < eventCount; i++) {
+        barrier_sets[i] = BarrierSet(*this, queue_flags, pDependencyInfos[i]);
+    }
     return ValidateCmdWaitEvents(cb_context, events, barrier_sets, ResourceUsageRecord::kMaxIndex, error_obj.location);
 }
 
@@ -2585,12 +2670,17 @@ void SyncValidator::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, 
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
 
-    auto sync_op =
-        std::make_shared<SyncOpWaitEvents>(record_obj.location.function, *this, queue_flags, eventCount, pEvents, pDependencyInfos);
-    const ResourceUsageTag tag = sync_op->Record(cb_context);
-    cb_context.AddSyncOp(tag, std::move(sync_op));
+    std::vector<std::shared_ptr<const vvl::Event>> events(eventCount);
+    for (uint32_t i = 0; i < eventCount; i++) {
+        events[i] = Get<vvl::Event>(pEvents[i]);
+    }
+    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+    std::vector<BarrierSet> barrier_sets(eventCount);
+    for (uint32_t i = 0; i < eventCount; i++) {
+        barrier_sets[i] = BarrierSet(*this, queue_flags, pDependencyInfos[i]);
+    }
+    RecordCmdWaitEvents(cb_context, std::move(events), std::move(barrier_sets), record_obj.location);
 }
 
 bool SyncValidator::PreCallValidateCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2KHR pipelineStage,

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -427,6 +427,12 @@ class SyncValidator : public vvl::DeviceProxy {
                              const SyncExecScope& src_exec_scope, ResourceUsageTag base_tag, const Location& loc) const;
     bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                     const ErrorObject &error_obj) const override;
+
+    void ApplySetEvent(CommandExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+                       const SyncExecScope& src_exec_scope, const std::shared_ptr<const AccessContext>& src_access_context,
+                       ResourceUsageTag tag, vvl::Func command) const;
+    void RecordCmdSetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
+                           const SyncExecScope& src_exec_scope, const Location& loc) const;
     void PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                    const RecordObject &record_obj) override;
     bool PreCallValidateCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfoKHR *pDependencyInfo,
@@ -442,6 +448,11 @@ class SyncValidator : public vvl::DeviceProxy {
                                const SyncExecScope& exec_scope, ResourceUsageTag base_tag, const Location& loc) const;
     bool PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                       const ErrorObject &error_obj) const override;
+
+    void ApplyResetEvent(CommandExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+                         ResourceUsageTag tag, vvl::Func command) const;
+    void RecordCmdResetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
+                             const SyncExecScope& exec_scope, const Location& loc) const;
     void PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                      const RecordObject &record_obj) override;
     bool PreCallValidateCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2KHR stageMask,
@@ -463,6 +474,9 @@ class SyncValidator : public vvl::DeviceProxy {
                                       uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                       uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers,
                                       const ErrorObject &error_obj) const override;
+
+    void RecordCmdWaitEvents(CommandBufferAccessContext& cb_context, std::vector<std::shared_ptr<const vvl::Event>>&& events,
+                             std::vector<BarrierSet>&& barrier_sets, const Location& loc) const;
     void PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
                                      VkPipelineStageFlags sourceStageMask, VkPipelineStageFlags dstStageMask,
                                      uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,


### PR DESCRIPTION
Follow-up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12724 refactor.
Remove SyncOp::Record for events.
Also moved barrier/event free functions and helpers into dedicated files.
