### PR TITLE
tests: Replace i8 -> i32 in TOSA ADD; fix tests

### DIFF
--- a/tests/framework/data_graph_objects.cpp
+++ b/tests/framework/data_graph_objects.cpp
@@ -112,8 +112,7 @@ std::string DataGraphPipelineHelper::GetSpirvMultiEntryTwoDataGraph() {
                           %in_1 = OpGraphInputARM %uchar_1_8_16_4_tensor %uint_0
                           %op_2 = OpExtInst %uchar_1_4_8_4_tensor %tosa AVG_POOL2D %uint_2_tensor_2_2 %uint_2_tensor_2_2 %uint_4_tensor_0_0_0_0 %uint_1 %in_1 %uchar_1_tensor_0 %uchar_1_tensor_0
                           %op_3 = OpExtInst %uchar_1_2_4_4_tensor %tosa AVG_POOL2D %uint_2_tensor_2_2 %uint_2_tensor_2_2 %uint_4_tensor_0_0_0_0 %uint_1 %op_2 %uchar_1_tensor_0 %uchar_1_tensor_0
-                          %op_4 = OpExtInst %uchar_1_2_4_4_tensor %tosa ADD %op_3 %constant0
-                                  OpGraphSetOutputARM %op_4 %uint_0
+                                  OpGraphSetOutputARM %op_3 %uint_0
                                   OpGraphEndARM
 ; bind graphs to entrypoints
                                   OpGraphEntryPointARM %graph_1 "entrypoint_1" %main_arg_0 %main_res_0
@@ -297,8 +296,12 @@ std::string DataGraphPipelineHelper::GetSpirvTensorArrayDataGraph(bool is_runtim
 
 std::string DataGraphPipelineHelper::GetSpirvConstantDataGraph() {
     vkt::dg::ModifiableShaderParameters spirv_params;
-    spirv_params.types = "%constant_0 = OpGraphConstantARM %uchar_1_2_4_4_tensor 0";
-    spirv_params.instructions = "%dummy = OpExtInst %uchar_1_2_4_4_tensor %tosa ADD %op_1 %constant_0";
+    spirv_params.types = R"(
+    %i32_1_2_4_4_tensor = OpTypeTensorARM %uint %uint_4 %uint_arr_4_1_2_4_4
+    %constant_0 = OpGraphConstantARM %i32_1_2_4_4_tensor 0)";
+    spirv_params.instructions = R"(
+    %i32_op_1 = OpExtInst %i32_1_2_4_4_tensor %tosa CAST %op_1
+    %dummy = OpExtInst %i32_1_2_4_4_tensor %tosa ADD %i32_op_1 %constant_0)";
     return vkt::dg::DataGraphPipelineHelper::GetSpirvModifyableDataGraph(spirv_params);
 }
 

--- a/tests/unit/data_graph.cpp
+++ b/tests/unit/data_graph.cpp
@@ -1248,7 +1248,7 @@ TEST_F(NegativeDataGraph, GraphConstantTensorWrongRank) {
     VkTensorDescriptionARM desc = vku::InitStructHelper();
     const std::vector<int64_t> dimensions{1, 2, 4};
     desc.tiling = VK_TENSOR_TILING_LINEAR_ARM;
-    desc.format = VK_FORMAT_R8_UINT;
+    desc.format = VK_FORMAT_R32_SINT;
     desc.dimensionCount = dimensions.size();
     desc.pDimensions = dimensions.data();
     desc.usage = VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM;
@@ -1277,7 +1277,7 @@ TEST_F(NegativeDataGraph, GraphConstantTensorWrongDimensions) {
     VkTensorDescriptionARM desc = vku::InitStructHelper();
     const std::vector<int64_t> dimensions{1, 2, 4, 1};  // dim[3] is 4 in the spirv
     desc.tiling = VK_TENSOR_TILING_LINEAR_ARM;
-    desc.format = VK_FORMAT_R8_UINT;
+    desc.format = VK_FORMAT_R32_SINT;
     desc.dimensionCount = dimensions.size();
     desc.pDimensions = dimensions.data();
     desc.usage = VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM;
@@ -1302,10 +1302,9 @@ TEST_F(NegativeDataGraph, GraphConstantTensorWrongFormat) {
     params.spirv_source = spirv_string.c_str();
 
     // try a few different formats, different for bit width, float encoding and type
-    // NOTE: VK_FORMAT_R8_SINT included as a sanity check: it is different only by sign from the actual format,
-    // meaning it is compatible, and it must NOT trigger the VU
+    // compatible VK_FORMAT_R32_SINT and VK_FORMAT_R32_UINT also included
     for (auto format :
-         {VK_FORMAT_R8_SINT, VK_FORMAT_R8_BOOL_ARM, VK_FORMAT_R32_SINT, VK_FORMAT_R32_SFLOAT, VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM}) {
+         {VK_FORMAT_R32_UINT, VK_FORMAT_R32_SINT, VK_FORMAT_R8_SINT, VK_FORMAT_R8_BOOL_ARM, VK_FORMAT_R32_SFLOAT, VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM}) {
         vkt::dg::DataGraphPipelineHelper pipeline(*this, params);
 
         VkTensorDescriptionARM desc = DefaultConstantTensorDesc();
@@ -1314,8 +1313,8 @@ TEST_F(NegativeDataGraph, GraphConstantTensorWrongFormat) {
         pipeline.shader_module_ci_.constantCount = 1;
         pipeline.shader_module_ci_.pConstants = &constant;
 
-        if (format == VK_FORMAT_R8_SINT) {
-            // INT check must not consider the sign, as required by TOSA function specifications
+        // SPIRV is signless, so both VK_FORMAT_R32_SINT and VK_FORMAT_R32_UINT must not trigger the error
+        if (format == VK_FORMAT_R32_SINT || format == VK_FORMAT_R32_UINT) {
             pipeline.CreateDataGraphPipeline();
         } else {
             m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-pNext-09921");
@@ -2051,9 +2050,14 @@ TEST_F(NegativeDataGraph, DataGraphOpGraphConstantARMNoShape) {
 
     // inject in the spirv a constant based on a shapeless tensor
     vkt::dg::ModifiableShaderParameters spirv_params;
-    spirv_params.types = R"(%tensor_r4 = OpTypeTensorARM %uchar %uint_4
-            %constant_no_shape = OpGraphConstantARM %tensor_r4 0)";
-    spirv_params.instructions = "%dummy = OpExtInst %uchar_1_2_4_4_tensor %tosa ADD %op_1 %constant_no_shape";
+    spirv_params.types = R"(
+    %i32_1_2_4_4_tensor = OpTypeTensorARM %uint %uint_4 %uint_arr_4_1_2_4_4
+    %tensor_r4 = OpTypeTensorARM %uint %uint_4
+    %constant_no_shape = OpGraphConstantARM %tensor_r4 0)";
+    spirv_params.instructions = R"(
+    %i32_op_1 = OpExtInst %i32_1_2_4_4_tensor %tosa CAST %op_1
+    %dummy = OpExtInst %i32_1_2_4_4_tensor %tosa ADD %i32_op_1 %constant_no_shape)";
+
     const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvModifyableDataGraph(spirv_params);
 
     vkt::dg::HelperParameters params;
@@ -2073,12 +2077,11 @@ TEST_F(NegativeDataGraph, DataGraphNoConstant) {
     TEST_DESCRIPTION("Try to create a datagraph without a required constant.");
     RETURN_IF_SKIP(InitBasicDataGraph());
 
-    // get spirv with 2 entrypoints; has a constant in entrypoint 2
-    const std::string two_entrypoint_spirv = vkt::dg::DataGraphPipelineHelper::GetSpirvMultiEntryTwoDataGraph();
+    // spirv has a constant, but we don't define it in Vulkan
+    const std::string spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
-    params.spirv_source = two_entrypoint_spirv.c_str();
-    params.entrypoint = "entrypoint_2";
+    params.spirv_source = spirv_string.c_str();
     // helper constructor does NOT initialize the constant
     vkt::dg::DataGraphPipelineHelper pipeline(*this, params);
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-pNext-09921");

--- a/tests/unit/data_graph_positive.cpp
+++ b/tests/unit/data_graph_positive.cpp
@@ -73,19 +73,34 @@ VkTensorDescriptionARM DataGraphTest::DefaultConstantTensorDesc() {
     VkTensorDescriptionARM desc = vku::InitStructHelper();
     static std::vector<int64_t> dimensions{1, 2, 4, 4};
     desc.tiling = VK_TENSOR_TILING_LINEAR_ARM;
-    desc.format = VK_FORMAT_R8_UINT;
+    desc.format = VK_FORMAT_R32_SINT;
     desc.dimensionCount = dimensions.size();
     desc.pDimensions = dimensions.data();
     desc.usage = VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM;
     return desc;
 }
 
+// Assumes description defines a packed tensor with linear tiling.
+inline VkDeviceSize GetLinearTensorBufferSizeBytes(const VkTensorDescriptionARM &description) {
+    assert(description.dimensionCount > 0);
+    assert(description.pDimensions);
+    // NOTE: no assert for linear tiling: used for different tilings in negative tests
+
+    VkDeviceSize size = vkuFormatTexelBlockSize(description.format);
+    for (uint32_t i = 0; i < description.dimensionCount; ++i) {
+        assert(description.pDimensions[i] > 0);
+        size *= static_cast<VkDeviceSize>(description.pDimensions[i]);
+    }
+    return size;
+}
+
 // Constant for GetSpirvModifyableDataGraph and GetSpirvMultiEntryTwoDataGraph
 VkDataGraphPipelineConstantARM DataGraphTest::GetConstant(const VkTensorDescriptionARM& desc) {
     VkDataGraphPipelineConstantARM constant = vku::InitStructHelper();
     constant.id = 0;
-    // buffer size correct for DefaultConstantTensorDesc
-    static std::array<uint8_t, 32> constant_data;
+
+    VkDeviceSize buffer_size = GetLinearTensorBufferSizeBytes(desc);
+    static std::vector<uint8_t> constant_data(buffer_size);
     constant.pConstantData = constant_data.data();
     constant.pNext = &desc;
     return constant;
@@ -237,11 +252,6 @@ TEST_F(PositiveDataGraph, DataGraphMultipleEntrypoints) {
         params.spirv_source = two_entrypoint_spirv.c_str();
         params.entrypoint = "entrypoint_2";
         vkt::dg::DataGraphPipelineHelper pipeline(*this, params);
-
-        VkDataGraphPipelineConstantARM constant = GetConstant();
-        pipeline.shader_module_ci_.constantCount = 1;
-        pipeline.shader_module_ci_.pConstants = &constant;
-
         pipeline.CreateDataGraphPipeline();
     }
 }


### PR DESCRIPTION
This fixes some spirv programs that incorrectly used i8 (signless 8-bit INT) instead of 32-bit INT as type for the tensors used in TOSA ADD, as required by the function specifications.