### PR TITLE
layers: Handle mip level for renderArea.extent

### DIFF
--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include <vulkan/vk_enum_string_helper.h>
@@ -2971,33 +2972,91 @@ bool CoreChecks::PreCallValidateCreateRenderPass2KHR(VkDevice device, const VkRe
     return PreCallValidateCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, error_obj);
 }
 
-bool CoreChecks::ValidateRenderingInfoAttachmentDeviceGroup(const vvl::Image& image_state, const VkRenderingInfo& rendering_info,
-                                                            const LogObjectList& objlist, const Location& loc) const {
+bool CoreChecks::ValidateRenderingInfoAttachment(const vvl::ImageView& image_view_state, const VkRenderingInfo& rendering_info,
+                                                 const LogObjectList& objlist, const Location& attachment_loc) const {
     bool skip = false;
+
+    const bool is_color = attachment_loc.field == Field::pColorAttachments;
+    const bool is_depth = attachment_loc.field == Field::pDepthAttachment;
+    assert(is_color || is_depth || attachment_loc.field == Field::pStencilAttachment);
+
+    const VkComponentMapping components = image_view_state.create_info.components;
+    if (!IsIdentitySwizzle(components)) {
+        const char* vuid = is_color   ? "VUID-VkRenderingInfo-colorAttachmentCount-09479"
+                           : is_depth ? "VUID-VkRenderingInfo-pDepthAttachment-09481"
+                                      : "VUID-VkRenderingInfo-pStencilAttachment-09483";
+        skip |=
+            LogError(vuid, objlist, attachment_loc, "has a non-identiy swizzle component, here are the actual swizzle values:\n%s",
+                     string_VkComponentMapping(components).c_str());
+    }
+
+    if (rendering_info.viewMask == 0 && rendering_info.layerCount > image_view_state.normalized_subresource_range.layerCount) {
+        const char* vuid = is_color   ? "VUID-VkRenderingInfo-viewMask-10859"
+                           : is_depth ? "VUID-VkRenderingInfo-viewMask-10860"
+                                      : "VUID-VkRenderingInfo-viewMask-10861";
+        skip |= LogError(vuid, objlist, attachment_loc.dot(Field::layerCount),
+                         "(%" PRIu32 ") is greater than the imageView which was created with a layerCount of %" PRIu32 ".",
+                         rendering_info.layerCount, image_view_state.normalized_subresource_range.layerCount);
+    }
+
+    if (rendering_info.viewMask != 0 &&
+        image_view_state.normalized_subresource_range.layerCount <= (uint32_t)MostSignificantBit(rendering_info.viewMask)) {
+        const char* vuid = is_color   ? "VUID-VkRenderingInfo-viewMask-12403"
+                           : is_depth ? "VUID-VkRenderingInfo-viewMask-12404"
+                                      : "VUID-VkRenderingInfo-viewMask-12405";
+        skip |= LogError(vuid, objlist, attachment_loc,
+                         "must have a layerCount (%" PRIu32
+                         ") greater than the most significant bit index (%d) in viewMask (0x%" PRIx32 ")",
+                         image_view_state.normalized_subresource_range.layerCount, MostSignificantBit(rendering_info.viewMask),
+                         rendering_info.viewMask);
+    }
 
     auto device_group_render_pass_begin_info = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(rendering_info.pNext);
     if (!device_group_render_pass_begin_info || device_group_render_pass_begin_info->deviceRenderAreaCount == 0) {
+        const vvl::Image& image_state = *image_view_state.image_state;
+
+        const VkExtent3D effective_extent =
+            image_state.GetEffectiveSubresourceExtent(image_view_state.create_info.subresourceRange);
+
         // Upcasting to handle overflow
         const bool x_extent_valid =
-            static_cast<int64_t>(image_state.GetExtent().width) >=
+            static_cast<int64_t>(effective_extent.width) >=
             static_cast<int64_t>(rendering_info.renderArea.offset.x) + static_cast<int64_t>(rendering_info.renderArea.extent.width);
         if (!x_extent_valid) {
+            std::ostringstream ss;
+            ss << "width (" << effective_extent.width << ") is less than pRenderingInfo->renderArea.offset.x ("
+               << rendering_info.renderArea.offset.x << ") + pRenderingInfo->renderArea.extent.width ("
+               << rendering_info.renderArea.extent.width << ").";
+            if (image_view_state.normalized_subresource_range.baseMipLevel != 0) {
+                ss << "\nThe VkImageView baseMipLevel (" << image_view_state.normalized_subresource_range.baseMipLevel
+                   << ") has an effective extent [" << string_VkExtent3D(effective_extent) << "] based off the VkImage extent ["
+                   << string_VkExtent3D(image_state.GetExtent()) << "]";
+                if (rendering_info.renderArea.extent.width == image_state.GetExtent().width) {
+                    ss << "\nHint: Did you forget to adjust the renderArea::extent for the mip level?";
+                }
+            }
             skip |=
-                LogError("VUID-VkRenderingInfo-pNext-06079", objlist, loc,
-                         "width (%" PRIu32 ") is less than pRenderingInfo->renderArea.offset.x (%" PRId32
-                         ") + pRenderingInfo->renderArea.extent.width (%" PRIu32 ").",
-                         image_state.GetExtent().width, rendering_info.renderArea.offset.x, rendering_info.renderArea.extent.width);
+                LogError("VUID-VkRenderingInfo-pNext-06079", objlist, attachment_loc.dot(Field::imageView), "%s", ss.str().c_str());
         }
 
-        const bool y_extent_valid = static_cast<int64_t>(image_state.GetExtent().height) >=
-                                    static_cast<int64_t>(rendering_info.renderArea.offset.y) +
-                                        static_cast<int64_t>(rendering_info.renderArea.extent.height);
+        const bool y_extent_valid =
+            static_cast<int64_t>(effective_extent.height) >= static_cast<int64_t>(rendering_info.renderArea.offset.y) +
+                                                                 static_cast<int64_t>(rendering_info.renderArea.extent.height);
         if (!y_extent_valid) {
-            skip |= LogError("VUID-VkRenderingInfo-pNext-06080", objlist, loc,
-                             "height (%" PRIu32 ") is less than pRenderingInfo->renderArea.offset.y (%" PRId32
-                             ") + pRenderingInfo->renderArea.extent.height (%" PRIu32 ").",
-                             image_state.GetExtent().height, rendering_info.renderArea.offset.y,
-                             rendering_info.renderArea.extent.height);
+            std::ostringstream ss;
+            ss << "height (" << effective_extent.height << ") is less than pRenderingInfo->renderArea.offset.y ("
+               << rendering_info.renderArea.offset.y << ") + pRenderingInfo->renderArea.extent.height ("
+               << rendering_info.renderArea.extent.height << ").";
+            if (image_view_state.normalized_subresource_range.baseMipLevel != 0) {
+                ss << "\nThe VkImageView baseMipLevel (" << image_view_state.normalized_subresource_range.baseMipLevel
+                   << ") has an effective extent [" << string_VkExtent3D(effective_extent) << "] based off the VkImage extent ["
+                   << string_VkExtent3D(image_state.GetExtent()) << "]";
+                if (rendering_info.renderArea.extent.height == image_state.GetExtent().height) {
+                    ss << "\nHint: Did you forget to adjust the renderArea::extent for the mip level?";
+                }
+            }
+            skip |=
+                LogError("VUID-VkRenderingInfo-pNext-06080", objlist, attachment_loc.dot(Field::imageView), "%s", ss.str().c_str());
         }
     }
 
@@ -4155,38 +4214,15 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer&
             ASSERT_AND_CONTINUE(image_view_state);
             const vvl::Image& image_state = *image_view_state->image_state;
             const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state.Handle());
-            const Location color_image_view = color_attachment_loc.dot(Field::imageView);
 
             if (!(image_view_state->inherited_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {
-                skip |= LogError("VUID-VkRenderingInfo-colorAttachmentCount-06087", objlist, color_image_view,
-                                 "references an image which was not created with VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT.\n%s",
-                                 image_view_state->DescribeImageUsage(*this).c_str());
+                skip |=
+                    LogError("VUID-VkRenderingInfo-colorAttachmentCount-06087", objlist, color_attachment_loc.dot(Field::imageView),
+                             "references an image which was not created with VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT.\n%s",
+                             image_view_state->DescribeImageUsage(*this).c_str());
             }
 
-            const VkComponentMapping components = image_view_state->create_info.components;
-            if (!IsIdentitySwizzle(components)) {
-                skip |= LogError("VUID-VkRenderingInfo-colorAttachmentCount-09479", objlist, color_image_view,
-                                 "has a non-identiy swizzle component, here are the actual swizzle values:\n%s",
-                                 string_VkComponentMapping(components).c_str());
-            }
-
-            if (rendering_info.viewMask == 0 &&
-                rendering_info.layerCount > image_view_state->normalized_subresource_range.layerCount) {
-                skip |= LogError("VUID-VkRenderingInfo-viewMask-10859", objlist, color_attachment_loc.dot(Field::layerCount),
-                                 "(%" PRIu32 ") is greater than the imageView which was created with a layerCount of %" PRIu32 ".",
-                                 rendering_info.layerCount, image_view_state->normalized_subresource_range.layerCount);
-            }
-
-            if (rendering_info.viewMask != 0 && image_view_state->normalized_subresource_range.layerCount <=
-                                                    (uint32_t)MostSignificantBit(rendering_info.viewMask)) {
-                skip |= LogError("VUID-VkRenderingInfo-viewMask-12403", objlist, color_image_view,
-                                 "must have a layerCount (%" PRIu32
-                                 ") greater than the most significant bit index (%d) in viewMask (0x%" PRIx32 ")",
-                                 image_view_state->normalized_subresource_range.layerCount,
-                                 MostSignificantBit(rendering_info.viewMask), rendering_info.viewMask);
-            }
-
-            skip |= ValidateRenderingInfoAttachmentDeviceGroup(image_state, rendering_info, objlist, color_image_view);
+            skip |= ValidateRenderingInfoAttachment(*image_view_state, rendering_info, objlist, color_attachment_loc);
         }
 
         auto resolve_view_state = Get<vvl::ImageView>(color_attachment.resolveImageView);
@@ -4333,43 +4369,20 @@ bool CoreChecks::ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer&
         ASSERT_AND_RETURN_SKIP(depth_view_state);
         const vvl::Image& image_state = *depth_view_state->image_state;
         const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state.Handle());
-        const Location depth_image_view = depth_attachment_loc.dot(Field::imageView);
 
         if (!(depth_view_state->inherited_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06088", objlist, depth_image_view,
+            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06088", objlist, depth_attachment_loc.dot(Field::imageView),
                              "references an image which was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.\n%s",
                              depth_view_state->DescribeImageUsage(*this).c_str());
         }
 
         if (!vkuFormatHasDepth(depth_view_state->create_info.format)) {
-            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06547", objlist, depth_image_view,
+            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06547", objlist, depth_attachment_loc.dot(Field::imageView),
                              "was created with a format (%s) that does not have a depth aspect.",
                              string_VkFormat(depth_view_state->create_info.format));
         }
 
-        const VkComponentMapping components = depth_view_state->create_info.components;
-        if (!IsIdentitySwizzle(components)) {
-            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-09481", objlist, depth_image_view,
-                             "has a non-identiy swizzle component, here are the actual swizzle values:\n%s",
-                             string_VkComponentMapping(components).c_str());
-        }
-
-        if (rendering_info.viewMask == 0 && rendering_info.layerCount > depth_view_state->normalized_subresource_range.layerCount) {
-            skip |= LogError("VUID-VkRenderingInfo-viewMask-10860", objlist, depth_attachment_loc.dot(Field::layerCount),
-                             "(%" PRIu32 ") is greater than the imageView which was created with a layerCount of %" PRIu32 ".",
-                             rendering_info.layerCount, depth_view_state->normalized_subresource_range.layerCount);
-        }
-
-        if (rendering_info.viewMask != 0 &&
-            depth_view_state->normalized_subresource_range.layerCount <= (uint32_t)MostSignificantBit(rendering_info.viewMask)) {
-            skip |= LogError("VUID-VkRenderingInfo-viewMask-12404", objlist, depth_image_view,
-                             "must have a layerCount (%" PRIu32
-                             ") greater than the most significant bit index (%d) in viewMask (0x%" PRIx32 ")",
-                             depth_view_state->normalized_subresource_range.layerCount, MostSignificantBit(rendering_info.viewMask),
-                             rendering_info.viewMask);
-        }
-
-        skip |= ValidateRenderingInfoAttachmentDeviceGroup(image_state, rendering_info, objlist, depth_image_view);
+        skip |= ValidateRenderingInfoAttachment(*depth_view_state, rendering_info, objlist, depth_attachment_loc);
     }
 
     if (depth_attachment.resolveMode != VK_RESOLVE_MODE_NONE) {
@@ -4439,44 +4452,20 @@ bool CoreChecks::ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffe
         ASSERT_AND_RETURN_SKIP(stencil_view_state);
         const vvl::Image& image_state = *stencil_view_state->image_state;
         const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state.Handle());
-        const Location stencil_image_view = stencil_attachment_loc.dot(Field::imageView);
 
         if (!(stencil_view_state->inherited_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-            skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-06089", objlist, stencil_image_view,
+            skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-06089", objlist, stencil_attachment_loc.dot(Field::imageView),
                              "references an image which was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.\n%s",
                              stencil_view_state->DescribeImageUsage(*this).c_str());
         }
 
         if (!vkuFormatHasStencil(stencil_view_state->create_info.format)) {
-            skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-06548", objlist, stencil_image_view,
+            skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-06548", objlist, stencil_attachment_loc.dot(Field::imageView),
                              "was created with a format (%s) that does not have a stencil aspect.",
                              string_VkFormat(stencil_view_state->create_info.format));
         }
 
-        const VkComponentMapping components = stencil_view_state->create_info.components;
-        if (!IsIdentitySwizzle(components)) {
-            skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-09483", objlist, stencil_image_view,
-                             "has a non-identiy swizzle component, here are the actual swizzle values:\n%s",
-                             string_VkComponentMapping(components).c_str());
-        }
-
-        if (rendering_info.viewMask == 0 &&
-            rendering_info.layerCount > stencil_view_state->normalized_subresource_range.layerCount) {
-            skip |= LogError("VUID-VkRenderingInfo-viewMask-10861", objlist, stencil_attachment_loc.dot(Field::layerCount),
-                             "(%" PRIu32 ") is greater than the imageView which was created with a layerCount of %" PRIu32 ".",
-                             rendering_info.layerCount, stencil_view_state->normalized_subresource_range.layerCount);
-        }
-
-        if (rendering_info.viewMask != 0 &&
-            stencil_view_state->normalized_subresource_range.layerCount <= (uint32_t)MostSignificantBit(rendering_info.viewMask)) {
-            skip |= LogError("VUID-VkRenderingInfo-viewMask-12405", objlist, stencil_image_view,
-                             "must have a layerCount (%" PRIu32
-                             ") greater than the most significant bit index (%d) in viewMask (0x%" PRIx32 ")",
-                             stencil_view_state->normalized_subresource_range.layerCount,
-                             MostSignificantBit(rendering_info.viewMask), rendering_info.viewMask);
-        }
-
-        skip |= ValidateRenderingInfoAttachmentDeviceGroup(image_state, rendering_info, objlist, stencil_image_view);
+        skip |= ValidateRenderingInfoAttachment(*stencil_view_state, rendering_info, objlist, stencil_attachment_loc);
     }
     if (stencil_attachment.resolveMode != VK_RESOLVE_MODE_NONE) {
         if (stencil_attachment.resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID) {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1706,8 +1706,8 @@ class CoreChecks : public vvl::DeviceProxy {
                                                                    const VkCommandBufferInheritanceInfo& info,
                                                                    const VkCommandBufferUsageFlags begin_flags,
                                                                    const Location& inheritance_loc) const;
-    bool ValidateRenderingInfoAttachmentDeviceGroup(const vvl::Image& image_state, const VkRenderingInfo& rendering_info,
-                                                    const LogObjectList& objlist, const Location& loc) const;
+    bool ValidateRenderingInfoAttachment(const vvl::ImageView& image_view_state, const VkRenderingInfo& rendering_info,
+                                         const LogObjectList& objlist, const Location& attachment_loc) const;
     bool ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
                                                   const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -385,6 +385,8 @@ VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresource& sub) c
 }
 
 VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresourceRange& range) const {
+    // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4918
+    // When dealing with ranges you use only the base level
     return GetEffectiveSubresourceExtent(range.aspectMask, range.baseMipLevel);
 }
 

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -2716,6 +2716,58 @@ TEST_F(NegativeDynamicRendering, DeviceGroupAreaGreaterThanAttachmentExtent) {
     m_command_buffer.End();
 }
 
+TEST_F(NegativeDynamicRendering, RenderAreaMipLevel) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12772");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(Init());
+
+    const VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
+    auto image_ci = vkt::Image::ImageCreateInfo2D(1280, 687, 4, 1, color_format,
+                                                  VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    // Mip 0 size: 1280 x 687
+    // Mip 1 size: 640 x 343
+    // Mip 2 size: 320 x 171
+    vkt::Image bloom_image(*m_device, image_ci);
+    vkt::ImageView view_mip0 = bloom_image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 0, 1, 0, 1);
+    vkt::ImageView view_mip1 = bloom_image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 1, 1, 0, 1);
+    // has mip 1 and 2
+    vkt::ImageView view_mip12 = bloom_image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 1, 2, 0, 1);
+
+    VkRenderingAttachmentInfo attachment_info = vku::InitStructHelper();
+    attachment_info.imageView = view_mip0;
+    attachment_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment_info.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_info.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_info.clearValue.color = {{0.0f, 0.0f, 0.0f, 1.0f}};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.renderArea = {{0, 0}, {1280, 688}};  // over by 1
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &attachment_info;
+    m_command_buffer.Begin();
+
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06080");
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    m_errorMonitor->VerifyFound();
+
+    attachment_info.imageView = view_mip1;
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06079");
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06080");
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    m_errorMonitor->VerifyFound();
+
+    attachment_info.imageView = view_mip12;
+    rendering_info.renderArea.extent = {640 + 320, 343 + 171};
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06079");
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06080");
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleRenderPass) {
     TEST_DESCRIPTION("Execute secondary command buffers within render pass instance with incompatible render pass");
 

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -2178,3 +2178,134 @@ TEST_F(PositiveDynamicRendering, QueryDynamicRenderingTileProperties) {
     VkTilePropertiesQCOM tile_properties = vku::InitStructHelper();
     vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_properties);
 }
+
+TEST_F(PositiveDynamicRendering, RenderAreaMipLevel) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12772");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(Init());
+
+    const VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 64, 4, 1, color_format,
+                                                  VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+
+    // Mip 0 size: 128 x 64
+    // Mip 1 size: 64 x 32
+    // Mip 2 size: 32 x 16
+    // Mip 3 size: 16 x 8
+    vkt::Image bloom_image(*m_device, image_ci);
+    vkt::ImageView view_mip0 = bloom_image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 0, 1, 0, 1);
+    vkt::ImageView view_mip1 = bloom_image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 1, 1, 0, 1);
+    vkt::ImageView view_mip2 = bloom_image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 2, 1, 0, 1);
+    vkt::ImageView view_mip3 = bloom_image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 3, 1, 0, 1);
+
+    VkPipelineRenderingCreateInfo rendering_ci = vku::InitStructHelper();
+    rendering_ci.colorAttachmentCount = 1;
+    rendering_ci.pColorAttachmentFormats = &color_format;
+
+    CreatePipelineHelper pipe(*this, &rendering_ci);
+    pipe.CreateGraphicsPipeline();
+    m_command_buffer.Begin();
+
+    VkRenderingAttachmentInfo attachment_info = vku::InitStructHelper();
+    attachment_info.imageView = view_mip0;
+    attachment_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment_info.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_info.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_info.clearValue.color = {{0.0f, 0.0f, 0.0f, 1.0f}};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.renderArea = {{0, 0}, {128, 64}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &attachment_info;
+
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    vk::CmdEndRendering(m_command_buffer);
+    m_command_buffer.FullMemoryBarrier();
+
+    attachment_info.imageView = view_mip1;
+    rendering_info.renderArea.extent = {64, 32};
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    vk::CmdEndRendering(m_command_buffer);
+    m_command_buffer.FullMemoryBarrier();
+
+    attachment_info.imageView = view_mip2;
+    rendering_info.renderArea.extent = {32, 16};
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    vk::CmdEndRendering(m_command_buffer);
+    m_command_buffer.FullMemoryBarrier();
+
+    attachment_info.imageView = view_mip3;
+    rendering_info.renderArea.extent = {16, 8};
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    vk::CmdEndRendering(m_command_buffer);
+
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveDynamicRendering, RenderAreaMipLevelMultipleLevels) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12772");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(Init());
+
+    const VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 64, 4, 1, color_format,
+                                                  VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+
+    // Mip 0 size: 128 x 64
+    // Mip 1 size: 64 x 32
+    // Mip 2 size: 32 x 16
+    // Mip 3 size: 16 x 8
+    vkt::Image bloom_image(*m_device, image_ci);
+    vkt::ImageView view_mip0 = bloom_image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 0, 1, 0, 1);
+    vkt::ImageView view_mip123 = bloom_image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 1, 3, 0, 1);
+
+    VkPipelineRenderingCreateInfo rendering_ci = vku::InitStructHelper();
+    rendering_ci.colorAttachmentCount = 1;
+    rendering_ci.pColorAttachmentFormats = &color_format;
+
+    CreatePipelineHelper pipe(*this, &rendering_ci);
+    pipe.CreateGraphicsPipeline();
+    m_command_buffer.Begin();
+
+    VkRenderingAttachmentInfo attachment_info = vku::InitStructHelper();
+    attachment_info.imageView = view_mip0;
+    attachment_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment_info.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_info.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_info.clearValue.color = {{0.0f, 0.0f, 0.0f, 1.0f}};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.renderArea = {{0, 0}, {128, 64}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &attachment_info;
+
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    vk::CmdEndRendering(m_command_buffer);
+    m_command_buffer.FullMemoryBarrier();
+
+    // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4918
+    // only the base mip should be rendered to
+    attachment_info.imageView = view_mip123;
+    rendering_info.renderArea.extent = {64, 32};
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    vk::CmdEndRendering(m_command_buffer);
+    m_command_buffer.FullMemoryBarrier();
+
+    m_command_buffer.End();
+}


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12772

will now properly generate

```
Validation Error: [ VUID-VkRenderingInfo-pNext-06079 ] | MessageID = 0xde21c6b
vkCmdBeginRendering(): pRenderingInfo->pColorAttachments[0].imageView width (640) is less than pRenderingInfo->renderArea.offset.x (0) + pRenderingInfo->renderArea.extent.width (1280).
The VkImageView baseMipLevel (1) has an effective extent [width = 640, height = 343, depth = 1] based off the VkImage extent [width = 1280, height = 687, depth = 1]
Hint: Did you forget to adjust the renderArea::extent for the mip level?
```