### PR TITLE
layers: fix out-of-bounds crash in static descriptor validation

### DIFF
--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -164,6 +164,12 @@ bool DescriptorValidator::ValidateDescriptorsStatic(const spirv::ResourceInterfa
         count = resource_variable.array_length;
     }
 
+    if (count > binding.descriptors.size()) {
+        // An out-of-range binding index requires an invalid pipeline to reach
+        // draw-time validation. Just skip all validation from here as things are already bad.
+        return skip;
+    }
+
     for (uint32_t index = 0; !skip && index < count; index++) {
         const auto& descriptor = binding.descriptors[index];
 

--- a/tests/undefined/core_undefined.cpp
+++ b/tests/undefined/core_undefined.cpp
@@ -81,3 +81,67 @@ TEST_F(UndefinedCore, RetireSignaledFence) {
     // The fix ensures that std::promise is always re-initialized when the fence is enqueued.
     m_default_queue->Wait();
 }
+
+TEST_F(UndefinedCore, DescriptorArrayLayoutMismatchDraw) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12294");
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::descriptorBindingSampledImageUpdateAfterBind);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    vkt::DescriptorSetLayout ds_layout(*m_device,
+                                       {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}});
+    vkt::PipelineLayout pipeline_layout(*m_device, {&ds_layout});
+
+    VkDescriptorPoolSize pool_size = {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1};
+    VkDescriptorPoolCreateInfo dspci = vku::InitStructHelper();
+    dspci.poolSizeCount = 1;
+    dspci.pPoolSizes = &pool_size;
+    dspci.maxSets = 1;
+    vkt::DescriptorPool pool(*m_device, dspci);
+
+    VkDescriptorSetAllocateInfo ds_alloc_info = vku::InitStructHelper();
+    ds_alloc_info.descriptorPool = pool;
+    ds_alloc_info.descriptorSetCount = 1;
+    ds_alloc_info.pSetLayouts = &ds_layout.handle();
+    VkDescriptorSet ds = VK_NULL_HANDLE;
+    ASSERT_EQ(VK_SUCCESS, vk::AllocateDescriptorSets(*m_device, &ds_alloc_info, &ds));
+
+    const char* fs_source = R"glsl(
+        #version 450
+        layout(location=0) out vec4 color;
+        layout(set=0, binding=0) uniform sampler2D tex[10000];
+        void main(){
+           color = texture(tex[0], vec2(0.0));
+        }
+    )glsl";
+    VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    CreatePipelineHelper pipe(*this);
+    pipe.shader_stages_[1] = fs.GetStageCreateInfo();
+    pipe.gp_ci_.layout = pipeline_layout;
+
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkGraphicsPipelineCreateInfo-layout-07991");
+    pipe.CreateGraphicsPipeline();
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+    vkt::Image image(*m_device, 128, 128, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::ImageView image_view = image.CreateView();
+
+    VkDescriptorImageInfo image_info = {sampler, image_view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
+    VkWriteDescriptorSet write = vku::InitStructHelper();
+    write.dstSet = ds;
+    write.dstBinding = 0;
+    write.dstArrayElement = 0;
+    write.descriptorCount = 1;
+    write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    write.pImageInfo = &image_info;
+    vk::UpdateDescriptorSets(device(), 1, &write, 0, nullptr);
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &ds, 0, nullptr);
+    vk::CmdDraw(m_command_buffer, 3u, 1u, 0u, 0u);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
This PR fixes an avoidable crash in descriptor static validation (#12294).

### Root Cause
In `DescriptorValidator::ValidateDescriptorsStatic`, the validation loop iterates up to `count = resource_variable.array_length` (the descriptor array size statically declared in the shader).

However, the pipeline layout binding count (`binding.count`) can be smaller than the shader array length (resulting in a layout mismatch validation error at pipeline creation time). If validation is bypassed or disabled at pipeline creation, running a draw call causes VVL to access `binding.descriptors[index]` out of bounds (which has size `binding.count`), triggering a crash.

### Fix
Add a bounds-check `index >= binding.count` inside the static validation loop to safely terminate verification of out-of-bounds descriptors.

Fixes #12294