### PR TITLE
gpuav: Disable buffer validation with desc heap

### DIFF
--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -72,6 +72,14 @@ void CopyBufferToImage(Validator& gpuav, const Location& loc, CommandBufferSubSt
         return;
     }
 
+    // TODO https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+    for (LastBound& last_bound : cb_state.base.lastBound) {
+        if (last_bound.GetDescriptorMode() == vvl::DescriptorModeBuffer ||
+            last_bound.GetDescriptorMode() == vvl::DescriptorModeHeap) {
+            return;
+        }
+    }
+
     // No need to perform validation if VK_EXT_depth_range_unrestricted is enabled
     if (IsExtEnabled(gpuav.extensions.vk_ext_depth_range_unrestricted)) {
         return;

--- a/layers/gpuav/validation_cmd/gpuav_copy_memory_indirect.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_memory_indirect.cpp
@@ -27,6 +27,7 @@
 #include "gpuav/shaders/gpuav_error_header.h"
 #include "gpuav/shaders/validation_cmd/push_data.h"
 #include "generated/gpuav_offline_spirv.h"
+#include "state_tracker/last_bound_state.h"
 
 namespace gpuav {
 namespace valcmd {
@@ -68,6 +69,14 @@ void CopyMemoryIndirect(Validator& gpuav, const Location& loc, CommandBufferSubS
                         const CopyMemoryIndirectCommon& api_copy_info) {
     if (!gpuav.gpuav_settings.validate_copy_memory_indirect) {
         return;
+    }
+
+    // TODO https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+    for (LastBound& last_bound : cb_state.base.lastBound) {
+        if (last_bound.GetDescriptorMode() == vvl::DescriptorModeBuffer ||
+            last_bound.GetDescriptorMode() == vvl::DescriptorModeHeap) {
+            return;
+        }
     }
 
     if (api_copy_info.count == 0) {

--- a/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
@@ -59,6 +59,11 @@ void DispatchIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSta
         return;
     }
 
+    // TODO https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+    if (last_bound.GetDescriptorMode() == vvl::DescriptorModeBuffer || last_bound.GetDescriptorMode() == vvl::DescriptorModeHeap) {
+        return;
+    }
+
     ValidationCommandsGpuavState& val_cmd_gpuav_state =
         gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
     valpipe::ComputePipeline<DispatchValidationShader>& validation_pipeline =

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -120,6 +120,10 @@ void FirstInstance(Validator& gpuav, CommandBufferSubState& cb_state, const Loca
     if (!gpuav.gpuav_settings.validate_indirect_draws_buffers) {
         return;
     }
+    // TODO https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+    if (last_bound.GetDescriptorMode() == vvl::DescriptorModeBuffer || last_bound.GetDescriptorMode() == vvl::DescriptorModeHeap) {
+        return;
+    }
 
     const char* vuid = vuid_selector(gpuav, last_bound);
     if (!vuid) {
@@ -360,6 +364,10 @@ void CountBuffer(Validator& gpuav, CommandBufferSubState& cb_state, const Locati
     if (!gpuav.gpuav_settings.validate_indirect_draws_buffers) {
         return;
     }
+    // TODO https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+    if (last_bound.GetDescriptorMode() == vvl::DescriptorModeBuffer || last_bound.GetDescriptorMode() == vvl::DescriptorModeHeap) {
+        return;
+    }
 
     auto draw_buffer_state = gpuav.Get<vvl::Buffer>(api_buffer);
     if (!draw_buffer_state) {
@@ -512,6 +520,10 @@ void DrawMeshIndirect(Validator& gpuav, CommandBufferSubState& cb_state, const L
                       VkBuffer api_buffer, VkDeviceSize api_offset, uint32_t api_stride, VkBuffer api_count_buffer,
                       VkDeviceSize api_count_buffer_offset, uint32_t api_draw_count) {
     if (!gpuav.gpuav_settings.validate_indirect_draws_buffers) {
+        return;
+    }
+    // TODO https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+    if (last_bound.GetDescriptorMode() == vvl::DescriptorModeBuffer || last_bound.GetDescriptorMode() == vvl::DescriptorModeHeap) {
         return;
     }
 
@@ -800,6 +812,10 @@ void DrawIndexedIndirectIndexBuffer(Validator& gpuav, CommandBufferSubState& cb_
         if (robustness_ci && robustness_ci->vertexInputs) {
             return;
         }
+    }
+    // TODO https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+    if (last_bound.GetDescriptorMode() == vvl::DescriptorModeBuffer || last_bound.GetDescriptorMode() == vvl::DescriptorModeHeap) {
+        return;
     }
 
     if (!cb_state.base.IsPrimary()) {

--- a/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
@@ -54,6 +54,10 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
     if (!gpuav.gpuav_settings.validate_indirect_trace_rays_buffers) {
         return;
     }
+    // TODO https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+    if (last_bound.GetDescriptorMode() == vvl::DescriptorModeBuffer || last_bound.GetDescriptorMode() == vvl::DescriptorModeHeap) {
+        return;
+    }
 
     valpipe::RestorablePipelineState restorable_state(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE);
 
@@ -365,6 +369,10 @@ void TLAS(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state
           const VkAccelerationStructureBuildRangeInfoKHR* const* build_ranges_infos) {
     VVL_ZoneScoped;
     if (!gpuav.gpuav_settings.validate_acceleration_structures_builds) {
+        return;
+    }
+    // TODO https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+    if (last_bound.GetDescriptorMode() == vvl::DescriptorModeBuffer || last_bound.GetDescriptorMode() == vvl::DescriptorModeHeap) {
         return;
     }
 
@@ -743,6 +751,10 @@ void BLAS(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state
           const VkAccelerationStructureBuildRangeInfoKHR* const* pp_build_ranges_infos) {
     VVL_ZoneScoped;
     if (!gpuav.gpuav_settings.validate_acceleration_structures_builds) {
+        return;
+    }
+    // TODO https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+    if (last_bound.GetDescriptorMode() == vvl::DescriptorModeBuffer || last_bound.GetDescriptorMode() == vvl::DescriptorModeHeap) {
         return;
     }
 

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -2122,9 +2122,11 @@ void Pipeline::AddSpirvRayGenShader(const char* spirv, const char* entry_point) 
                                                                 SPV_SOURCE_ASM, nullptr, entry_point));
 }
 
-void Pipeline::AddSlangRayGenShader(const char* slang, const char* entry_point) {
-    ray_gen_shaders_.emplace_back(std::make_unique<VkShaderObj>(*device_, slang, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2,
-                                                                SPV_SOURCE_SLANG, nullptr, entry_point));
+void Pipeline::AddSlangRayGenShader(const char* slang, const char* entry_point, const void* shader_module_create_info_pnext,
+                                    const void* pipeline_shader_stage_create_info_pNext) {
+    ray_gen_shaders_.emplace_back(std::make_unique<VkShaderObj>(
+        *device_, slang, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2, SPV_SOURCE_SLANG, nullptr, entry_point,
+        shader_module_create_info_pnext, pipeline_shader_stage_create_info_pNext));
 }
 
 void Pipeline::AddGlslMissShader(const char* glsl, const void* shader_module_create_info_pnext,
@@ -2139,9 +2141,11 @@ void Pipeline::AddSpirvMissShader(const char* spirv, const char* entry_point) {
                                                              SPV_SOURCE_ASM, nullptr, entry_point));
 }
 
-void Pipeline::AddSlangMissShader(const char* slang, const char* entry_point) {
-    miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(*device_, slang, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2,
-                                                             SPV_SOURCE_SLANG, nullptr, entry_point));
+void Pipeline::AddSlangMissShader(const char* slang, const char* entry_point, const void* shader_module_create_info_pnext,
+                                  const void* pipeline_shader_stage_create_info_pNext) {
+    miss_shaders_.emplace_back(
+        std::make_unique<VkShaderObj>(*device_, slang, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2, SPV_SOURCE_SLANG, nullptr,
+                                      entry_point, shader_module_create_info_pnext, pipeline_shader_stage_create_info_pNext));
 }
 
 void Pipeline::AddGlslClosestHitShader(const char* glsl, const void* shader_module_create_info_pnext,
@@ -2165,10 +2169,13 @@ void Pipeline::AddSpirvClosestHitShader(const char* spirv, const char* entry_poi
                                         nullptr});
 }
 
-void Pipeline::AddSlangClosestHitShader(const char* slang, const char* entry_point) {
-    hit_shaders_.emplace_back(HitShader{std::make_unique<VkShaderObj>(*device_, slang, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR,
-                                                                      SPV_ENV_VULKAN_1_2, SPV_SOURCE_SLANG, nullptr, entry_point),
-                                        nullptr});
+void Pipeline::AddSlangClosestHitShader(const char* slang, const char* entry_point, const void* shader_module_create_info_pnext,
+                                        const void* pipeline_shader_stage_create_info_pNext) {
+    hit_shaders_.emplace_back(
+        HitShader{std::make_unique<VkShaderObj>(*device_, slang, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, SPV_ENV_VULKAN_1_2,
+                                                SPV_SOURCE_SLANG, nullptr, entry_point, shader_module_create_info_pnext,
+                                                pipeline_shader_stage_create_info_pNext),
+                  nullptr});
 }
 
 void Pipeline::AddLibrary(const Pipeline& library) {

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -455,16 +455,19 @@ class Pipeline {
     void SetGlslRayGenShader(const char* glsl, const void* shader_module_create_info_pnext = nullptr,
                              const void* pipeline_shader_stage_create_info_pNext = nullptr);
     void AddSpirvRayGenShader(const char* spirv, const char* entry_point);
-    void AddSlangRayGenShader(const char* slang, const char* entry_point);
+    void AddSlangRayGenShader(const char* slang, const char* entry_point, const void* shader_module_create_info_pnext = nullptr,
+                              const void* pipeline_shader_stage_create_info_pNext = nullptr);
     void AddGlslMissShader(const char* glsl, const void* shader_module_create_info_pnext = nullptr,
                            const void* pipeline_shader_stage_create_info_pNext = nullptr);
     void AddSpirvMissShader(const char* spirv, const char* entry_point);
-    void AddSlangMissShader(const char* slang, const char* entry_point);
+    void AddSlangMissShader(const char* slang, const char* entry_point, const void* shader_module_create_info_pnext = nullptr,
+                            const void* pipeline_shader_stage_create_info_pNext = nullptr);
     void AddGlslClosestHitShader(const char* glsl, const void* shader_module_create_info_pnext = nullptr,
                                  const void* pipeline_shader_stage_create_info_pNext = nullptr);
     void AddGlslHitGroupShader(const char* closest_hit_glsl, const char* intersection_glsl = nullptr);
     void AddSpirvClosestHitShader(const char* spirv, const char* entry_point);
-    void AddSlangClosestHitShader(const char* slang, const char* entry_point);
+    void AddSlangClosestHitShader(const char* slang, const char* entry_point, const void* shader_module_create_info_pnext = nullptr,
+                                  const void* pipeline_shader_stage_create_info_pNext = nullptr);
     void AddLibrary(const Pipeline& library);
     void AddDynamicState(VkDynamicState dynamic_state);
     // Will be the same size for *all* shaders

--- a/tests/unit/gpu_av_descriptor_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_buffer_positive.cpp
@@ -644,3 +644,64 @@ TEST_F(PositiveGpuAVDescriptorBuffer, ComputeAndGraphics) {
         ASSERT_EQ(data[i + 4], float(i + 1));
     }
 }
+
+TEST_F(PositiveGpuAVDescriptorBuffer, DispatchIndirect) {
+    const VkLayerSettingEXT layer_setting{OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer({layer_setting}, false));
+
+    vkt::Buffer descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
+    const VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr};
+    const vkt::DescriptorSetLayout set_layout(*m_device, {binding}, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+    VkPushConstantRange pc_range = {VK_SHADER_STAGE_COMPUTE_BIT, 0, 4};
+    const vkt::PipelineLayout pipeline_layout(*m_device, {&set_layout}, {pc_range});
+
+    vkt::Buffer ssbo_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, ssbo_buffer, 32u);
+
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
+    vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
+
+    char const* cs_source = R"glsl(
+          #version 450
+          layout(local_size_x = 1) in;
+          layout(set = 0, binding = 0) buffer A { uint a; };
+          layout(push_constant) uniform B { uint b; };
+          void main() {
+              a = b;
+          }
+      )glsl";
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cs_ = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
+    pipe.cp_ci_.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    pipe.cp_ci_.layout = pipeline_layout;
+    pipe.CreateComputePipeline();
+
+    vkt::Buffer dispatch_params_buffer(*m_device, sizeof(VkDrawIndirectCommand) * 2, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
+                                       kHostVisibleMemProps);
+    auto indirect_dispatch_parameters = static_cast<VkDispatchIndirectCommand*>(dispatch_params_buffer.Memory().Map());
+    indirect_dispatch_parameters[0].x = 2u;
+    indirect_dispatch_parameters[0].y = 1u;
+    indirect_dispatch_parameters[0].z = 1u;
+    indirect_dispatch_parameters[1].x = 1u;
+    indirect_dispatch_parameters[1].y = 2u;
+    indirect_dispatch_parameters[1].z = 1u;
+
+    uint32_t pc_data = 1;
+    const uint32_t index = 0;
+    const VkDeviceSize offset = 0;
+    VkDescriptorBufferBindingInfoEXT buffer_binding_info = vku::InitStructHelper();
+    buffer_binding_info.address = descriptor_buffer.Address();
+    buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 1, &buffer_binding_info);
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1, &index, &offset);
+
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdPushConstants(m_command_buffer, pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, 4, &pc_data);
+    vk::CmdDispatchIndirect(m_command_buffer, dispatch_params_buffer, 0u);
+    vk::CmdPushConstants(m_command_buffer, pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, 4, &pc_data);
+    vk::CmdDispatchIndirect(m_command_buffer, dispatch_params_buffer, sizeof(VkDrawIndirectCommand));
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}

--- a/tests/unit/gpu_av_descriptor_heap.cpp
+++ b/tests/unit/gpu_av_descriptor_heap.cpp
@@ -121,7 +121,8 @@ VkDeviceSize GpuAVDescriptorHeap::AlignSampler(VkDeviceSize offset) { return Ali
 
 class NegativeGpuAVDescriptorHeap : public GpuAVDescriptorHeap {};
 
-TEST_F(NegativeGpuAVDescriptorHeap, IndexBufferOOB) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+TEST_F(NegativeGpuAVDescriptorHeap, DISABLED_IndexBufferOOB) {
     TEST_DESCRIPTION("Validate overruning the index buffer");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
@@ -628,7 +629,8 @@ TEST_F(NegativeGpuAVDescriptorHeap, MappingsUsed) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeGpuAVDescriptorHeap, DispatchWorkgroupSize) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+TEST_F(NegativeGpuAVDescriptorHeap, DISABLED_DispatchWorkgroupSize) {
     TEST_DESCRIPTION("GPU validation: Validate VkDispatchIndirectCommand with descriptor heap");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);

--- a/tests/unit/gpu_av_descriptor_heap_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_heap_positive.cpp
@@ -2122,3 +2122,53 @@ TEST_F(PositiveGpuAVDescriptorHeap, UntypedHardcodedArrayStride) {
     data = (uint32_t*)ssbo3_buffer.Memory().Map();
     ASSERT_TRUE(data[0] == 33u);
 }
+
+TEST_F(PositiveGpuAVDescriptorHeap, DispatchIndirect) {
+    const VkLayerSettingEXT layer_setting{OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}, false));
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize * 2);
+
+    vkt::Buffer ssbo_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    desc_heap.WriteBufferDescriptor(ssbo_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping.sourceData.constantOffset.heapOffset = 0;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1;
+    mapping_info.pMappings = &mapping;
+
+    char const* cs_source = R"glsl(
+          #version 450
+          layout(local_size_x = 1) in;
+          layout(set = 0, binding = 0) buffer A { uint a; };
+          layout(push_constant) uniform B { uint b; };
+          void main() {
+              a = b;
+          }
+      )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    vkt::Buffer dispatch_params_buffer(*m_device, sizeof(VkDrawIndirectCommand) * 2, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
+                                       kHostVisibleMemProps);
+    auto indirect_dispatch_parameters = static_cast<VkDispatchIndirectCommand*>(dispatch_params_buffer.Memory().Map());
+    indirect_dispatch_parameters[0].x = 2u;
+    indirect_dispatch_parameters[0].y = 1u;
+    indirect_dispatch_parameters[0].z = 1u;
+    indirect_dispatch_parameters[1].x = 1u;
+    indirect_dispatch_parameters[1].y = 2u;
+    indirect_dispatch_parameters[1].z = 1u;
+
+    uint8_t pc_data[64];
+    m_command_buffer.Begin();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_command_buffer.PushData(0, 64, pc_data);
+    vk::CmdDispatchIndirect(m_command_buffer, dispatch_params_buffer, 0u);
+    m_command_buffer.PushData(0, 64, pc_data);
+    vk::CmdDispatchIndirect(m_command_buffer, dispatch_params_buffer, sizeof(VkDrawIndirectCommand));
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -12,12 +12,13 @@
  */
 
 #include <cmath>
+#include <cstddef>
 #include <vulkan/utility/vk_format_utils.h>
 #include "layer_validation_tests.h"
 #include "descriptor_helper.h"
 #include "ray_tracing_objects.h"
 #include "gpu_av_helper.h"
-#include "utils/math_utils.h"
+#include "descriptor_heap_object.h"
 
 class NegativeGpuAVRayTracing : public GpuAVRayTracingTest {};
 
@@ -4398,4 +4399,179 @@ TEST_F(NegativeGpuAVRayTracing, OpReportIntersectionKHRHitKindOutOfRange) {
     auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     ASSERT_GT(debug_buffer_ptr[0], 0u) << "Intersection shader was never invoked";
     debug_buffer.Memory().Unmap();
+}
+
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657
+TEST_F(NegativeGpuAVRayTracing, DISABLED_InvalidBlasReference1DescriptorHeap) {
+    TEST_DESCRIPTION(
+        "Validate an invalid BLAS reference in a TLAS build - first element BLAS ref invalid, subsequent ones valid."
+        "Trace a ray into the built TLAS to confirm it was built correctly without the invalid ref but with the valid ones."
+        "Use descriptor heaps");
+
+    RETURN_IF_SKIP(CheckSlangSupport());
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    vkt::DescriptorHeap::AddDescriptorHeapRequirements(*this);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::maintenance4);
+    AddRequiredFeature(vkt::Feature::shaderInt64);
+
+    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(&validation_features));
+    if (!CanEnableGpuAV(*this)) {
+        GTEST_SKIP() << "Requirements for GPU-AV are not met";
+    }
+    RETURN_IF_SKIP(InitState());
+    InitRenderTarget();
+
+    vkt::as::GeometryKHR cube(vkt::as::blueprint::GeometryCubeOnDeviceInfo(*m_device));
+    vkt::as::BuildGeometryInfoKHR cube_blas = vkt::as::blueprint::BuildGeometryInfoOnDeviceBottomLevel(*m_device, std::move(cube));
+
+    m_command_buffer.Begin();
+    cube_blas.BuildCmdBuffer(m_command_buffer);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    std::vector<vkt::as::GeometryKHR> cube_instances(1);
+    cube_instances[0].SetType(vkt::as::GeometryKHR::Type::Instance);
+
+    VkAccelerationStructureInstanceKHR cube_instance_1{};
+    cube_instance_1.transform.matrix[0][0] = 1.0f;
+    cube_instance_1.transform.matrix[1][1] = 1.0f;
+    cube_instance_1.transform.matrix[2][2] = 1.0f;
+    cube_instance_1.transform.matrix[0][3] = 50.0f;
+    cube_instance_1.transform.matrix[1][3] = 0.0f;
+    cube_instance_1.transform.matrix[2][3] = 0.0f;
+    cube_instance_1.mask = 0xff;
+    cube_instance_1.instanceCustomIndex = 0;
+    // Cube instance 1 will be associated to closest hit shader 1
+    cube_instance_1.instanceShaderBindingTableRecordOffset = 0;
+    cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, cube_blas.GetDstAS()->handle(), cube_instance_1);
+    cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, cube_blas.GetDstAS()->handle(), cube_instance_1);
+
+    VkAccelerationStructureInstanceKHR cube_instance_2{};
+    cube_instance_2.transform.matrix[0][0] = 1.0f;
+    cube_instance_2.transform.matrix[1][1] = 1.0f;
+    cube_instance_2.transform.matrix[2][2] = 1.0f;
+    cube_instance_2.transform.matrix[0][3] = 0.0f;
+    cube_instance_2.transform.matrix[1][3] = 0.0f;
+    cube_instance_2.transform.matrix[2][3] = 50.0f;
+    cube_instance_2.mask = 0xff;
+    cube_instance_2.instanceCustomIndex = 0;
+    // Cube instance 2 will be associated to closest hit shader 1
+    cube_instance_2.instanceShaderBindingTableRecordOffset = 0;
+
+    cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, cube_blas.GetDstAS()->handle(), cube_instance_2);
+
+    std::vector<vkt::as::BuildGeometryInfoKHR> tlas_build_info;
+    {
+        vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::CreateTLAS(*m_device, std::move(cube_instances));
+        tlas_build_info.emplace_back(std::move(tlas));
+        m_command_buffer.Begin();
+        vkt::as::BuildAccelerationStructuresKHR(m_command_buffer, tlas_build_info);
+        m_command_buffer.End();
+
+        m_default_queue->Submit(m_command_buffer);
+        m_device->Wait();
+    }
+    // Buffer used to count invocations for the 3 shaders
+    vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                             kHostVisibleMemProps);
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
+    std::memset(debug_buffer_ptr, 0, (size_t)debug_buffer.CreateInfo().size);
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(1024, true);
+    const VkDeviceSize as_heap_offset = desc_heap.WriteAccelerationStructureDescriptor(*tlas_build_info[0].GetDstAS());
+
+    const VkDeviceSize as_descriptor_size =
+        vk::GetPhysicalDeviceDescriptorSizeEXT(m_device->Physical(), VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = vku::InitStructHelper();
+    mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT;
+    mapping.sourceData.shaderRecordIndex = {};
+    mapping.sourceData.shaderRecordIndex.heapOffset = (uint32_t)as_heap_offset;
+    mapping.sourceData.shaderRecordIndex.shaderRecordOffset = 0;
+    mapping.sourceData.shaderRecordIndex.heapIndexStride = (uint32_t)as_descriptor_size;
+    mapping.sourceData.shaderRecordIndex.heapArrayStride = (uint32_t)as_descriptor_size;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    const char* slang_shader = R"slang(
+        [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
+        [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
+
+        struct RayPayload {
+            uint4 payload;
+            float3 hit;
+        };
+
+        [shader("raygeneration")]
+        void rayGenShader()
+        {
+            InterlockedAdd(debug_buffer[0], 1);
+            RayPayload ray_payload = {};
+            RayDesc ray;
+            ray.TMin = 0.01;
+            ray.TMax = 1000.0;
+
+            // Will hit cube 1
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(1,0,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        }
+
+        [shader("miss")]
+        void missShader(inout RayPayload payload)
+        {
+            InterlockedAdd(debug_buffer[1], 1);
+            payload.hit = float3(0.1, 0.2, 0.3);
+        }
+
+        [shader("closesthit")]
+        void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+        {
+            InterlockedAdd(debug_buffer[2], 1);
+            const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+                attr.barycentrics.y);
+            payload.hit = barycentric_coords;
+        }
+    )slang";
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+    pipeline.AddCreateInfoFlags2(VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT);
+    pipeline.SetShaderRecordSize(3 * sizeof(uint32_t));
+    pipeline.AddSlangRayGenShader(slang_shader, "rayGenShader", nullptr, &mapping_info);
+    pipeline.AddSlangMissShader(slang_shader, "missShader", nullptr, &mapping_info);
+    pipeline.AddSlangClosestHitShader(slang_shader, "closestHitShader", nullptr, &mapping_info);
+
+    pipeline.Build();
+
+    uint32_t vec[3] = {0, 2, 4};
+    pipeline.UpdateRayGenShaderRecord(0, vec, 3 * sizeof(uint32_t));
+
+    m_command_buffer.Begin();
+
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline);
+
+    vkt::rt::TraceRaysSbt sbt_ray_gen_1 = pipeline.GetTraceRaysSbt(0);
+    vk::CmdTraceRaysKHR(m_command_buffer, &sbt_ray_gen_1.ray_gen_sbt, &sbt_ray_gen_1.miss_sbt, &sbt_ray_gen_1.hit_sbt,
+                        &sbt_ray_gen_1.callable_sbt, 1, 1, 1);
+
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
+
+    // Make sure expected ray tracing setup worked, indicating the TLAS was correctly built
+    ASSERT_EQ(debug_buffer_ptr[0], 1);
+    ASSERT_EQ(debug_buffer_ptr[1], 0);
+    ASSERT_EQ(debug_buffer_ptr[2], 1);
 }

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -1928,17 +1928,19 @@ TEST_F(PositiveRayTracing, CmdBuildClusterAccelerationStructureIndirect) {
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
-    void* mapped_memory = build_buffer.Memory().Map();
-    unsigned char* memory_data = (unsigned char*)mapped_memory;
-    bool has_data = false;
-    for (size_t i = 0; i < clas_size_info.accelerationStructureSize; i++) {
-        if (memory_data[i] != 0) {
-            has_data = true;
-            break;
+    if (!IsPlatformMockICD()) {
+        void* mapped_memory = build_buffer.Memory().Map();
+        unsigned char* memory_data = (unsigned char*)mapped_memory;
+        bool has_data = false;
+        for (size_t i = 0; i < clas_size_info.accelerationStructureSize; i++) {
+            if (memory_data[i] != 0) {
+                has_data = true;
+                break;
+            }
         }
+        // validate CmdBuildClusterAccelerationStructureIndirectNV has the valid output
+        ASSERT_TRUE(has_data);
     }
-    // validate CmdBuildClusterAccelerationStructureIndirectNV has the valid output
-    ASSERT_TRUE(has_data);
 }
 
 TEST_F(PositiveRayTracing, CmdBuildClusterAccelerationStructureIndirectSameBufferNonOverlapping) {


### PR DESCRIPTION
From https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12657

This is a temp way to disable buffer validation for Buffer/Heaps

Will need to add a proper solution