### PR TITLE
layers: Add 3D dynamicRendering checks

### DIFF
--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -3024,6 +3024,11 @@ bool CoreChecks::ValidateRenderingAttachmentInfo(VkCommandBuffer commandBuffer, 
     skip |= ValidateRenderingAttachmentInfoFeedbackLoop(commandBuffer, attachment_info, *image_view_state, attachment_loc);
     skip |= ValidateRenderingAttachmentFlagsInfo(commandBuffer, attachment_info, *image_view_state, attachment_loc);
 
+    if (image_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_3D) {
+        const LogObjectList objlist(commandBuffer, attachment_info.imageView);
+        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-12470", objlist, attachment_loc.dot(Field::imageView),
+                         "was created with VK_IMAGE_VIEW_TYPE_3D");
+    }
     return skip;
 }
 
@@ -3064,6 +3069,11 @@ bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer comm
                              attachment_loc.dot(Field::resolveMode), "%s but resolveImageView has a sample count of %s",
                              string_VkResolveModeFlagBits(attachment_info.resolveMode),
                              string_VkSampleCountFlagBits(resolve_view_state->samples));
+        }
+        if (resolve_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_3D) {
+            const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
+            skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveImageView-12471", objlist,
+                             attachment_loc.dot(Field::resolveImageView), "was created with VK_IMAGE_VIEW_TYPE_3D");
         }
 
         if (attachment_info.resolveMode != VK_RESOLVE_MODE_CUSTOM_BIT_EXT &&

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -8511,3 +8511,37 @@ TEST_F(NegativeDynamicRendering, MemoryBarrier2AccessMasks) {
     m_command_buffer.EndRendering();
     m_command_buffer.End();
 }
+
+TEST_F(NegativeDynamicRendering, ImageView3D) {
+    TEST_DESCRIPTION("https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8394");
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
+    image_ci.imageType = VK_IMAGE_TYPE_3D;
+    image_ci.format = VK_FORMAT_R32_SINT;
+    image_ci.extent = {8, 8, 8};
+    image_ci.mipLevels = 1;
+    image_ci.arrayLayers = 1;
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_3D);
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
+    begin_rendering_info.layerCount = 1;
+    begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
+    begin_rendering_info.colorAttachmentCount = 1;
+    begin_rendering_info.pColorAttachments = &color_attachment;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-12470");
+    m_command_buffer.BeginRendering(begin_rendering_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
Added in 1.4.357 header

- VUID-VkRenderingAttachmentInfo-imageView-12470
- VUID-VkRenderingAttachmentInfo-resolveImageView-12471