### PR TITLE
layers: Fix UntypedImageTexelPointer used for TexelBuffers

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
@@ -1847,8 +1847,11 @@ void UntypedContext::FindAccess(const spirv::Instruction* next_inst, bool image_
             const spirv::Instruction* ac_inst = module.FindDef(base_type->Word(3));
             AddAccess(descriptor_type, ac_inst, from_function_call);
         } else if (base_type->Opcode() == spv::OpUntypedImageTexelPointerEXT) {
-            // Atomic storage image
-            const VkDescriptorType descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+            // Atomic storage image/texel buffer
+            const spirv::Instruction* image_type = module.FindDef(base_type->Word(3));
+            assert(image_type->Opcode() == spv::OpTypeImage);
+            const VkDescriptorType descriptor_type = image_type->GetImageType();
+
             const spirv::Instruction* ac_inst = module.FindDef(base_type->Word(4));
             AddAccess(descriptor_type, ac_inst, from_function_call);
         } else if (base_type->Opcode() == spv::OpFunctionParameter) {

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -881,6 +881,13 @@ const AccessPath TypeManager::BuildAccessPath(const Function& function, const In
                    next_access_chain->Opcode() == spv::OpUntypedImageTexelPointerEXT) {
             // Atomic Storage Image
             path.descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+
+            // Found CTS that uses this for texel buffer, but doesn't seem to be done for typed
+            // ... Not sure if this is just missing from OpImageTexelPointer
+            if (next_access_chain->Opcode() == spv::OpUntypedImageTexelPointerEXT) {
+                path.descriptor_type = FindTypeById(next_access_chain->Word(3))->inst_.GetImageType();
+            }
+
             const uint32_t image_operand = next_access_chain->Opcode() == spv::OpUntypedImageTexelPointerEXT ? 1 : 0;
             const Instruction* access_chain_inst = function.FindInstruction(next_access_chain->Operand(image_operand));
             if (access_chain_inst && access_chain_inst->IsNonPtrAccessChain()) {


### PR DESCRIPTION
apparently you can use `OpUntypedImageTexelPointerEXT` for texel buffers, not just storage images... which doesn't 100% match up with `OpImageTexelPointer` but something to solve after the SDK

This fixes `dEQP-VK.binding_model.descriptor_heap.spirv.storage_texel_buffer_atomic64` 