### PR TITLE
layers: Add multiple-wait-queues vuid check

### DIFF
--- a/layers/chassis/dispatch_object.h
+++ b/layers/chassis/dispatch_object.h
@@ -124,6 +124,7 @@ struct DeviceExtensionProperties {
     VkPhysicalDeviceShaderLongVectorPropertiesEXT shader_long_vector_props;
     VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props;
     VkPhysicalDeviceImageProcessing2PropertiesQCOM image_processing2_props;
+    VkPhysicalDeviceShaderMultipleWaitQueuesPropertiesQCOM shader_multiple_wait_queues_props;
 };
 
 // This object holds all static state for the device (device properties, enabled extensions/features, etc.)

--- a/layers/chassis/dispatch_object_manual.cpp
+++ b/layers/chassis/dispatch_object_manual.cpp
@@ -503,6 +503,8 @@ StatelessDeviceData::StatelessDeviceData(DispatchInstance* instance, VkPhysicalD
                                              &phys_dev_ext_props.tile_shading_props);
     instance->GetPhysicalDeviceExtProperties(physical_device, extensions.vk_qcom_image_processing2,
                                              &phys_dev_ext_props.image_processing2_props);
+    instance->GetPhysicalDeviceExtProperties(physical_device, extensions.vk_qcom_shader_multiple_wait_queues,
+                                             &phys_dev_ext_props.shader_multiple_wait_queues_props);
 
     // None of these "check if supported" features are possible without first having gpdp2 first
     if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1067,6 +1067,12 @@ Module::StaticData::StaticData(const Module& module_state, bool parse, Stateless
                 }
                 break;
 
+            case spv::OpLoopMerge:
+                if (stateless_data) {
+                    stateless_data->loop_merge_inst.push_back(&insn);
+                }
+                break;
+
             // Execution Mode
             case spv::OpExecutionMode:
             case spv::OpExecutionModeId: {

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -674,6 +674,7 @@ struct StatelessData {
     std::vector<const Instruction *> fma_inst;
     std::vector<const Instruction *> tensor_inst;
     std::vector<const Instruction *> image_texel_pointer_inst;
+    std::vector<const Instruction *> loop_merge_inst;
 
     // simpler to just track all OpExecutionModeId and parse things needed later
     std::vector<const Instruction *> execution_mode_id_inst;

--- a/layers/stateless/sl_spirv.cpp
+++ b/layers/stateless/sl_spirv.cpp
@@ -24,6 +24,7 @@
 #include "chassis/dispatch_object.h"
 #include "state_tracker/shader_instruction.h"
 #include "state_tracker/shader_module.h"
+#include "utils/math_utils.h"
 #include <inttypes.h>
 #include <vulkan/vulkan_core.h>
 #include <set>
@@ -132,6 +133,10 @@ bool SpirvValidator::Validate(const spirv::Module& module_state, const spirv::St
         skip |= ValidateTransformFeedbackEmitStreams(module_state, entry_point, stateless_data, loc);
         skip |= ValidateShaderTensor(module_state, entry_point, stateless_data, loc);
         skip |= ValidateTileShadingCapability(module_state, entry_point, stateless_data, loc);
+    }
+
+    if (enabled_features.shaderMultipleWaitQueues && module_state.HasCapability(spv::CapabilityMultipleWaitQueuesQCOM)) {
+        skip |= ValidateShaderMultipleWaitQueues(module_state, stateless_data, loc);
     }
 
     if (enabled_features.tileShading) {
@@ -1708,6 +1713,64 @@ bool SpirvValidator::ValidateTileShadingAtomicAccess(const spirv::Module& module
                                  opcode == spv::OpImageTexelPointer ? "OpImageTexelPointer" : "OpUntypedImageTexelPointerEXT",
                                  module_state.DescribeInstruction(*instruction).c_str());
             }
+        }
+    }
+
+    return skip;
+}
+
+static uint32_t GetMultipleWaitQueuesLiteralWord(const spirv::Instruction& insn) {
+    constexpr uint32_t kLoopControlWord = 3;
+    constexpr uint32_t kFirstLoopControlLiteralWord = 4;
+
+    // Note: These are the only |Loop Control| that have a lower mask value and carry a literal operand.
+    //       Only these need to be checked when counting preceding literal words.
+    //       |Unroll| and similar controls have no literal operand and are excluded.
+    constexpr uint32_t kLoopControlsWithLiteralOperands =
+        static_cast<uint32_t>(spv::LoopControlDependencyLengthMask) | spv::LoopControlMinIterationsMask |
+        spv::LoopControlMaxIterationsMask | spv::LoopControlIterationMultipleMask | spv::LoopControlPeelCountMask |
+        spv::LoopControlPartialCountMask | spv::LoopControlInitiationIntervalALTERAMask |
+        spv::LoopControlMaxConcurrencyALTERAMask | spv::LoopControlDependencyArrayALTERAMask |
+        spv::LoopControlPipelineEnableALTERAMask | spv::LoopControlLoopCoalesceALTERAMask |
+        spv::LoopControlMaxInterleavingALTERAMask | spv::LoopControlSpeculatedIterationsALTERAMask |
+        spv::LoopControlLoopCountALTERAMask | spv::LoopControlMaxReinvocationDelayALTERAMask |
+        spv::LoopControlMultipleWaitQueuesQCOMMask;
+
+    if (insn.Length() <= kLoopControlWord) {
+        return 0;
+    }
+
+    const uint32_t loop_control = insn.Word(kLoopControlWord);
+    if ((loop_control & spv::LoopControlMultipleWaitQueuesQCOMMask) == 0) {
+        return 0;
+    }
+
+    const uint32_t preceding_literal_controls =
+        loop_control & kLoopControlsWithLiteralOperands & (spv::LoopControlMultipleWaitQueuesQCOMMask - 1);
+    const uint32_t word_index = kFirstLoopControlLiteralWord + CountSetBits(preceding_literal_controls);
+
+    return insn.Length() > word_index ? word_index : 0;
+}
+
+bool SpirvValidator::ValidateShaderMultipleWaitQueues(const spirv::Module& module_state, const spirv::StatelessData& stateless_data,
+                                                      const Location& loc) const {
+    bool skip = false;
+
+    for (auto& instruction : stateless_data.loop_merge_inst) {
+        const uint32_t word_index = GetMultipleWaitQueuesLiteralWord(*instruction);
+        if (word_index == 0) {
+            continue;
+        }
+
+        const uint32_t max_wait_queues = instruction->Word(word_index);
+        if (max_wait_queues != 0 &&
+            max_wait_queues > phys_dev_ext_props.shader_multiple_wait_queues_props.maxShaderWaitQueues) {
+            skip |= LogError("VUID-RuntimeSpirv-maxShaderWaitQueues-12426", module_state.handle(), loc,
+                             "SPIR-V uses MultipleWaitQueuesQCOM with literal operand %" PRIu32
+                             ", but exceeds VkPhysicalDeviceShaderMultipleWaitQueuesPropertiesQCOM::maxShaderWaitQueues (%" PRIu32
+                             ").\n%s\n",
+                             max_wait_queues, phys_dev_ext_props.shader_multiple_wait_queues_props.maxShaderWaitQueues,
+                             module_state.DescribeInstruction(*instruction).c_str());
         }
     }
 

--- a/layers/stateless/sl_spirv.h
+++ b/layers/stateless/sl_spirv.h
@@ -98,6 +98,7 @@ class SpirvValidator : public Logger {
     bool ValidateTileShadingCapability(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
                                        const spirv::StatelessData &stateless_data, const Location &loc) const;
     bool ValidateTileShadingAtomicAccess(const spirv::Module &module_state, const spirv::StatelessData &stateless_data, const Location &loc) const;
+    bool ValidateShaderMultipleWaitQueues(const spirv::Module &module_state, const spirv::StatelessData &stateless_data, const Location &loc) const;
 
     // Auto-generated helper functions
     bool ValidateShaderCapabilitiesAndExtensions(const spirv::Module& module_state, const spirv::Instruction& insn,

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -3248,3 +3248,48 @@ TEST_F(NegativeShaderSpirv, SpecializationConstantInt8Default) {
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeShaderSpirv, LargerThanMaxShaderWaitQueues) {
+    TEST_DESCRIPTION("Try to use a MultipleWaitQueuesQCOM loop hint larger than maxShaderWaitQueues.");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_QCOM_SHADER_MULTIPLE_WAIT_QUEUES_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderMultipleWaitQueues);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceShaderMultipleWaitQueuesPropertiesQCOM wait_queues_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(wait_queues_props);
+
+    const uint32_t invalid_wait_queues = wait_queues_props.maxShaderWaitQueues > 0 ?
+                                         wait_queues_props.maxShaderWaitQueues << 1 : 1;
+
+    std::string spv_source = R"(
+               OpCapability Shader
+               OpCapability MultipleWaitQueuesQCOM
+               OpExtension "SPV_QCOM_multiple_wait_queues"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpBranch %loop
+       %loop = OpLabel
+               OpLoopMerge %merge %cont DependencyLength|MultipleWaitQueuesQCOM 1 )" +
+                    std::to_string(invalid_wait_queues) + R"(
+               OpBranchConditional %true %body %merge
+       %body = OpLabel
+               OpBranch %cont
+       %cont = OpLabel
+               OpBranch %loop
+      %merge = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-maxShaderWaitQueues-12426");
+    VkShaderObj cs{*m_device, spv_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1, SPV_SOURCE_ASM};
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -2761,3 +2761,43 @@ TEST_F(PositiveShaderSpirv, SpecializationConstantInt8) {
         VkShaderObj(*m_device, cs_src, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM, &specialization_info);
     pipe.CreateComputePipeline();
 }
+
+TEST_F(PositiveShaderSpirv, MultipleWaitQueuesAtMaxShaderWaitQueues) {
+    TEST_DESCRIPTION("Use a MultipleWaitQueuesQCOM loop hint equal to maxShaderWaitQueues.");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_QCOM_SHADER_MULTIPLE_WAIT_QUEUES_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderMultipleWaitQueues);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceShaderMultipleWaitQueuesPropertiesQCOM wait_queues_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(wait_queues_props);
+
+    std::string spv_source = R"(
+               OpCapability Shader
+               OpCapability MultipleWaitQueuesQCOM
+               OpExtension "SPV_QCOM_multiple_wait_queues"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpBranch %loop
+       %loop = OpLabel
+               OpLoopMerge %merge %cont DependencyLength|MultipleWaitQueuesQCOM 1 )" +
+                    std::to_string(wait_queues_props.maxShaderWaitQueues) + R"(
+               OpBranchConditional %true %body %merge
+       %body = OpLabel
+               OpBranch %cont
+       %cont = OpLabel
+               OpBranch %loop
+      %merge = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    VkShaderObj cs{*m_device, spv_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1, SPV_SOURCE_ASM};
+}


### PR DESCRIPTION
# Overview
Adds validation for `VK_QCOM_shader_multiple_wait_queues`:
- `VUID-RuntimeSpirv-maxShaderWaitQueues-12426`

Checks that when a SPIR-V `OpLoopMerge` sets the `MultipleWaitQueuesQCOM` loop control bit, the associated literal operand does not exceed `VkPhysicalDeviceShaderMultipleWaitQueuesPropertiesQCOM::maxShaderWaitQueues`.

# Unit Tests

| Test | VUID & Description |
|------|------|
| `LargerThanMaxShaderWaitQueues` | 12426 |
| `MultipleWaitQueuesAtMaxShaderWaitQueues` | Positive |
