### PR TITLE
build: Check if Vulkan-Headers is an ALIAS target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,10 +122,16 @@ find_package(VulkanUtilityLibraries CONFIG QUIET)
 
 # Workaround AppleClang using the wrong headers when there are headers in /usr/local/include
 if (CMAKE_CXX_COMPILER_ID STREQUAL AppleClang AND TARGET Vulkan::Headers AND TARGET Vulkan::LayerSettings AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.25)
-    set_target_properties(Vulkan::Headers PROPERTIES SYSTEM OFF)
-    set_target_properties(Vulkan::LayerSettings PROPERTIES SYSTEM OFF)
-    set_target_properties(Vulkan::SafeStruct PROPERTIES SYSTEM OFF)
-    set_target_properties(Vulkan::UtilityHeaders PROPERTIES SYSTEM OFF)
+    get_target_property(vulkan_headers_aliased Vulkan::Headers ALIASED_TARGET)
+    if (NOT vulkan_headers_aliased)
+        set_target_properties(Vulkan::Headers PROPERTIES SYSTEM OFF)
+    endif()
+    get_target_property(vulkan_utilities_aliased Vulkan::LayerSettings ALIASED_TARGET)
+    if (NOT vulkan_utilities_aliased)
+        set_target_properties(Vulkan::LayerSettings PROPERTIES SYSTEM OFF)
+        set_target_properties(Vulkan::SafeStruct PROPERTIES SYSTEM OFF)
+        set_target_properties(Vulkan::UtilityHeaders PROPERTIES SYSTEM OFF)
+    endif()
 endif()
 
 


### PR DESCRIPTION
When projects make Vulkan-headers available using add_subdirectory, the Vulkan::Headers target is an ALIAS, not an IMPORTED target. This breaks the AppleClang workaround as CMake cannot modify the properties of ALIAS targets. Because we don't need the workaround when users add Vulkan-Headers using add_subdirectory, just check that it isn't an ALIAS target before calling set_target_properties. This applies to Vulkan-Utility-Libraries as well, so the same check is made for those targets as well.

Derived from https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/402 to fix the Dawn build.