### PR TITLE
gpuav: Better BDA error message

### DIFF
--- a/layers/gpuav/instrumentation/buffer_device_address.cpp
+++ b/layers/gpuav/instrumentation/buffer_device_address.cpp
@@ -58,10 +58,11 @@ void RegisterBufferDeviceAddressValidation(Validator& gpuav, CommandBufferSubSta
                 const uint32_t error_sub_code = GetSubError(error_record);
                 switch (error_sub_code) {
                     case kErrorSubCode_BufferDeviceAddress_UnallocRef: {
-                        const char* access_type = is_write ? "written" : "read";
+                        const char* access_type = is_write ? "write" : "read";
                         const uint32_t byte_size = payload & kInst_BuffAddrAccess_PayloadMaskAccessInfo;
-                        ss << "Out of bounds access: " << byte_size << " bytes " << access_type << " at buffer device address 0x"
-                           << std::hex << address << '.';
+                        ss << "Out of bounds: trying to " << access_type << " " << byte_size << " bytes at [0x" << std::hex
+                           << address << ", 0x" << (address + byte_size) - 1
+                           << ") but no buffer device address was found at this range.";
                         if (is_struct) {
                             // Added because glslang currently has no way to seperate out the struct (Slang does as of 2025.6.2)
                             ss << " This " << (is_write ? "write" : "read") << " corresponds to a full OpTypeStruct load";

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -538,7 +538,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140) {
     uniform_buffer_ptr[0] = storage_buffer.Address();
     uniform_buffer_ptr[1] = 5;
 
-    m_errorMonitor->SetDesiredError("Out of bounds access: 4 bytes written", 3);
+    m_errorMonitor->SetDesiredError("Out of bounds: trying to write 4 bytes", 3);
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 
@@ -621,7 +621,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140NumerousRanges) {
     uniform_buffer_ptr[0] = storage_buffer_addr;
     uniform_buffer_ptr[1] = 5;  // Will provoke a 4 bytes write past buffer end
 
-    m_errorMonitor->SetDesiredError("Out of bounds access: 4 bytes written", 3);
+    m_errorMonitor->SetDesiredError("Out of bounds: trying to write 4 bytes", 3);
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 
@@ -686,7 +686,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430) {
     uniform_buffer_ptr[0] = storage_buffer.Address();
     uniform_buffer_ptr[1] = 5;
 
-    m_errorMonitor->SetDesiredError("Out of bounds access: 4 bytes written", 3);
+    m_errorMonitor->SetDesiredError("Out of bounds: trying to write 4 bytes", 3);
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 
@@ -799,7 +799,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
     auto uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer_addr;
 
-    m_errorMonitor->SetDesiredError("Out of bounds access: 12 bytes written");
+    m_errorMonitor->SetDesiredError("Out of bounds: trying to write 12 bytes");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 
@@ -891,7 +891,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayoutFront) {
     // The OpStore is aligned to 16 bytes, so need to substract by that
     uniform_buffer_ptr[0] = storage_buffer_addr - 16;
 
-    m_errorMonitor->SetDesiredError("Out of bounds access: 4 bytes written");
+    m_errorMonitor->SetDesiredError("Out of bounds: trying to write 4 bytes");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 }
@@ -950,7 +950,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
     auto uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer_addr;
 
-    m_errorMonitor->SetDesiredError("Out of bounds access: 12 bytes written");
+    m_errorMonitor->SetDesiredError("Out of bounds: trying to write 12 bytes");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 
@@ -1013,7 +1013,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayoutFront) {
     // The OpStore is aligned to 16 bytes, so need to substract by that
     uniform_buffer_ptr[0] = storage_buffer_addr - 16;
 
-    m_errorMonitor->SetDesiredError("Out of bounds access: 4 bytes written");
+    m_errorMonitor->SetDesiredError("Out of bounds: trying to write 4 bytes");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 }
@@ -1084,7 +1084,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
         uniform_buffer_ptr[i] = addr;
     }
 
-    m_errorMonitor->SetDesiredError("Out of bounds access: 12 bytes written");
+    m_errorMonitor->SetDesiredError("Out of bounds: trying to write 12 bytes");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
from

```
vkCmdDispatch(): Out of bounds access: 12 bytes read at buffer device address 0x64210000c.
```

to 

```
vkCmdDispatch(): Out of bounds: trying to read 12 bytes at [0x64210000c, 0x642100017) but no buffer device address was found at this range.
```