### PR TITLE
bpa: Don't warn for MAILBOX present mode not having been queried on wayland

### DIFF
--- a/layers/best_practices/bp_wsi.cpp
+++ b/layers/best_practices/bp_wsi.cpp
@@ -85,6 +85,8 @@ bool BestPractices::PreCallValidateCreateSwapchainKHR(VkDevice device, const VkS
     }
 
     if (pCreateInfo->presentMode != VK_PRESENT_MODE_FIFO_KHR &&
+        !( instance_state->Get<vvl::Surface>(pCreateInfo->surface)->GetSurfaceType() == vvl::SurfaceType::Wayland
+            && pCreateInfo->presentMode == VK_PRESENT_MODE_MAILBOX_KHR) &&
         physical_device_state->GetCallState(vvl::Func::vkGetPhysicalDeviceSurfacePresentModesKHR) != vvl::CallState::QueryDetails) {
         skip |= LogWarning("BestPractices-vkCreateSwapchainKHR-present-mode-no-surface", device, error_obj.location,
                            "called before getting surface present mode(s) from "

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4444,7 +4444,7 @@ void InstanceState::PostCallRecordCreateWin32SurfaceKHR(VkInstance instance, con
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::Win32);
 }
 
 void DeviceState::PostCallRecordAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
@@ -5128,7 +5128,7 @@ void InstanceState::PreCallRecordDestroySurfaceKHR(VkInstance instance, VkSurfac
     Destroy<Surface>(surface);
 }
 
-void InstanceState::RecordVulkanSurface(VkSurfaceKHR* pSurface) { Add(std::make_shared<Surface>(*pSurface)); }
+void InstanceState::RecordVulkanSurface(VkSurfaceKHR* pSurface, SurfaceType type) { Add(std::make_shared<Surface>(*pSurface, type)); }
 
 void InstanceState::PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance,
                                                                const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
@@ -5137,7 +5137,7 @@ void InstanceState::PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instan
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::DisplayPlane);
 }
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
@@ -5147,7 +5147,7 @@ void InstanceState::PostCallRecordCreateAndroidSurfaceKHR(VkInstance instance, c
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::Android);
 }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 
@@ -5159,7 +5159,7 @@ void InstanceState::PostCallRecordCreateImagePipeSurfaceFUCHSIA(VkInstance insta
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::ImagePipe_FUCHSIA);
 }
 #endif  // VK_USE_PLATFORM_FUCHSIA
 
@@ -5170,7 +5170,7 @@ void InstanceState::PostCallRecordCreateIOSSurfaceMVK(VkInstance instance, const
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::IOS_MVK);
 }
 #endif  // VK_USE_PLATFORM_IOS_MVK
 
@@ -5181,7 +5181,7 @@ void InstanceState::PostCallRecordCreateMacOSSurfaceMVK(VkInstance instance, con
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::MacOS_MVK);
 }
 #endif  // VK_USE_PLATFORM_MACOS_MVK
 
@@ -5192,7 +5192,7 @@ void InstanceState::PostCallRecordCreateMetalSurfaceEXT(VkInstance instance, con
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::Metal);
 }
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
@@ -5203,7 +5203,7 @@ void InstanceState::PostCallRecordCreateWaylandSurfaceKHR(VkInstance instance, c
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::Wayland);
 }
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 
@@ -5217,7 +5217,7 @@ void InstanceState::PostCallRecordCreateXcbSurfaceKHR(VkInstance instance, const
 #if defined(DEBUG_CAPTURE_KEYBOARD)
     xcb_connection = (void*)pCreateInfo->connection;
 #endif
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::Xcb);
 }
 #endif  // VK_USE_PLATFORM_XCB_KHR
 
@@ -5231,7 +5231,7 @@ void InstanceState::PostCallRecordCreateXlibSurfaceKHR(VkInstance instance, cons
 #if defined(DEBUG_CAPTURE_KEYBOARD)
     xlib_display = (void*)pCreateInfo->dpy;
 #endif
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::Xlib);
 }
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
@@ -5242,7 +5242,7 @@ void InstanceState::PostCallRecordCreateScreenSurfaceQNX(VkInstance instance, co
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::Screen_QNX);
 }
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
 
@@ -5252,7 +5252,7 @@ void InstanceState::PostCallRecordCreateHeadlessSurfaceEXT(VkInstance instance, 
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    RecordVulkanSurface(pSurface);
+    RecordVulkanSurface(pSurface, SurfaceType::Headless);
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -61,6 +61,7 @@ class SamplerYcbcrConversion;
 class Framebuffer;
 class RenderPass;
 class PipelineCache;
+enum class SurfaceType;
 class Surface;
 class PhysicalDevice;
 class DisplayMode;
@@ -267,7 +268,7 @@ class InstanceState : public vvl::BaseInstance {
 
     VkFormatFeatureFlags2 GetImageFormatFeatures(VkPhysicalDevice physical_device, bool has_format_feature2, bool has_drm_modifiers,
                                                  VkDevice device, VkImage image, VkFormat format, VkImageTiling tiling);
-    void RecordVulkanSurface(VkSurfaceKHR* pSurface);
+    void RecordVulkanSurface(VkSurfaceKHR* pSurface, SurfaceType type);
     void PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                     const RecordObject& record_obj) override;

--- a/layers/state_tracker/wsi_state.h
+++ b/layers/state_tracker/wsi_state.h
@@ -196,11 +196,31 @@ class SwapchainSubState {
     Swapchain &base;
 };
 
+enum class SurfaceType {
+    Unknown,
+
+    Android,
+    DisplayPlane,
+    Headless,
+    ImagePipe_FUSCHIA,
+    IOS_MVK,
+    MacOS_MVK,
+    Metal,
+    Screen_QNX,
+    Wayland,
+    Win32,
+    Xcb,
+    Xlib,
+};
+
+
 // Parent -> child relationships in the object usage tree:
 //    vvl::Surface -> nothing
 class Surface : public StateObject {
   public:
-    Surface(VkSurfaceKHR handle) : StateObject(handle, kVulkanObjectTypeSurfaceKHR) {}
+    Surface(VkSurfaceKHR handle, SurfaceType type) : StateObject(handle, kVulkanObjectTypeSurfaceKHR) {
+        type_ = type;
+    }
 
     ~Surface() {
         if (!Destroyed()) {
@@ -236,6 +256,8 @@ class Surface : public StateObject {
     VkSurfacePresentScalingCapabilitiesKHR GetPresentModeScalingCapabilities(VkPhysicalDevice phys_dev,
                                                                              VkPresentModeKHR present_mode) const;
     std::vector<VkPresentModeKHR> GetCompatibleModes(VkPhysicalDevice phys_dev, VkPresentModeKHR present_mode) const;
+
+    SurfaceType GetSurfaceType() { return type_; }
 
     vvl::Swapchain *swapchain{nullptr};
 
@@ -277,6 +299,7 @@ class Surface : public StateObject {
     mutable vvl::unordered_map<VkPhysicalDevice, std::vector<vku::safe_VkSurfaceFormat2KHR>> formats_;
 
     vvl::unordered_map<VkPhysicalDevice, PhysDevCache> cache_;
+    SurfaceType type_;
 };
 
 }  // namespace vvl

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -2504,6 +2504,7 @@ IndirectExecutionSet::IndirectExecutionSet(const Device& dev, const VkIndirectEx
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 VkResult Surface::Init(VkInstance instance, const VkWin32SurfaceCreateInfoKHR& info) {
+    type_ = vvl::SurfaceType::Win32;
     VkResult result = vk::CreateWin32SurfaceKHR(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;
@@ -2511,6 +2512,7 @@ VkResult Surface::Init(VkInstance instance, const VkWin32SurfaceCreateInfoKHR& i
 #endif
 #if defined(VK_USE_PLATFORM_METAL_EXT)
 VkResult Surface::Init(VkInstance instance, const VkMetalSurfaceCreateInfoEXT& info) {
+    type_ = vvl::SurfaceType::Metal;
     VkResult result = vk::CreateMetalSurfaceEXT(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;
@@ -2518,6 +2520,7 @@ VkResult Surface::Init(VkInstance instance, const VkMetalSurfaceCreateInfoEXT& i
 #endif
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 VkResult Surface::Init(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR& info) {
+    type_ = vvl::SurfaceType::Android;
     VkResult result = vk::CreateAndroidSurfaceKHR(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;
@@ -2525,6 +2528,7 @@ VkResult Surface::Init(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR&
 #endif
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
 VkResult Surface::Init(VkInstance instance, const VkXlibSurfaceCreateInfoKHR& info) {
+    type_ = vvl::SurfaceType::Xlib;
     VkResult result = vk::CreateXlibSurfaceKHR(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;
@@ -2532,6 +2536,7 @@ VkResult Surface::Init(VkInstance instance, const VkXlibSurfaceCreateInfoKHR& in
 #endif
 #if defined(VK_USE_PLATFORM_XCB_KHR)
 VkResult Surface::Init(VkInstance instance, const VkXcbSurfaceCreateInfoKHR& info) {
+    type_ = vvl::SurfaceType::Xcb;
     VkResult result = vk::CreateXcbSurfaceKHR(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;
@@ -2539,6 +2544,7 @@ VkResult Surface::Init(VkInstance instance, const VkXcbSurfaceCreateInfoKHR& inf
 #endif
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
 VkResult Surface::Init(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR& info) {
+    type_ = vvl::SurfaceType::Wayland;
     VkResult result = vk::CreateWaylandSurfaceKHR(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -26,6 +26,7 @@
 #include "containers/span.h"
 #include "containers/limits.h"
 #include "generated/vk_function_pointers.h"
+#include "state_tracker/wsi_state.h"
 #include "utils/cast_utils.h"
 #include "test_common.h"
 
@@ -1501,10 +1502,14 @@ class Surface {
     std::vector<VkPresentModeKHR> GetPresentModes(VkPhysicalDevice physical_device) const;
     VkSurfacePresentScalingCapabilitiesKHR GetScalingCapabilities(VkPhysicalDevice physical_device,
                                                                   VkPresentModeKHR present_mode) const;
+    vvl::SurfaceType GetType() const noexcept {
+        return type_;
+    }
 
   private:
     VkInstance instance_ = VK_NULL_HANDLE;
     VkSurfaceKHR handle_ = VK_NULL_HANDLE;
+    vvl::SurfaceType type_ = vvl::SurfaceType::Unknown;
 };
 
 const VkAllocationCallbacks *DefaultAllocator();

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -651,6 +651,9 @@ TEST_F(NegativeBestPractices, SwapchainCreationTest) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
     RETURN_IF_SKIP(InitSurface());
+    if (vvl::SurfaceType::Wayland == m_surface.GetType()) {
+        GTEST_SKIP() << "No MAILBOX warning for Wayland";
+    }
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     m_surface_composite_alpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;


### PR DESCRIPTION
KHR_wayland_surface explicitly requires that mailbox be supported. We shouldn't warn about a lack of calling vkGetPhysicalDevicePresentModes for such surfaces.

Some notes:

You can't forward declare enums, which is my only reason for using `enum class` instead so the forward deceleration in state_tracker.h works.

When naming the enum values, I made the choice to only add vendor suffixes, and left off KHR/EXT.

There's no test. I'm not sure how to author a test that only runs on Wayland, and regardless the existing test for this warning for FIFO swapchains is '[lazy](https://github.com/umbral-software/Vulkan-ValidationLayers/blob/main/tests/unit/best_practices.cpp#L700)' and doesn't actually check if the warning is emitted or not emitted correctly.