### PR TITLE
sync: Avoid GetCurrentAccessContext where context is known

### DIFF
--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -349,7 +349,7 @@ bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject& error
 
         const AttachmentAccess attachment_access = GetAttachmentAccess(attachment.GetOrdering(), AttachmentAccessType::LoadOp);
         ImageRangeGen range_gen = attachment.GetRangeGen(info.info.viewMask);
-        const HazardResult hazard = GetCurrentAccessContext().DetectAttachmentHazard(range_gen, load_index, attachment_access);
+        const HazardResult hazard = GetCbAccessContext().DetectAttachmentHazard(range_gen, load_index, attachment_access);
         if (hazard.IsHazard()) {
             LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
 
@@ -376,7 +376,7 @@ void CommandBufferAccessContext::RecordBeginRendering(BeginRenderingCmdState& cm
 
     const DynamicRenderingInfo& info = cmd_state.GetRenderingInfo();
     if ((info.info.flags & VK_RENDERING_RESUMING_BIT) == 0) {
-        AccessContext& access_context = GetCurrentAccessContext();
+        AccessContext& access_context = GetCbAccessContext();
         for (size_t i = 0; i < info.attachments.size(); i++) {
             const DynamicRenderingInfo::Attachment& attachment = info.attachments[i];
             const SyncAccessIndex load_index = attachment.GetLoadUsage();
@@ -488,7 +488,7 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject& record_o
     }
 
     auto store_tag = NextCommandTag(record_obj.location.function, SubCommandType::kStoreOp);
-    AccessContext& access_context = GetCurrentAccessContext();
+    AccessContext& access_context = GetCbAccessContext();
 
     for (const auto& attachment : dynamic_rendering_info_->attachments) {
         if (attachment.resolve_gen) {
@@ -951,7 +951,7 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
     if (!pipe || pipe->RasterizationDisabled()) return skip;
 
     const auto& list = pipe->fs_writable_output_location_list;
-    const AccessContext& access_context = GetCurrentAccessContext();
+    const AccessContext& access_context = GetCbAccessContext();
 
     const DynamicRenderingInfo& info = *dynamic_rendering_info_;
     for (const auto output_location : list) {
@@ -1020,7 +1020,7 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
     }
 
     const auto& list = pipe->fs_writable_output_location_list;
-    auto& access_context = GetCurrentAccessContext();
+    auto& access_context = GetCbAccessContext();
 
     const DynamicRenderingInfo& info = *dynamic_rendering_info_;
     for (const auto output_location : list) {
@@ -1362,7 +1362,7 @@ ResourceUsageTag CommandBufferAccessContext::RecordEndRenderPass(vvl::Func comma
 void CommandBufferAccessContext::RecordDestroyEvent(vvl::Event* event_state) { GetEventsContext().Destroy(event_state); }
 
 void CommandBufferAccessContext::RecordExecutedCommandBuffer(const CommandBufferAccessContext& recorded_cb_context) {
-    const AccessContext& recorded_context = recorded_cb_context.GetCurrentAccessContext();
+    const AccessContext& recorded_context = recorded_cb_context.GetCbAccessContext();
 
     // Just run through the barriers ignoring the usage from the recorded context, as Resolve will overwrite outdated state
     const ResourceUsageTag base_tag = GetTagCount();
@@ -1565,7 +1565,7 @@ CommandBufferSubState::CommandBufferSubState(SyncValidator& dev, vvl::CommandBuf
 }
 
 void CommandBufferSubState::End() {
-    access_context.GetCurrentAccessContext().Finalize();
+    access_context.GetCbAccessContext().Finalize();
 
     // For threads that are dedicated to recording command buffers but do not submit themselves,
     // the end of recording is a logical point to update memory stats
@@ -1593,7 +1593,7 @@ void CommandBufferSubState::NotifyInvalidate(const vvl::StateObject::NodeList& i
 void CommandBufferSubState::RecordCopyBuffer(vvl::Buffer& src_buffer_state, vvl::Buffer& dst_buffer_state, uint32_t region_count,
                                              const VkBufferCopy* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
@@ -1610,7 +1610,7 @@ void CommandBufferSubState::RecordCopyBuffer(vvl::Buffer& src_buffer_state, vvl:
 void CommandBufferSubState::RecordCopyBuffer2(vvl::Buffer& src_buffer_state, vvl::Buffer& dst_buffer_state, uint32_t region_count,
                                               const VkBufferCopy2* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
@@ -1628,7 +1628,7 @@ void CommandBufferSubState::RecordCopyImage(vvl::Image& src_image_state, vvl::Im
                                             VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
                                             const VkImageCopy* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
@@ -1645,7 +1645,7 @@ void CommandBufferSubState::RecordCopyImage2(vvl::Image& src_image_state, vvl::I
                                              VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
                                              const VkImageCopy2* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
@@ -1661,7 +1661,7 @@ void CommandBufferSubState::RecordCopyImage2(vvl::Image& src_image_state, vvl::I
 void CommandBufferSubState::RecordCopyBufferToImage(vvl::Buffer& src_buffer_state, vvl::Image& dst_image_state, VkImageLayout,
                                                     uint32_t region_count, const VkBufferImageCopy* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
@@ -1679,7 +1679,7 @@ void CommandBufferSubState::RecordCopyBufferToImage2(vvl::Buffer& src_buffer_sta
                                                      uint32_t region_count, const VkBufferImageCopy2* regions,
                                                      const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
@@ -1697,7 +1697,7 @@ void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image& src_image_state,
                                                     VkImageLayout src_image_layout, uint32_t region_count,
                                                     const VkBufferImageCopy* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
@@ -1715,7 +1715,7 @@ void CommandBufferSubState::RecordCopyImageToBuffer2(vvl::Image& src_image_state
                                                      VkImageLayout src_image_layout, uint32_t region_count,
                                                      const VkBufferImageCopy2* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
@@ -1733,7 +1733,7 @@ void CommandBufferSubState::RecordBlitImage(vvl::Image& src_image_state, vvl::Im
                                             VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
                                             const VkImageBlit* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
@@ -1763,7 +1763,7 @@ void CommandBufferSubState::RecordBlitImage2(vvl::Image& src_image_state, vvl::I
                                              VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
                                              const VkImageBlit2* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
@@ -1792,7 +1792,7 @@ void CommandBufferSubState::RecordBlitImage2(vvl::Image& src_image_state, vvl::I
 void CommandBufferSubState::RecordResolveImage(vvl::Image& src_image_state, vvl::Image& dst_image_state, uint32_t region_count,
                                                const VkImageResolve* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
@@ -1810,7 +1810,7 @@ void CommandBufferSubState::RecordResolveImage(vvl::Image& src_image_state, vvl:
 void CommandBufferSubState::RecordResolveImage2(vvl::Image& src_image_state, vvl::Image& dst_image_state, uint32_t region_count,
                                                 const VkImageResolve2* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
@@ -1829,7 +1829,7 @@ void CommandBufferSubState::RecordClearColorImage(vvl::Image& image_state, VkIma
                                                   uint32_t range_count, const VkImageSubresourceRange* ranges,
                                                   const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     access_context.AddCommandHandle(tag, image_state.Handle());
 
@@ -1843,7 +1843,7 @@ void CommandBufferSubState::RecordClearDepthStencilImage(vvl::Image& image_state
                                                          uint32_t range_count, const VkImageSubresourceRange* ranges,
                                                          const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     access_context.AddCommandHandle(tag, image_state.Handle());
 
@@ -1867,7 +1867,7 @@ void CommandBufferSubState::RecordClearAttachments(uint32_t attachment_count, co
 void CommandBufferSubState::RecordFillBuffer(vvl::Buffer& buffer_state, VkDeviceSize offset, VkDeviceSize size,
                                              const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     const AccessRange range = MakeRange(buffer_state, offset, size);
     const ResourceUsageTagEx tag_ex = access_context.AddCommandHandle(tag, buffer_state.Handle());
@@ -1877,7 +1877,7 @@ void CommandBufferSubState::RecordFillBuffer(vvl::Buffer& buffer_state, VkDevice
 void CommandBufferSubState::RecordUpdateBuffer(vvl::Buffer& buffer_state, VkDeviceSize offset, VkDeviceSize size,
                                                const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     // VK_WHOLE_SIZE not allowed
     const AccessRange range = MakeRange(offset, size);
@@ -1888,7 +1888,7 @@ void CommandBufferSubState::RecordUpdateBuffer(vvl::Buffer& buffer_state, VkDevi
 void CommandBufferSubState::RecordDecodeVideo(vvl::VideoSession& vs_state, const VkVideoDecodeInfoKHR& decode_info,
                                               const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     if (auto src_buffer = base.dev_data.Get<vvl::Buffer>(decode_info.srcBuffer)) {
         const AccessRange src_range = MakeRange(*src_buffer, decode_info.srcBufferOffset, decode_info.srcBufferRange);
@@ -1922,7 +1922,7 @@ void CommandBufferSubState::RecordDecodeVideo(vvl::VideoSession& vs_state, const
 void CommandBufferSubState::RecordEncodeVideo(vvl::VideoSession& vs_state, const VkVideoEncodeInfoKHR& encode_info,
                                               const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     if (auto src_buffer = base.dev_data.Get<vvl::Buffer>(encode_info.dstBuffer)) {
         const AccessRange src_range = MakeRange(*src_buffer, encode_info.dstBufferOffset, encode_info.dstBufferRange);
@@ -1974,7 +1974,7 @@ void CommandBufferSubState::RecordCopyQueryPoolResults(vvl::QueryPool& pool_stat
         return;
     }
     const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCurrentAccessContext();
+    AccessContext& context = access_context.GetCbAccessContext();
 
     const uint32_t query_size = (flags & VK_QUERY_RESULT_64_BIT) ? 8 : 4;
     const VkDeviceSize range_size = (query_count - 1) * stride + query_size;

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -216,6 +216,12 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
 
     QueueId GetQueueId() const override;
 
+    // The command buffer's own access context. Subpass contexts exist only inside a vkCmdBeginRenderPass
+    // instance, so use this instead of GetCurrentAccessContext() anywhere else. Dynamic rendering has no
+    // subpass contexts, so this applies there too.
+    AccessContext& GetCbAccessContext() { return cb_access_context_; }
+    const AccessContext& GetCbAccessContext() const { return cb_access_context_; }
+
     RenderPassAccessContext *GetCurrentRenderPassContext() { return current_renderpass_context_; }
     const RenderPassAccessContext *GetCurrentRenderPassContext() const { return current_renderpass_context_; }
     uint32_t GetCurrentRenderPassInstanceId() const { return current_render_pass_instance_id_; }

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -192,7 +192,7 @@ bool ReplayState::DetectFirstUseHazard(const ResourceUsageRange& first_use_range
         return skip;
     }
     const AccessContext& recorded_access_context =
-        rp_replay.replay_context ? *rp_replay.replay_context : recorded_context.GetCurrentAccessContext();
+        rp_replay.replay_context ? *rp_replay.replay_context : recorded_context.GetCbAccessContext();
     const HazardResult hazard = recorded_access_context.DetectFirstUseHazard(exec_context.GetQueueId(), first_use_range,
                                                                              exec_context.GetCurrentAccessContext());
     if (hazard.IsHazard()) {

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -296,7 +296,7 @@ void QueueBatchContext::Trim() {
 }
 
 void QueueBatchContext::ResolveSubmittedCommandBuffer(const AccessContext& recorded_context, ResourceUsageTag offset) {
-    GetCurrentAccessContext().ResolveFromContext(QueueTagOffsetBarrierAction(GetQueueId(), offset), recorded_context);
+    GetAccessContext().ResolveFromContext(QueueTagOffsetBarrierAction(GetQueueId(), offset), recorded_context);
 }
 
 VulkanTypedHandle QueueBatchContext::Handle() const { return queue_state_->GetQueue()->Handle(); }
@@ -632,7 +632,7 @@ std::vector<BatchContextPtr> QueueBatchContext::RegisterAsyncContexts(const std:
         }
 
         // The start of the asynchronous access range for a given queue is one more than the highest tagged reference
-        access_context_.AddAsyncContext(async_batch->GetCurrentAccessContext(), sync_tag, async_batch->GetQueueId());
+        access_context_.AddAsyncContext(async_batch->GetAccessContext(), sync_tag, async_batch->GetQueueId());
         // We need to snapshot the async log information for async hazard reporting
         batch_log_.Import(async_batch->batch_log_);
     }
@@ -742,7 +742,7 @@ bool QueueBatchContext::ValidateSubmit(const std::vector<CommandBufferConstPtr>&
 
             // The barriers have already been applied in ValidatFirstUse
             batch_log_.Import(batch, access_context, current_label_stack);
-            ResolveSubmittedCommandBuffer(access_context.GetCurrentAccessContext(), batch.base_tag);
+            ResolveSubmittedCommandBuffer(access_context.GetCbAccessContext(), batch.base_tag);
             batch.base_tag += access_context.GetTagCount();
         }
         // Apply debug label commands

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -377,7 +377,7 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_context.GetCbAccessContext();
 
     // If we have no previous accesses, we have no hazards
     auto src_buffer = Get<vvl::Buffer>(srcBuffer);
@@ -416,7 +416,7 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_context.GetCbAccessContext();
 
     // If we have no previous accesses, we have no hazards
     auto src_buffer = Get<vvl::Buffer>(pCopyBufferInfo->srcBuffer);
@@ -464,7 +464,7 @@ bool SyncValidator::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, V
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     auto src_image = Get<vvl::Image>(srcImage);
     auto dst_image = Get<vvl::Image>(dstImage);
@@ -505,7 +505,7 @@ bool SyncValidator::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, 
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     auto src_image = Get<vvl::Image>(pCopyImageInfo->srcImage);
     auto dst_image = Get<vvl::Image>(pCopyImageInfo->dstImage);
@@ -767,7 +767,7 @@ bool SyncValidator::ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const
     // TODO: investigate if using nullptr in InitFrom is safe (this just follows the initial implementation - it assumes
     // that array of subpass dependencies won't be indexed, but it's not obvious).
     temp_context.InitFrom(subpass_zero, cb_context.GetQueueFlags(), rp_state->subpass_dependency_infos, nullptr,
-                          cb_context.GetCurrentAccessContext());
+                          cb_context.GetCbAccessContext());
 
     // Validate attachment operations
     const uint32_t render_pass_instance_id = cb_context.GetCurrentRenderPassInstanceId();
@@ -931,7 +931,7 @@ bool SyncValidator::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, 
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     auto src_buffer = Get<vvl::Buffer>(srcBuffer);
     auto dst_image = Get<vvl::Image>(dstImage);
@@ -995,7 +995,7 @@ bool SyncValidator::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, 
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     auto src_image = Get<vvl::Image>(srcImage);
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
@@ -1055,7 +1055,7 @@ bool SyncValidator::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage 
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     auto src_image = Get<vvl::Image>(srcImage);
     auto dst_image = Get<vvl::Image>(dstImage);
@@ -1735,7 +1735,7 @@ bool SyncValidator::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuf
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     if (auto image_state = Get<vvl::Image>(image)) {
         for (const auto [range_index, range] : vvl::enumerate(pRanges, rangeCount)) {
@@ -1759,7 +1759,7 @@ bool SyncValidator::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer com
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     if (auto image_state = Get<vvl::Image>(image)) {
         for (const auto [range_index, range] : vvl::enumerate(pRanges, rangeCount)) {
@@ -1796,7 +1796,7 @@ bool SyncValidator::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer comma
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
 
@@ -1824,7 +1824,7 @@ bool SyncValidator::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, 
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
 
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
 
@@ -1848,7 +1848,7 @@ bool SyncValidator::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     auto src_image = Get<vvl::Image>(srcImage);
     auto dst_image = Get<vvl::Image>(dstImage);
@@ -1888,7 +1888,7 @@ bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     const Location image_info_loc = error_obj.location.dot(Field::pResolveImageInfo);
     auto src_image = Get<vvl::Image>(pResolveImageInfo->srcImage);
@@ -1938,7 +1938,7 @@ bool SyncValidator::PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
 
@@ -1998,7 +1998,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     const auto vs_state = cb_state->bound_video_session.get();
     if (!vs_state) return skip;
@@ -2086,7 +2086,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_access_context.GetCbAccessContext();
 
     const auto vs_state = cb_state->bound_video_session.get();
     if (!vs_state) return skip;
@@ -2296,7 +2296,7 @@ void SyncValidator::RecordCmdSetEvent(CommandBufferAccessContext& cb_context, st
     // of access history, the current access context (include barrier state for chaining)
     // won't necessarily contain the needed information at Wait or Submit time reference.
     auto src_access_context = std::make_shared<AccessContext>(*this);
-    src_access_context->InitFrom(cb_context.GetCurrentAccessContext());
+    src_access_context->InitFrom(cb_context.GetCbAccessContext());
 
     ApplySetEvent(cb_context, event, src_exec_scope, src_access_context, tag, loc.function);
 
@@ -2723,7 +2723,7 @@ bool SyncValidator::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuf
 
         // The barriers have already been applied in ValidatFirstUse
         proxy_cb_context.ImportRecordedAccessLog(recorded_cb_context);
-        proxy_cb_context.ResolveExecutedCommandBuffer(recorded_cb_context.GetCurrentAccessContext(), base_tag);
+        proxy_cb_context.ResolveExecutedCommandBuffer(recorded_cb_context.GetCbAccessContext(), base_tag);
     }
     proxy_label_commands.clear();
 
@@ -3389,7 +3389,7 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_context.GetCbAccessContext();
 
     for (const auto [i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, i);
@@ -3498,7 +3498,7 @@ void SyncValidator::PostCallRecordCmdBuildAccelerationStructuresKHR(
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    AccessContext& context = cb_context.GetCurrentAccessContext();
+    AccessContext& context = cb_context.GetCbAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
@@ -3587,7 +3587,7 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuff
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_context.GetCbAccessContext();
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
@@ -3629,7 +3629,7 @@ void SyncValidator::PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffe
                                                                   const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    AccessContext& context = cb_context.GetCurrentAccessContext();
+    AccessContext& context = cb_context.GetCbAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
@@ -3657,7 +3657,7 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkCom
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_context.GetCbAccessContext();
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
@@ -3690,7 +3690,7 @@ void SyncValidator::PostCallRecordCmdCopyAccelerationStructureToMemoryKHR(VkComm
                                                                           const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    AccessContext& context = cb_context.GetCurrentAccessContext();
+    AccessContext& context = cb_context.GetCbAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
@@ -3710,7 +3710,7 @@ bool SyncValidator::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkCom
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCurrentAccessContext();
+    const AccessContext& context = cb_context.GetCbAccessContext();
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
@@ -3743,7 +3743,7 @@ void SyncValidator::PostCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkComm
                                                                           const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    AccessContext& context = cb_context.GetCurrentAccessContext();
+    AccessContext& context = cb_context.GetCbAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
@@ -3771,7 +3771,7 @@ bool SyncValidator::ValidateSbtBuffer(const CommandBufferAccessContext& cb_conte
     const VkDeviceSize offset = p_sbt_address_region->deviceAddress - p_sbt_buffer->deviceAddress;
     const AccessRange sbt_range = MakeRange(*p_sbt_buffer, offset, p_sbt_address_region->size);
 
-    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
     auto hazard = access_context.DetectHazard(*p_sbt_buffer, SYNC_RAY_TRACING_SHADER_SHADER_BINDING_TABLE_READ, sbt_range);
     if (hazard.IsHazard()) {
         const LogObjectList objlist(cb_context.GetCBState().Handle(), p_sbt_buffer->Handle());
@@ -3796,7 +3796,7 @@ void SyncValidator::RecordSbtBuffer(CommandBufferAccessContext& cb_context,
     const AccessRange sbt_range = MakeRange(*p_sbt_buffer, offset, p_sbt_address_region->size);
 
     const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, p_sbt_buffer->Handle());
-    AccessContext& access_context = cb_context.GetCurrentAccessContext();
+    AccessContext& access_context = cb_context.GetCbAccessContext();
     access_context.UpdateAccessState(*p_sbt_buffer, SYNC_RAY_TRACING_SHADER_SHADER_BINDING_TABLE_READ, sbt_range, tag_ex);
 }
 
@@ -3846,7 +3846,7 @@ bool SyncValidator::PreCallValidateCmdTraceRaysIndirectKHR(VkCommandBuffer comma
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
     skip |= ValidateSbtBuffer(cb_context, pRaygenShaderBindingTable, error_obj.location, "raygen");
@@ -3887,7 +3887,7 @@ bool SyncValidator::PreCallValidateCmdTraceRaysIndirect2KHR(VkCommandBuffer comm
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
 


### PR DESCRIPTION
`GetCurrentAccessContext` has dynamic behavior (selects either regular context or render pass context). For functions that are used only outside of render pass instance (legacy one) we can directly use regular context.