### PR TITLE
gpuav: Fix destruction order on process exit

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -76,6 +76,7 @@ class Validator : public GpuShaderInstrumentor {
           global_resource_descriptor_buffer_(*this),
           global_resource_descriptor_heap_(*this),
           gpu_resources_manager_(*this, true) {}
+    ~Validator();
 
     // gpuav_setup.cpp
     // -------------
@@ -318,6 +319,8 @@ class Validator : public GpuShaderInstrumentor {
 
     // Make sure we call the right versions of any timeline semaphore functions.
     bool timeline_khr_ = false;
+
+    bool substates_destroyed_ = false;
 
   public:
     vko::GpuResourcesManager gpu_resources_manager_;

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -524,9 +524,10 @@ bool Validator::IsAllDeviceLocalMappable() const {
 // resources we need to track. One issue is on vkDestroyDevice we need to teardown the GPU-AV class, then after we try and destroy
 // leaked state objects (ex. user forgot to call vkDestroySampler).
 void Validator::DestroySubstate() {
-    if (!dispatch_device_ || aborted_) {
+    if (!dispatch_device_ || aborted_ || substates_destroyed_) {
         return;
     }
+    substates_destroyed_ = true;
 
     // While this is not ideal, it is more important to keep normal code fast and do extra cleanup on teardown
     for (auto object_it = dispatch_device_->object_dispatch.begin(); object_it != dispatch_device_->object_dispatch.end();
@@ -536,6 +537,17 @@ void Validator::DestroySubstate() {
             state_tracker.RemoveSubState(LayerObjectTypeGpuAssisted);
         }
     }
+}
+
+// In normal operation, the substate are already removed from tracked objects by the time
+// we get here, because Validator::DestroySubstate() is called during DestroyDevice().
+// However, if the DeviceDispatch is destroyed during exit, by FreeAllDispatchObjects(), then DestroyDevice()
+// is never called.
+// We end up in a situation where GPUAV substates would survive the Validator, only to be later freed as
+// the states themselves are destroyed.
+// We can't let it happen in this order since some substates keep a reference to the validator to run cleanup code,
+Validator::~Validator() {
+    DestroySubstate();
 }
 
 }  // namespace gpuav

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -2741,6 +2741,14 @@ std::string CommandBuffer::DescribeInvalidatedState(CBDynamicState dynamic_state
     return ss.str();
 }
 
+void CommandBuffer::RemoveOwnedSubState(LayerObjectTypeId id) {
+    for (auto& last_bound : lastBound) {
+        if (last_bound.push_descriptor_set) {
+            last_bound.push_descriptor_set->RemoveSubState(id);
+        }
+    }
+}
+
 VulkanTypedHandle CommandBufferSubState::Handle() const { return base.Handle(); }
 VkCommandBuffer CommandBufferSubState::VkHandle() const { return base.VkHandle(); }
 

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -832,6 +832,9 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     static std::string GetDebugRegionName(const std::vector<LabelCommand>& label_commands, uint32_t label_command_index,
                                           const std::vector<std::string>& initial_label_stack = {});
 
+    // This command buffer might contain a push descriptor set, which is not tracked in the object maps.
+    // So the only way to cleanup SubStates on the descriptor set is through here.
+    void RemoveOwnedSubState(LayerObjectTypeId id);
   private:
     void ResetCBState();
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -88,7 +88,10 @@ void DeviceState::RemoveProxy(LayerObjectTypeId id) {
 // cleanup tries to destroy the substate)
 void DeviceState::RemoveSubState(LayerObjectTypeId id) {
     // Currently we have not good way to track all objects that have a substate, so this is a list from manual inspection
-    ForEachShared<vvl::CommandBuffer>([id](std::shared_ptr<vvl::CommandBuffer> state) { state->RemoveSubState(id); });
+    ForEachShared<vvl::CommandBuffer>([id](std::shared_ptr<vvl::CommandBuffer> state) {
+        state->RemoveSubState(id);
+        state->RemoveOwnedSubState(id);
+    });
     ForEachShared<vvl::Queue>([id](std::shared_ptr<vvl::Queue> state) { state->RemoveSubState(id); });
     ForEachShared<vvl::Swapchain>([id](std::shared_ptr<vvl::Swapchain> state) { state->RemoveSubState(id); });
     ForEachShared<vvl::ImageView>([id](std::shared_ptr<vvl::ImageView> state) { state->RemoveSubState(id); });


### PR DESCRIPTION
When running the VVL atexit handler, gpuav::Validator is not teared down in the usual way as part of vkDestroyDevice (since the device is not destroyed).

Instead, the DeviceDispatch is destroyed by FreeAllDispatchObject, and it then frees each member of object_dispatch in reverse order, so gpuav goes first.

In the normal path, gpuav removes all its SubState from all tracked object as part of device destruction, but since this does not happen here, the SubStates survive.
They are destroyed right after, when the state tracker gets itself destroyed, but as part of their destructor, they will try to use the Validator's state which has been freed.
In my case it was a DescriptorSetSubState that tried to free VMA memory but the VMA was owned by the validator so it's already gone.

There is a small added complication that Validator::DestroySubstates could not reach push descriptor sets, since they are not part of the object maps, but are instead owned by the command buffer (if I understood correctly).

TBH I'm not sure about the approach, it works to fix this bug, but there might be a bunch of other issues with the atexit path since it's different from the normal one. I've also toyed with a different way that tries to just "unhook" VVL and leak everything, instead of uninitializing. In a way it might be safer but since it's pretty different from what happens now I don't know enough about this whole thing to have an opinion. (it's here https://github.com/carnaval/Vulkan-ValidationLayers/commit/96e449bfcf927f989709c9a2160e352d2c129127).

To repro the bug, on my setup (windows, RDNA2) it's pretty simple : hitting CTRL+C in the console with validation debug printf active will GPU hang 4 out of 5 times, and crash otherwise. As you imagine it's pretty annoying which is why I'm keen to fix it :-)