### PR TITLE
Fix validating buffer bounds

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -2139,14 +2139,18 @@ bool CoreChecks::ValidateBufferBounds(const vvl::CommandBuffer& cb_state, const 
     const uint32_t last_z = region.imageExtent.depth - 1;
     const uint32_t last_layer = normalized_layer_count - 1;
 
+    // We have to cast to double before using std::ceil, otherwise when dividing integers the fractional part will be truncated,
+    // making std::ceil a no-op.
     const VkDeviceSize row_extent =
-        static_cast<VkDeviceSize>(std::ceil(std::max(region.bufferRowLength, region.imageExtent.width) / block_extent.width)) *
+        static_cast<VkDeviceSize>(
+            std::ceil(static_cast<double>(std::max(region.bufferRowLength, region.imageExtent.width)) / block_extent.width)) *
         block_size;
     const VkDeviceSize slice_extent =
-        static_cast<VkDeviceSize>(std::ceil(std::max(region.bufferImageHeight, region.imageExtent.height) / block_extent.height)) *
+        static_cast<VkDeviceSize>(
+            std::ceil(static_cast<double>(std::max(region.bufferImageHeight, region.imageExtent.height)) / block_extent.height)) *
         row_extent;
     const VkDeviceSize layer_extent =
-        static_cast<VkDeviceSize>(std::ceil(region.imageExtent.depth / block_extent.depth)) * slice_extent;
+        static_cast<VkDeviceSize>(std::ceil(static_cast<double>(region.imageExtent.depth) / block_extent.depth)) * slice_extent;
 
     const VkDeviceSize x_value = static_cast<VkDeviceSize>(std::floor(last_x / block_extent.width)) * block_size;
     const VkDeviceSize y_value = static_cast<VkDeviceSize>(std::floor(last_y / block_extent.height)) * row_extent;
@@ -2206,14 +2210,18 @@ bool CoreChecks::ValidateDeviceAddressBufferBounds(const vvl::CommandBuffer& cb_
     const uint32_t last_z = region.imageExtent.depth - 1;
     const uint32_t last_layer = normalized_layer_count - 1;
 
+    // We have to cast to double before using std::ceil, otherwise when dividing integers the fractional part will be truncated,
+    // making std::ceil a no-op.
     const VkDeviceSize row_extent =
-        static_cast<VkDeviceSize>(std::ceil(std::max(region.addressRowLength, region.imageExtent.width) / block_extent.width)) *
+        static_cast<VkDeviceSize>(
+            std::ceil(static_cast<double>(std::max(region.addressRowLength, region.imageExtent.width)) / block_extent.width)) *
         block_size;
     const VkDeviceSize slice_extent =
-        static_cast<VkDeviceSize>(std::ceil(std::max(region.addressImageHeight, region.imageExtent.height) / block_extent.height)) *
+        static_cast<VkDeviceSize>(
+            std::ceil(static_cast<double>(std::max(region.addressImageHeight, region.imageExtent.height)) / block_extent.height)) *
         row_extent;
     const VkDeviceSize layer_extent =
-        static_cast<VkDeviceSize>(std::ceil(region.imageExtent.depth / block_extent.depth)) * slice_extent;
+        static_cast<VkDeviceSize>(std::ceil(static_cast<double>(region.imageExtent.depth) / block_extent.depth)) * slice_extent;
 
     const VkDeviceSize x_value = static_cast<VkDeviceSize>(std::floor(last_x / block_extent.width)) * block_size;
     const VkDeviceSize y_value = static_cast<VkDeviceSize>(std::floor(last_y / block_extent.height)) * row_extent;

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -5380,3 +5380,24 @@ TEST_F(NegativeCopyBufferImage, DestroyAfterCopyImageToMemory) {
     vk::EndCommandBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeCopyBufferImage, BC3Copy) {
+    RETURN_IF_SKIP(Init());
+
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_BC3_UNORM_BLOCK, VK_IMAGE_TILING_OPTIMAL, kSrcDstFeature)) {
+        GTEST_SKIP() << "Required formats/features not supported";
+    }
+
+    vkt::Image image(*m_device, 5u, 8u, VK_FORMAT_BC3_UNORM_BLOCK, kSrcDstUsage);
+    vkt::Buffer buffer(*m_device, 56u, kSrcDstUsage);
+
+    VkBufferImageCopy region = {};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 0u, 1u};
+    region.imageExtent = {5u, 8u, 1u};
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBufferToImage-pRegions-00171");
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
When computing extents we have to cast to double before using std::ceil, otherwise when dividing integers the fractional part will be truncated, making std::ceil a no-op.
