### PR TITLE
dump: Use offset instead of range for reserved range

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
@@ -2043,8 +2043,10 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         ss << "- vkCmdBindResourceHeapEXT last bound the resource heap to "
            << string_range_hex(cb_state.descriptor_heap.resource_range);
         if (!cb_state.descriptor_heap.resource_reserved.empty()) {
-            ss << " (reserved range " << std::dec << cb_state.descriptor_heap.resource_reserved.size() << " bytes at "
-               << string_range_hex(cb_state.descriptor_heap.resource_reserved) << ")";
+            VkDeviceSize rr_offset =
+                cb_state.descriptor_heap.resource_reserved.begin - cb_state.descriptor_heap.resource_range.begin;
+            ss << " (reserved range: " << std::dec << cb_state.descriptor_heap.resource_reserved.size() << " bytes at offset "
+               << rr_offset << ")";
         } else {
             ss << " (no reserved range)";
         }
@@ -2055,8 +2057,9 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         ss << "- vkCmdBindSamplerHeapEXT last bound the sampler heap to "
            << string_range_hex(cb_state.descriptor_heap.sampler_range);
         if (!cb_state.descriptor_heap.sampler_reserved.empty()) {
-            ss << " (reserved range " << std::dec << cb_state.descriptor_heap.sampler_reserved.size() << " bytes at "
-               << string_range_hex(cb_state.descriptor_heap.sampler_reserved) << ")";
+            VkDeviceSize rr_offset = cb_state.descriptor_heap.sampler_reserved.begin - cb_state.descriptor_heap.sampler_range.begin;
+            ss << " (reserved range: " << std::dec << cb_state.descriptor_heap.sampler_reserved.size() << " bytes at offset "
+               << rr_offset << ")";
         } else {
             ss << " (no reserved range)";
         }


### PR DESCRIPTION
```
vkCmdBindSamplerHeapEXT last bound the sampler heap to [0x110f7a00, 0x110f9c00) (reserved range 512 bytes at [0x110f9a00, 0x110f9c00))
    - VkBuffer 0x27d1db20d20[sampler_heap], size: 8704 bytes, range: [0x110f7a00, 0x110f9c00)
```

is now

```
vkCmdBindSamplerHeapEXT last bound the sampler heap to [0x110f7a00, 0x110f9c00) (reserved range: 512 bytes at offset 8192)
    - VkBuffer 0x27d1db20d20[sampler_heap], size: 8704 bytes, range: [0x110f7a00, 0x110f9c00)
```

