### PR TITLE
cmake: Fix multi-config generator builds

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -288,6 +288,10 @@ jobs:
     strategy:
       matrix:
         arch: [ amd64 ]
+    env:
+      # Exercises the multi-config generator path (Visual Studio, Xcode, Ninja Multi-Config),
+      # where switching Debug/Release/RelWithDebInfo must work from a single configure.
+      CMAKE_GENERATOR: Ninja Multi-Config
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -309,17 +313,26 @@ jobs:
             ${{ github.workspace }}/external/Vulkan-Headers/build/install
             ${{ github.workspace }}/external/Vulkan-Utility-Libraries/build/install
             ${{ github.workspace }}/external/slang/install
-          key: windows-dependencies-${{ matrix.arch }}-${{ hashfiles('scripts/known_good.json') }}
-      - run: |
+          key: windows-dependencies-multi-config-${{ matrix.arch }}-${{ hashfiles('scripts/known_good.json') }}
+      - name: Configure (once, for every --config used below)
+        run: |
          cmake -S. -B build `
          -D BUILD_WERROR=ON `
          -D UPDATE_DEPS=ON `
-         -D CMAKE_BUILD_TYPE=Debug `
          -D BUILD_TESTS=ON `
          -D UPDATE_DEPS_SKIP_EXISTING_INSTALL=ON `
          -D UPDATE_DEPS_DIR=${{ github.workspace }}/external
-      - run: cmake --build build
-      - run: cmake --install build --prefix ${{ github.workspace }}/install
+      - name: Build and install Debug, Release and RelWithDebInfo without reconfiguring
+        run: |
+         foreach ($config in "Debug", "Release", "RelWithDebInfo") {
+           # BUILD_WERROR's link_options(/WX) turns any link warning (e.g. LNK4098, mismatched
+           # Debug/Release runtimes) into a build failure, so a non-zero exit here already covers it.
+           cmake --build build --config $config
+           if ($LASTEXITCODE -ne 0) {
+             throw "cmake --build failed for config $config"
+           }
+           cmake --install build --config $config --prefix ${{ github.workspace }}/install/$config
+         }
 
   windowsUpload:
     needs: windows

--- a/BUILD.md
+++ b/BUILD.md
@@ -57,6 +57,11 @@ Misc Useful Information:
 
 - By default `UPDATE_DEPS` is `ON` and simply use `-D UPDATE_DEPS=OFF` if you don't want to use it
 - You can run `update_deps.py` manually but it isn't recommended for most users.
+- For multi-config generators (Visual Studio, Xcode, Ninja Multi-Config), dependencies are always
+  prebuilt for both `Debug` and `Release` (regardless of `CMAKE_CONFIGURATION_TYPES`), so switching
+  between those configs in the IDE works without having to reconfigure. `RelWithDebInfo` and
+  `MinSizeRel` builds transparently use the `Release` dependency binaries (matching what `vcpkg` does
+  for the same reason), so those configs work out of the box too, without a separate prebuild step.
 
 ### How to test new dependency versions
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,18 @@ endif()
 option(BUILD_WERROR "Treat compiler warnings as errors")
 if (BUILD_WERROR)
     add_compile_options("$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>")
+    # MSVC only: turns link.exe warnings (e.g. LNK4098, mismatched Debug/Release runtimes) into
+    # build failures too. There's no cross-platform link.exe/ld equivalent to add here.
+    # TODO: replace with CMAKE_LINK_WARNING_AS_ERROR once the minimum CMake version is >= 4.0.
+    #
+    # LNK4099 (PDB for a prebuilt dependency .lib not found) is ignored: it's a pre-existing,
+    # benign issue independent of this fix - our dependencies' static libraries don't carry
+    # their compiler-generated PDBs (CMake's COMPILE_PDB_NAME isn't installable for STATIC_LIBRARY
+    # targets via $<TARGET_PDB_FILE:...>), so the linker always falls back to no debug info for
+    # those objects. It was already happening before /WX was added to the linker; /WX would just
+    # newly turn it into a hard failure. Fixing it for real means installing each dependency's own
+    # PDB, which requires patching that dependency's CMakeLists.txt, not something to do here.
+    add_link_options("$<$<CXX_COMPILER_ID:MSVC>:/WX;/IGNORE:4099>")
 endif()
 
 option(VVL_ENABLE_ASAN "Use address sanitization")

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -32,18 +32,50 @@ if (UPDATE_DEPS)
         list(APPEND update_dep_command "${CMAKE_GENERATOR_PLATFORM}")
     endif()
 
-    if (NOT CMAKE_BUILD_TYPE)
-        message(WARNING "CMAKE_BUILD_TYPE not set. Using Debug for dependency build type")
-        set(_build_type Debug)
+    get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
+    if (_is_multi_config)
+        # CMAKE_BUILD_TYPE doesn't apply to multi-config generators (Visual
+        # Studio, Xcode, Ninja Multi-Config): the config is picked at build
+        # time, not configure time. Always prebuild dependencies for exactly
+        # Debug and Release into one shared install tree regardless of
+        # CMAKE_CONFIGURATION_TYPES, so switching configs in the IDE without
+        # reconfiguring just works. (See update_deps.py's CMAKE_DEBUG_POSTFIX
+        # handling for how Debug and Release avoid clobbering each other's
+        # binaries in that shared tree.)
+        set(_update_deps_configs Debug Release)
+        set(UPDATE_DEPS_DIR_SUFFIX "multi-config")
+
+        # RelWithDebInfo/MinSizeRel have no dependency binaries of their own,
+        # so map them onto the Release ones instead (PARENT_SCOPE so it's set
+        # before the root CMakeLists.txt's find_package() calls run). The
+        # trailing empty entry isn't a typo - it makes targets with only a
+        # plain (non-per-config) IMPORTED_LOCATION still resolve correctly.
+        # Must stay confined to this branch: for single-config generators,
+        # CMAKE_BUILD_TYPE can itself be RelWithDebInfo/MinSizeRel with a real
+        # dependency binary, which this mapping would otherwise discard.
+        if (NOT DEFINED CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO)
+            set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO "Release;" PARENT_SCOPE)
+        endif()
+        if (NOT DEFINED CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL)
+            set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL "Release;" PARENT_SCOPE)
+        endif()
     else()
-        set(_build_type ${CMAKE_BUILD_TYPE})
+        if (NOT CMAKE_BUILD_TYPE)
+            message(WARNING "CMAKE_BUILD_TYPE not set. Using Debug for dependency build type")
+            set(_update_deps_configs Debug)
+        else()
+            set(_update_deps_configs ${CMAKE_BUILD_TYPE})
+        endif()
+        set(UPDATE_DEPS_DIR_SUFFIX "${_update_deps_configs}")
     endif()
-    list(APPEND update_dep_command "--config")
-    list(APPEND update_dep_command "${_build_type}")
+
+    foreach(_config IN LISTS _update_deps_configs)
+        list(APPEND update_dep_command "--config" "${_config}")
+    endforeach()
     list(APPEND update_dep_command "--api")
     list(APPEND update_dep_command "${API_TYPE}")
 
-    set(UPDATE_DEPS_DIR_SUFFIX "${_build_type}")
     if (CMAKE_CROSSCOMPILING)
         set(UPDATE_DEPS_DIR_SUFFIX "${CMAKE_SYSTEM_NAME}/${UPDATE_DEPS_DIR_SUFFIX}/${CMAKE_SYSTEM_PROCESSOR}")
     else()

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -44,6 +44,16 @@ Program Options
 
 See the help text (update_deps.py --help) for a complete list of options.
 
+The "--config" option may be repeated (e.g. "--config Debug --config
+Release") to build a dependency for more than one configuration. This is
+required when "--generator" names a multi-config generator (Visual Studio,
+Xcode, Ninja Multi-Config): each dependency is configured once, then built
+and installed once per requested config, all into the same install
+directory, so that a single find_package() call in the consuming project
+resolves correctly no matter which config the IDE is currently building.
+Single-config generators (Ninja, Unix Makefiles, etc.) accept only one
+"--config" value.
+
 Program Operation
 -----------------
 
@@ -292,6 +302,16 @@ CONFIG_MAP = {
     'minsizerel': 'MinSizeRel'
 }
 
+# Generators that support more than one configuration in a single build tree
+# (the user/IDE picks the config at build time via --config, not at configure
+# time via CMAKE_BUILD_TYPE).
+MULTI_CONFIG_GENERATORS = {'Xcode', 'Ninja Multi-Config', 'Green Hills MULTI'}
+
+def is_multi_config_generator(generator):
+    if generator is None:
+        return False
+    return generator in MULTI_CONFIG_GENERATORS or generator.startswith('Visual Studio')
+
 # NOTE: CMake also uses the VERBOSE environment variable. This is intentional.
 VERBOSE = os.getenv("VERBOSE")
 
@@ -406,6 +426,8 @@ class GoodRepo(object):
         self.api = json['api'] if ('api' in json) else None
         self.url_format_map = json.get('url_format_map')
         self.build_architectures = json.get('build_architectures') if ('build_architectures' in json) else []
+
+        self.is_multi_config = is_multi_config_generator(self._args.generator)
 
         # Absolute paths for a repo's directories
         dir_top = os.path.abspath(args.dir)
@@ -558,7 +580,10 @@ class GoodRepo(object):
         return True
 
     def CustomPreProcess(self, cmd_str, repo_dict):
-        return cmd_str.format(repo_dict, self._args, CONFIG_MAP[self._args.config])
+        # NOTE: custom_build commands only ever see the first requested config.
+        # None of the entries in known_good.json currently vary by config, so
+        # this hasn't needed to be config-list-aware yet.
+        return cmd_str.format(repo_dict, self._args, CONFIG_MAP[self._args.configs[0]])
 
     def PreBuild(self):
         """Execute any prebuild steps from the repo root"""
@@ -614,8 +639,29 @@ class GoodRepo(object):
         for option in self.cmake_options:
             cmake_cmd.append(escape(option.format(**self.__dict__)))
 
-        # Set build config for single-configuration generators (this is a no-op on multi-config generators)
-        cmake_cmd.append(f'-D CMAKE_BUILD_TYPE={CONFIG_MAP[self._args.config]}')
+        if self.is_multi_config:
+            # CMAKE_BUILD_TYPE is meaningless for multi-config generators (Visual
+            # Studio, Xcode, Ninja Multi-Config): the config is picked at build
+            # time via --config, not at configure time. Restrict the generated
+            # project to just the configs we're going to build (CMakeBuild()
+            # builds/installs each of self._args.configs into this same tree),
+            # rather than relying on the generator's own default config list.
+            configs_str = ';'.join(CONFIG_MAP[c] for c in self._args.configs)
+            cmake_cmd.append(f'-D CMAKE_CONFIGURATION_TYPES={configs_str}')
+
+            # Debug and Release are installed into the same shared prefix
+            # (see CMakeBuild() below), so without this they'd produce
+            # identically-named binaries and the second config installed
+            # would silently overwrite the first on disk - even though each
+            # config's generated CMake target file correctly records its own
+            # IMPORTED_LOCATION_DEBUG/_RELEASE, both would point at the same
+            # (now-clobbered) file. Giving Debug a distinct filename avoids
+            # the collision; CMake's own per-config exported target files
+            # then resolve correctly with no further work needed.
+            if 'debug' in self._args.configs and 'release' in self._args.configs:
+                cmake_cmd.append('-D CMAKE_DEBUG_POSTFIX=debug')
+        else:
+            cmake_cmd.append(f'-D CMAKE_BUILD_TYPE={CONFIG_MAP[self._args.configs[0]]}')
 
         # Optionally build dependencies with ASAN enabled
         if self._args.asan:
@@ -631,9 +677,10 @@ class GoodRepo(object):
             cmake_cmd.append('-D ENABLE_RTTI=ON')
             os.environ['LDFLAGS'] = '-fsanitize=undefined'
 
-        # Use the CMake -A option to select the platform architecture
-        # without needing a Visual Studio generator.
-        if platform.system() == 'Windows' and self._args.generator != "Ninja":
+        # The -A option is only understood by Visual Studio generators - Ninja
+        # (single- or multi-config) picks up the architecture from the compiler
+        # already selected on PATH/environment instead, and rejects -A outright.
+        if platform.system() == 'Windows' and self._args.generator is not None and self._args.generator.startswith("Visual Studio"):
             cmake_cmd.append('-A')
             if self._args.arch.lower() == '64' or self._args.arch == 'x64' or self._args.arch == 'win64':
                 cmake_cmd.append('x64')
@@ -656,17 +703,23 @@ class GoodRepo(object):
         run_cmake_command(cmake_cmd)
 
     def CMakeBuild(self):
-        """Build CMake command for the build phase and execute it"""
-        cmake_cmd = ['cmake', '--build', self.build_dir, '--target', 'install', '--config', CONFIG_MAP[self._args.config]]
-        if self._args.do_clean:
-            cmake_cmd.append('--clean-first')
+        """Build CMake command for the build phase and execute it, once per
+        requested config. All configs share the same build_dir (no need to
+        reconfigure between configs on multi-config generators) and the same
+        install_dir, so the combined install tree works for any of them."""
+        for config in self._args.configs:
+            cmake_cmd = ['cmake', '--build', self.build_dir, '--target', 'install', '--config', CONFIG_MAP[config]]
+            if self._args.do_clean:
+                cmake_cmd.append('--clean-first')
 
-        # Xcode / Ninja are parallel by default.
-        if self._args.generator != "Ninja" or self._args.generator != "Xcode":
-            cmake_cmd.append('--parallel')
-            cmake_cmd.append(format(multiprocessing.cpu_count()))
+            # Xcode / Ninja are parallel by default; skip --parallel for either one.
+            # (Note the "and": the generator can't equal both, so "or" here would
+            # always be true and defeat the skip.)
+            if self._args.generator != "Ninja" and self._args.generator != "Xcode":
+                cmake_cmd.append('--parallel')
+                cmake_cmd.append(format(multiprocessing.cpu_count()))
 
-        run_cmake_command(cmake_cmd)
+            run_cmake_command(cmake_cmd)
 
     def Build(self, repos, repo_dict):
         """Build the dependent repo and time how long it took"""
@@ -853,11 +906,13 @@ def main():
         default=GetDefaultArch())
     parser.add_argument(
         '--config',
-        dest='config',
+        dest='configs',
         choices=['debug', 'release', 'relwithdebinfo', 'minsizerel'],
         type=str.lower,
-        help="Set build files configuration",
-        default='debug')
+        action='append',
+        help="Set build files configuration. May be repeated (e.g. --config Debug --config Release) "
+             "when --generator is a multi-config generator (Visual Studio, Xcode, Ninja Multi-Config).",
+        default=None)
     parser.add_argument(
         '--api',
         dest='api',
@@ -896,6 +951,14 @@ def main():
         default=False)
 
     args = parser.parse_args()
+
+    if args.configs is None:
+        args.configs = ['debug']
+    elif len(args.configs) > 1 and not is_multi_config_generator(args.generator):
+        raise RuntimeError(
+            f'Cannot build multiple configs ({args.configs}) with the single-config generator "{args.generator}". '
+            'Pass a single --config, or use a multi-config generator (Visual Studio, Xcode, Ninja Multi-Config).')
+
     save_cwd = os.getcwd()
 
     # Create working "top" directory if needed


### PR DESCRIPTION
update_deps.py only ever built a single CMake config, so switching Debug/Release/RelWithDebInfo in an IDE (Visual Studio, Xcode, Ninja Multi-Config) without reconfiguring failed, since only one config's dependency binaries ever existed.

Prebuild Debug and Release for multi-config generators, mapping RelWithDebInfo/MinSizeRel onto the Release binaries. See the comments in scripts/CMakeLists.txt and scripts/update_deps.py for how the shared install prefix and config mapping work.

Fixes #7891