### PR TITLE
layers: Improve info level information

### DIFF
--- a/layers/chassis/chassis_manual.cpp
+++ b/layers/chassis/chassis_manual.cpp
@@ -21,6 +21,7 @@
 #include "chassis.h"
 
 #include <cstring>
+#include <sstream>
 
 #include "chassis/dispatch_object.h"
 #include "generated/dispatch_vector.h"
@@ -40,8 +41,7 @@ namespace vulkan_layer_chassis {
 
 // Check enabled instance extensions against supported instance extension whitelist
 static void InstanceExtensionWhitelist(vvl::DispatchInstance* layer_data, const VkInstanceCreateInfo* pCreateInfo,
-                                       VkInstance instance) {
-    Location loc(vvl::Func::vkCreateInstance);
+                                       VkInstance instance, const Location& loc) {
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         vvl::Extension extension = GetExtension(pCreateInfo->ppEnabledExtensionNames[i]);
         if (extension == vvl::Extension::Empty) {
@@ -83,40 +83,55 @@ static void DeviceExtensionWhitelist(vvl::DispatchDevice* layer_data, const VkDe
     }
 }
 
-void OutputLayerStatusInfo(vvl::DispatchInstance* context) {
-    std::string list_of_enables;
-    std::string list_of_disables;
-    for (uint32_t i = 0; i < kMaxEnableFlags; i++) {
-        if (context->settings.enabled[i]) {
-            if (list_of_enables.size()) list_of_enables.append(", ");
-            list_of_enables.append(GetEnableFlagNameHelper()[i]);
-        }
-    }
-    if (list_of_enables.empty()) {
-        list_of_enables.append("None");
-    }
-    for (uint32_t i = 0; i < kMaxDisableFlags; i++) {
-        if (context->settings.disabled[i]) {
-            if (list_of_disables.size()) list_of_disables.append(", ");
-            list_of_disables.append(GetDisableFlagNameHelper()[i]);
-        }
-    }
-    if (list_of_disables.empty()) {
-        list_of_disables.append("None");
+// Output layer status information message
+// TODO - We should just dump all settings to a file (see https://github.com/KhronosGroup/Vulkan-Utility-Libraries/issues/188)
+void OutputLayerStatusInfo(vvl::DispatchInstance* context, const Location& loc) {
+    // Will save a lot of time if every test doesn't have to build this string up to not be printed
+    if (!context->debug_report->HasSeverityLevel(VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT)) {
+        return;
     }
 
-    Location loc(vvl::Func::vkCreateInstance);
-    // Output layer status information message
-    // TODO - We should just dump all settings to a file (see https://github.com/KhronosGroup/Vulkan-Utility-Libraries/issues/188)
-    context->LogInfo("WARNING-CreateInstance-status-message", context->instance, loc,
-                     "Khronos Validation Layer Active:\n    Current Enables: %s.\n    Current Disables: %s.\n",
-                     list_of_enables.c_str(), list_of_disables.c_str());
+    std::ostringstream ss;
+    const auto& settings = context->settings;
+    ss << "Current Validaiton Enabled:\n";
 
-    // Create warning message if user is running debug layers.
-#ifndef NDEBUG
-    context->LogPerformanceWarning("WARNING-CreateInstance-debug-warning", context->instance, loc,
-                                   "Using debug builds of the validation layers *will* adversely affect performance.");
-#endif
+    // Match the order in vkconfig
+    // The goal here is to not print ALL the settings, just which parts of validation are turned on
+    if (!settings.disabled[core_checks]) {
+        ss << "  - Core Checks\n";
+    }
+    if (settings.enabled[sync_validation]) {
+        ss << "  - Synchronization\n";
+    }
+    if (!settings.disabled[stateless_checks]) {
+        ss << "  - Stateless Parameter\n";
+    }
+    if (!settings.disabled[object_tracking]) {
+        ss << "  - Object lifetime\n";
+    }
+    if (!settings.disabled[thread_safety]) {
+        ss << "  - Thread Safety\n";
+    }
+    if (!settings.disabled[handle_wrapping]) {
+        ss << "  - Handle Wrapping\n";
+    }
+    if (settings.enabled[legacy_detection]) {
+        ss << "  - Legacy Detection\n";
+    }
+    if (settings.enabled[best_practices]) {
+        ss << "  - Best Practices\n";
+    }
+    if (settings.enabled[gpu_validation]) {
+        ss << "  - GPU-AV\n";
+    }
+    if (settings.enabled[gpu_dump]) {
+        ss << "  - GPU Dump\n";
+    }
+    if (settings.enabled[debug_printf_validation]) {
+        ss << "  - Debug Printf\n";
+    }
+
+    context->LogInfo("CURRENT-VALIDATION-ENABLED", context->instance, loc, "%s", ss.str().c_str());
 }
 const vvl::unordered_map<std::string, function_data>& GetNameToFuncPtrMap();
 
@@ -235,8 +250,15 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
 
     layer_init_instance_dispatch_table(*pInstance, &instance_dispatch->instance_dispatch_table, fpGetInstanceProcAddr);
 
-    OutputLayerStatusInfo(instance_dispatch.get());
-    InstanceExtensionWhitelist(instance_dispatch.get(), pCreateInfo, *pInstance);
+    Location loc(vvl::Func::vkCreateInstance);
+    // Create warning message if user is running debug layers.
+#ifndef NDEBUG
+    instance_dispatch->LogPerformanceWarning("WARNING-CreateInstance-debug-warning", instance_dispatch->instance, loc,
+                                             "Using debug builds of the validation layers *will* adversely affect performance.");
+#endif
+
+    OutputLayerStatusInfo(instance_dispatch.get(), loc);
+    InstanceExtensionWhitelist(instance_dispatch.get(), pCreateInfo, *pInstance, loc);
     instance_dispatch->FindSupportedExtensions();
 
     // save a raw pointer since the unique_ptr will be invalidate by the move() below

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -738,7 +738,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback([[maybe_unused]] VkDebugUt
     // It is annoying to break on some of our internal device creation warnings
     const uint32_t vuid_hash = callback_data ? (uint32_t)callback_data->messageIdNumber : 0;
     if (vuid_hash == 0x86fe6721 ||  // "WARNING-Setting-Limit-Adjusted"
-        vuid_hash == 0x7f1922d7     // "VALIDATION-SETTINGS"
+        vuid_hash == 0x7f1922d7 ||  // "VALIDATION-SETTINGS"
+        vuid_hash == 0xfd7b2292     // "CURRENT-VALIDATION-ENABLED"
     ) {
         return false;
     }

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -252,6 +252,8 @@ class DebugReport {
     void ResetCmdDebugUtilsLabel(VkCommandBuffer command_buffer);
     void EraseCmdDebugUtilsLabel(VkCommandBuffer command_buffer);
 
+    bool HasSeverityLevel(VkDebugUtilsMessageSeverityFlagBitsEXT level) const { return (active_msg_severities & level) != 0; }
+
   private:
     std::string CreateMessageText(const Location &loc, std::string_view vuid_text, const std::string &main_message,
                                   bool at_message_limit);

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -94,43 +94,6 @@ const auto& ValidationEnableLookup() {
     return validation_enable_lookup;
 }
 
-// This should mirror the 'DisableFlags' enumerated type
-const std::vector<std::string>& GetDisableFlagNameHelper() {
-    static const std::vector<std::string> disable_flag_name_helper = {
-        "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",                // command_buffer_state,
-        "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",                       // object_in_use,
-        "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",                    // query_validation,
-        "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",             // image_layout_validation,
-        "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",           // object_tracking,
-        "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT",                // core_checks,
-        "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",              // thread_safety,
-        "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",             // stateless_checks,
-        "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",             // handle_wrapping,
-        "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",                    // shader_validation,
-        "VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHING_EXT",  // shader_validation_caching
-    };
-    return disable_flag_name_helper;
-}
-
-const std::vector<std::string>& GetEnableFlagNameHelper() {
-    // This should mirror the 'EnableFlags' enumerated type
-    static const std::vector<std::string> enable_flag_name_helper = {
-        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",                       // gpu_validation,
-        "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT",  // gpu_validation_reserve_binding_slot,
-        "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",                     // best_practices,
-        "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM",                         // vendor_specific_arm,
-        "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD",                         // vendor_specific_amd,
-        "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG",                         // vendor_specific_img,
-        "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_NVIDIA",                      // vendor_specific_nvidia,
-        "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",                       // debug_printf,
-        "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT",         // sync_validation,
-        // These were added after we got rid of VkValidationFeatureDisableEXT
-        "VK_LAYER_LEGACY_DETECTION",      // legacy_detection,
-        "VK_LAYER_GPU_DUMP_DESCRIPTORS",  // gpu_dump,
-    };
-    return enable_flag_name_helper;
-}
-
 // To enable "my_setting",
 // Set env var VK_LAYER_MY_SETTING to 1
 //

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -58,6 +58,7 @@ enum DisableFlags {
     shader_validation,
     shader_validation_caching,
     // Insert new disables above this line
+    // Make sure to add to OutputLayerStatusInfo function
     kMaxDisableFlags,
 };
 
@@ -74,6 +75,7 @@ enum EnableFlags {
     legacy_detection,
     gpu_dump,
     // Insert new enables above this line
+    // Make sure to add to OutputLayerStatusInfo function
     kMaxEnableFlags,
 };
 
@@ -137,8 +139,6 @@ struct ConfigAndEnvSettings {
     GpuDumpSettings* gpu_dump_settings;
     LegacyDetectionSettings* legacy_detection_settings;
 };
-const std::vector<std::string> &GetDisableFlagNameHelper();
-const std::vector<std::string> &GetEnableFlagNameHelper();
 
 // Process validation features, flags and settings specified through extensions, a layer settings file, or environment variables
 void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data);

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -94,6 +94,7 @@ TEST_F(NegativeOther, VuidHashStability) {
     ASSERT_TRUE(hash_util::VuidHash("GPU-DUMP") == 0xe5c5edc1);
     ASSERT_TRUE(hash_util::VuidHash("WARNING-Setting-Limit-Adjusted") == 0x86fe6721);
     ASSERT_TRUE(hash_util::VuidHash("VALIDATION-SETTINGS") == 0x7f1922d7);
+    ASSERT_TRUE(hash_util::VuidHash("CURRENT-VALIDATION-ENABLED") == 0xfd7b2292);
 }
 
 TEST_F(NegativeOther, RequiredParameter) {


### PR DESCRIPTION
I really want to get away from this "enable" vs "disabled" idea that was baked in many years ago

Today the user should just have various levels of validation that are "turned on" (and what is default or not is separate)

So this will look something like

```
Validation Information: [ CURRENT-VALIDATION-ENABLED ] | MessageID = 0xfd7b2292
vkCreateInstance(): Current Validaiton Enabled:
  - Core Checks
  - Stateless Parameter
  - Object lifetime
  - Thread Safety
  - Handle Wrapping
```

Future goal will be to have another way to print ALL the settings out