### PR TITLE
build: Avoid AppleClang using the wrong headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,15 @@ find_package(VulkanHeaders ${PROJECT_VERSION} CONFIG QUIET)
 
 find_package(VulkanUtilityLibraries CONFIG QUIET)
 
+# Workaround AppleClang using the wrong headers when there are headers in /usr/local/include
+if (CMAKE_CXX_COMPILER_ID STREQUAL AppleClang AND TARGET Vulkan::Headers AND TARGET Vulkan::LayerSettings AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.25)
+    set_target_properties(Vulkan::Headers PROPERTIES SYSTEM OFF)
+    set_target_properties(Vulkan::LayerSettings PROPERTIES SYSTEM OFF)
+    set_target_properties(Vulkan::SafeStruct PROPERTIES SYSTEM OFF)
+    set_target_properties(Vulkan::UtilityHeaders PROPERTIES SYSTEM OFF)
+endif()
+
+
 find_package(SPIRV-Headers CONFIG QUIET)
 
 find_package(SPIRV-Tools-opt CONFIG QUIET)


### PR DESCRIPTION
Because of AppleClang always adding /usr/local/include and CMake using -isystem by default in 3.25+, builds on MacOS could use system installed headers by mistake. Because this repo has code generated against a specific version of the Vulkan Headers, if the system installed headers are older (which is usually the case for developers of this repo) then the build fails.