### PR TITLE
layers: Checks and tests for VUIDs 9966, 9967, 9971, 9972, 9973

### DIFF
--- a/layers/core_checks/cc_data_graph.cpp
+++ b/layers/core_checks/cc_data_graph.cpp
@@ -292,6 +292,99 @@ bool CoreChecks::ValidateOpticalFlowConnections(const VkDataGraphPipelineSingleN
     return skip;
 }
 
+bool CoreChecks::ValidateOpticalFlowGridSizes(const VkDataGraphPipelineOpticalFlowCreateInfoARM& optical_flow_ci,
+                                              const Location& optical_flow_ci_loc) const {
+    bool skip = false;
+
+    const VkDataGraphOpticalFlowGridSizeFlagsARM hint_grid_size = optical_flow_ci.hintGridSize;
+    const VkDataGraphOpticalFlowGridSizeFlagsARM output_grid_size = optical_flow_ci.outputGridSize;
+    if (hint_grid_size != 0 && hint_grid_size != output_grid_size) {
+        skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-hintGridSize-09973", device,
+                         optical_flow_ci_loc.dot(Field::hintGridSize), "(%s) is not the same as outputGridSize (%s).\n",
+                         string_VkDataGraphOpticalFlowGridSizeFlagsARM(hint_grid_size).c_str(),
+                         string_VkDataGraphOpticalFlowGridSizeFlagsARM(output_grid_size).c_str());
+    }
+
+    VkDataGraphOpticalFlowGridSizeFlagsARM supported_output_grid_sizes = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
+    VkDataGraphOpticalFlowGridSizeFlagsARM supported_hint_grid_sizes = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
+    // At this point we don't know which specific queue/engine is used, so we check if any of them support the selected sizes.
+    for (const auto& entry : physical_device_state->data_graph.optical_flow_properties) {
+        supported_output_grid_sizes |= entry.second.supportedOutputGridSizes;
+        supported_hint_grid_sizes |= entry.second.supportedHintGridSizes;
+    }
+
+    auto matching_output_grid_sizes = output_grid_size & supported_output_grid_sizes;
+    if (matching_output_grid_sizes == 0) {
+        skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-outputGridSize-09971", device,
+                         optical_flow_ci_loc.dot(Field::outputGridSize), "(%s) not included in supported bits (%s).",
+                         string_VkDataGraphOpticalFlowGridSizeFlagsARM(output_grid_size).c_str(),
+                         string_VkDataGraphOpticalFlowGridSizeFlagsARM(supported_output_grid_sizes).c_str());
+    } else if (!IsSingleBitSet(matching_output_grid_sizes)) {
+        skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-outputGridSize-09971", device,
+                         optical_flow_ci_loc.dot(Field::outputGridSize), "(%s) has multiple bits selected.",
+                         string_VkDataGraphOpticalFlowGridSizeFlagsARM(output_grid_size).c_str());
+    }
+
+    const bool hint_enabled = (optical_flow_ci.flags & VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM) != 0;
+    if (!hint_enabled) {
+        if (hint_grid_size != 0) {
+            skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-hintGridSize-09972", device,
+                             optical_flow_ci_loc.dot(Field::hintGridSize),
+                             "(%s) is not zero while VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM is not set.",
+                             string_VkDataGraphOpticalFlowGridSizeFlagsARM(hint_grid_size).c_str());
+        }
+    } else {
+        auto matching_hint_grid_sizes = hint_grid_size & supported_hint_grid_sizes;
+        if (matching_hint_grid_sizes == 0) {
+            skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-hintGridSize-09972", device,
+                             optical_flow_ci_loc.dot(Field::hintGridSize), "(%s) not included in supported bits (%s).",
+                             string_VkDataGraphOpticalFlowGridSizeFlagsARM(hint_grid_size).c_str(),
+                             string_VkDataGraphOpticalFlowGridSizeFlagsARM(supported_hint_grid_sizes).c_str());
+        } else if (!IsSingleBitSet(matching_hint_grid_sizes)) {
+            skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-hintGridSize-09972", device,
+                             optical_flow_ci_loc.dot(Field::hintGridSize), "(%s) has multiple bits selected.",
+                             string_VkDataGraphOpticalFlowGridSizeFlagsARM(hint_grid_size).c_str());
+        }
+    }
+
+    return skip;
+}
+
+bool CoreChecks::ValidateOpticalFlowImageSizes(const VkDataGraphPipelineOpticalFlowCreateInfoARM& optical_flow_ci,
+                                               const Location& optical_flow_ci_loc) const {
+    bool skip = false;
+
+    uint32_t width = optical_flow_ci.width;
+    uint32_t height = optical_flow_ci.height;
+
+    uint32_t min_width = vvl::kU32Max;
+    uint32_t max_width = 0;
+    uint32_t min_height = vvl::kU32Max;
+    uint32_t max_height = 0;
+
+    // At this point we don't know which specific queue/engine is used, so we check the widest available range.
+    for (const auto& entry : physical_device_state->data_graph.optical_flow_properties) {
+        min_width = std::min(min_width, entry.second.minWidth);
+        max_width = std::max(max_width, entry.second.maxWidth);
+        min_height = std::min(min_height, entry.second.minHeight);
+        max_height = std::max(max_height, entry.second.maxHeight);
+    }
+
+    if (width < min_width || width > max_width) {
+        skip |= LogError(
+            "VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-width-09966", device, optical_flow_ci_loc.dot(Field::width),
+            "(%" PRIu32 ") is outside the [minWidth, maxWidth] (%" PRIu32 ", %" PRIu32 ") range", width, min_width, max_width);
+    }
+
+    if (height < min_height || height > max_height) {
+        skip |= LogError(
+            "VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-height-09967", device, optical_flow_ci_loc.dot(Field::height),
+            "(%" PRIu32 ") is outside the [minHeight, maxHeight] (%" PRIu32 ", %" PRIu32 ") range", height, min_height, max_height);
+    }
+
+    return skip;
+}
+
 bool core::Instance::PreCallValidateGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
     VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
     const VkQueueFamilyDataGraphPropertiesARM* pQueueFamilyDataGraphProperties, VkBaseOutStructure* pProperties,
@@ -460,6 +553,8 @@ bool CoreChecks::PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkD
                 const Location optical_flow_ci_loc = create_info_loc.pNext(Struct::VkDataGraphPipelineOpticalFlowCreateInfoARM);
                 skip |= ValidateOpticalFlowFormats(*optical_flow_ci, optical_flow_ci_loc);
                 skip |= ValidateOpticalFlowFlags(*optical_flow_ci, optical_flow_ci_loc);
+                skip |= ValidateOpticalFlowGridSizes(*optical_flow_ci, optical_flow_ci_loc);
+                skip |= ValidateOpticalFlowImageSizes(*optical_flow_ci, optical_flow_ci_loc);
 
                 const Location single_node_ci_loc = create_info_loc.pNext(Struct::VkDataGraphPipelineSingleNodeCreateInfoARM);
                 skip |= ValidateOpticalFlowConnections(*single_node_ci, single_node_ci_loc, optical_flow_ci->hintGridSize);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1085,6 +1085,10 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateOpticalFlowConnections(const VkDataGraphPipelineSingleNodeCreateInfoARM& single_node_ci,
                                         const Location& single_node_ci_loc,
                                         VkDataGraphOpticalFlowGridSizeFlagsARM hint_grid_size) const;
+    bool ValidateOpticalFlowGridSizes(const VkDataGraphPipelineOpticalFlowCreateInfoARM& optical_flow_ci,
+                                      const Location& optical_flow_ci_loc) const;
+    bool ValidateOpticalFlowImageSizes(const VkDataGraphPipelineOpticalFlowCreateInfoARM& optical_flow_ci,
+                                       const Location& optical_flow_ci_loc) const;
 
     bool PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                     VkPipelineCache pipelineCache, uint32_t createInfoCount,

--- a/tests/framework/data_graph_objects.cpp
+++ b/tests/framework/data_graph_objects.cpp
@@ -569,9 +569,13 @@ void OpticalFlowHelper::CreateOpticalFlow() {
     optical_flow_ci_.width = params_.width;
     optical_flow_ci_.imageFormat = GetAnyOpticalFlowFormat(VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM);
     optical_flow_ci_.flowVectorFormat = GetAnyOpticalFlowFormat(VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM);
-    optical_flow_ci_.outputGridSize = params_.outputGridSize ? params_.outputGridSize
-        : static_cast<VkDataGraphOpticalFlowGridSizeFlagsARM>(GetAnyOpticalFlowGridSize(optical_flow_properties_));
-    optical_flow_ci_.hintGridSize = params_.hintGridSize ? params_.hintGridSize : optical_flow_ci_.outputGridSize;
+    optical_flow_ci_.outputGridSize =
+        params_.outputGridSize != VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_FLAG_BITS_MAX_ENUM_ARM
+            ? params_.outputGridSize
+            : static_cast<VkDataGraphOpticalFlowGridSizeFlagsARM>(GetAnyOpticalFlowGridSize(optical_flow_properties_));
+    optical_flow_ci_.hintGridSize = params_.hintGridSize != VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_FLAG_BITS_MAX_ENUM_ARM
+                                        ? params_.hintGridSize
+                                        : optical_flow_ci_.outputGridSize;
     if (optical_flow_properties_.hintSupported) {
         optical_flow_ci_.flags |= VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM;
     }

--- a/tests/framework/data_graph_objects.h
+++ b/tests/framework/data_graph_objects.h
@@ -134,8 +134,8 @@ class DataGraphPipelineHelper {
 struct OfHelperParameters {
     uint32_t height = 100;
     uint32_t width = 100;
-    VkDataGraphOpticalFlowGridSizeFlagsARM outputGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
-    VkDataGraphOpticalFlowGridSizeFlagsARM hintGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
+    VkDataGraphOpticalFlowGridSizeFlagsARM outputGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_FLAG_BITS_MAX_ENUM_ARM;
+    VkDataGraphOpticalFlowGridSizeFlagsARM hintGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_FLAG_BITS_MAX_ENUM_ARM;
     uint32_t n_inputs = 1;
     uint32_t n_references = 1;
     uint32_t n_outputs = 1;

--- a/tests/unit/data_graph.cpp
+++ b/tests/unit/data_graph.cpp
@@ -2783,6 +2783,91 @@ TEST_F(NegativeDataGraph, OpticalFlowNoCost) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeDataGraph, OpticalFlowUnequalGridSizes) {
+    TEST_DESCRIPTION("Try to create an optical flow datagraph with non-zero hintGridSize not equal to outputGridSize");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    // Set different output and hint grid sizes
+    uint32_t queue_index = DefaultQueue()->family_index;
+    auto opt_flow_properties = vkt::dg::OpticalFlowHelper::QueryOpticalFlowProperties(*this, queue_index);
+    vkt::dg::OfHelperParameters params;
+    params.outputGridSize = vkt::dg::OpticalFlowHelper::GetAnyOpticalFlowGridSize(opt_flow_properties);
+    params.hintGridSize = vkt::dg::OpticalFlowHelper::GetAnyOpticalFlowGridSize(
+        opt_flow_properties, static_cast<VkDataGraphOpticalFlowGridSizeFlagBitsARM>(params.outputGridSize + 1));
+    vkt::dg::OpticalFlowHelper optical_flow(*this, params);
+
+    m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-hintGridSize-09973");
+    optical_flow.CreateDataGraphPipeline();
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDataGraph, OpticalFlowWrongOutputGridSize) {
+    TEST_DESCRIPTION("Try to create an optical flow datagraph with a wrong output grid size");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    // Set a wrong output grid size that is correct for hint grid size
+    vkt::dg::OfHelperParameters params;
+    params.outputGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
+    params.hintGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
+    vkt::dg::OpticalFlowHelper optical_flow(*this, params);
+    optical_flow.optical_flow_ci_.flags &= ~VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM;
+
+    m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-outputGridSize-09971");
+    optical_flow.CreateDataGraphPipeline();
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDataGraph, OpticalFlowWrongHintGridSize) {
+    TEST_DESCRIPTION("Try to create an optical flow datagraph with a wrong hint grid size");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    // Set a wrong hint grid size that is correct for output grid size
+    uint32_t queue_index = DefaultQueue()->family_index;
+    auto opt_flow_properties = vkt::dg::OpticalFlowHelper::QueryOpticalFlowProperties(*this, queue_index);
+    vkt::dg::OfHelperParameters params;
+    params.outputGridSize = vkt::dg::OpticalFlowHelper::GetAnyOpticalFlowGridSize(opt_flow_properties);
+    params.hintGridSize = params.outputGridSize;
+    vkt::dg::OpticalFlowHelper optical_flow(*this, params);
+    optical_flow.optical_flow_ci_.flags &= ~VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM;
+
+    m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-hintGridSize-09972");
+    optical_flow.CreateDataGraphPipeline();
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDataGraph, OpticalFlowWrongWidthHeight) {
+    TEST_DESCRIPTION("Try to create an optical flow datagraph with wrong image sizes");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    uint32_t queue_index = DefaultQueue()->family_index;
+    auto opt_flow_properties = vkt::dg::OpticalFlowHelper::QueryOpticalFlowProperties(*this, queue_index);
+    vkt::dg::OfHelperParameters params;
+
+    // Set widths and heights that are too low or too high
+    uint32_t good_width = params.width;
+    uint32_t good_height = params.height;
+    uint32_t under_width = opt_flow_properties.minWidth - 1;
+    uint32_t over_width = opt_flow_properties.maxWidth + 1;
+    uint32_t under_height = opt_flow_properties.minHeight - 1;
+    uint32_t over_height = opt_flow_properties.maxHeight + 1;
+
+    for (uint32_t w : {under_width, good_width, over_width}) {
+        for (uint32_t h : {under_height, good_height, over_height}) {
+            params.width = w;
+            params.height = h;
+            vkt::dg::OpticalFlowHelper optical_flow(*this, params);
+            if (w != good_width) {
+                m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-width-09966");
+            }
+            if (h != good_height) {
+                m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-height-09967");
+            }
+            optical_flow.CreateDataGraphPipeline();
+            m_errorMonitor->VerifyFound();
+        }
+    }
+}
+
 TEST_F(NegativeDataGraph, ProcessingEnginesGetPropertiesWrongQueue) {
     TEST_DESCRIPTION("Request Processing Engine operation properties on a different queue family that does not support them");
     RETURN_IF_SKIP(InitBasicDataGraph(true /*optical_flow*/));

--- a/tests/unit/data_graph_positive.cpp
+++ b/tests/unit/data_graph_positive.cpp
@@ -369,8 +369,6 @@ TEST_F(PositiveDataGraph, OpticalFlow) {
     vk::BindDataGraphPipelineSessionMemoryARM(*m_device, session_bind_infos.size(), session_bind_infos.data());
 
     VkDataGraphPipelineOpticalFlowDispatchInfoARM optical_flow_di = vku::InitStructHelper();
-    optical_flow_di.meanFlowL1NormHint =
-        optical_flow.optical_flow_ci_.height;  // must be less than or equal to optical_flow_ci.height/optical_flow_ci.width
     VkDataGraphPipelineDispatchInfoARM pipeline_di = vku::InitStructHelper(&optical_flow_di);
 
     m_command_buffer.Begin();


### PR DESCRIPTION
Adds the following VUIDs:
- VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-width-09966
- VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-height-09967
- VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-outputGridSize-09971
- VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-hintGridSize-09972
- VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-hintGridSize-09973
