### PR TITLE
sync: Replace execution context interface with a struct

### DIFF
--- a/layers/sync/sync_barrier.cpp
+++ b/layers/sync/sync_barrier.cpp
@@ -378,9 +378,9 @@ void BarrierSet::MakeImageMemoryBarriers(const SyncValidator& sync_state, VkQueu
 // A single barrier can be applied more efficently (immidiately) compared to multiple barrier.
 // The latter are applied in two steps (collect and then apply)
 //
-static void ApplySingleBufferBarrier(CommandExecutionContext& exec_context, AccessContext& access_context,
+static void ApplySingleBufferBarrier(ExecutionContext& exec_context, AccessContext& access_context,
                                      const SyncBufferBarrier& buffer_barrier, const SyncBarrier& exec_dep_barrier) {
-    const QueueId queue_id = exec_context.GetQueueId();
+    const QueueId queue_id = exec_context.queue_id;
     if (SimpleBinding(*buffer_barrier.buffer)) {
         const BarrierScope barrier_scope(buffer_barrier.barrier, queue_id);
         ApplySingleBufferBarrierFunctor apply_barrier(access_context, barrier_scope, buffer_barrier.barrier);
@@ -393,35 +393,34 @@ static void ApplySingleBufferBarrier(CommandExecutionContext& exec_context, Acce
     access_context.RegisterGlobalBarrier(exec_dep_barrier, queue_id);
 }
 
-static void ApplySingleImageBarrier(CommandExecutionContext& exec_context, AccessContext& access_context,
+static void ApplySingleImageBarrier(ExecutionContext& exec_context, AccessContext& access_context,
                                     const SyncImageBarrier& image_barrier, const SyncBarrier& exec_dep_barrier,
                                     ResourceUsageTag tag) {
-    const QueueId queue_id = exec_context.GetQueueId();
+    const QueueId queue_id = exec_context.queue_id;
     const BarrierScope barrier_scope(image_barrier.barrier, queue_id);
     ApplySingleImageBarrierFunctor apply_barrier(access_context, barrier_scope, image_barrier.barrier,
                                                  image_barrier.layout_transition, image_barrier.handle_index, tag);
 
     const auto& sub_state = SubState(*image_barrier.image);
-    const bool can_transition_depth_slices = CanTransitionDepthSlices(exec_context.GetSyncState().extensions,
-                                                                      sub_state.base.GetImageType(), sub_state.base.create_flags);
+    const bool can_transition_depth_slices =
+        CanTransitionDepthSlices(exec_context.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
     auto range_gen = sub_state.MakeImageRangeGen(image_barrier.subresource_range, can_transition_depth_slices);
 
     access_context.UpdateMemoryAccessState(apply_barrier, range_gen);
     access_context.RegisterGlobalBarrier(exec_dep_barrier, queue_id);
 }
 
-static void ApplySingleMemoryBarrier(CommandExecutionContext& exec_context, AccessContext& access_context,
+static void ApplySingleMemoryBarrier(ExecutionContext& exec_context, AccessContext& access_context,
                                      const SyncBarrier& memory_barrier) {
-    const QueueId queue_id = exec_context.GetQueueId();
-    access_context.RegisterGlobalBarrier(memory_barrier, queue_id);
+    access_context.RegisterGlobalBarrier(memory_barrier, exec_context.queue_id);
 }
 
 // This handles all configurations where barriers cannot be applied immidiately and need to use
 // the PendingBarriers helper to ensure independent barrier application. All such configurations
 // use more than one barrier.
-static void ApplyMultipleBarriers(CommandExecutionContext& exec_context, AccessContext& access_context,
-                                  const BarrierSet& barrier_set, ResourceUsageTag tag) {
-    const QueueId queue_id = exec_context.GetQueueId();
+static void ApplyMultipleBarriers(ExecutionContext& exec_context, AccessContext& access_context, const BarrierSet& barrier_set,
+                                  ResourceUsageTag tag) {
+    const QueueId queue_id = exec_context.queue_id;
 
     // Apply markup action.
     // The markup action does not change any access state but it can trim the access map according to the
@@ -442,8 +441,8 @@ static void ApplyMultipleBarriers(CommandExecutionContext& exec_context, AccessC
     }
     for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
         const auto& sub_state = SubState(*barrier.image);
-        const bool can_transition_depth_slices = CanTransitionDepthSlices(
-            exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+        const bool can_transition_depth_slices =
+            CanTransitionDepthSlices(exec_context.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
         auto range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
         // TODO: check if we need: barrier.layout_transition && (queue_id == kQueueIdInvalid)
         ApplyMarkupFunctor markup_action(barrier.layout_transition);
@@ -470,8 +469,8 @@ static void ApplyMultipleBarriers(CommandExecutionContext& exec_context, AccessC
                                                 barrier.handle_index, pending_barriers);
 
         const auto& sub_state = SubState(*barrier.image);
-        const bool can_transition_depth_slices = CanTransitionDepthSlices(
-            exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+        const bool can_transition_depth_slices =
+            CanTransitionDepthSlices(exec_context.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
         auto range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
 
         access_context.UpdateMemoryAccessState(collect_barriers, range_gen);
@@ -497,7 +496,7 @@ static void ApplyMultipleBarriers(CommandExecutionContext& exec_context, AccessC
     }
 }
 
-void ApplyBarrier(CommandExecutionContext& exec_context, AccessContext& access_context, const BarrierSet& barrier_set,
+void ApplyBarrier(ExecutionContext& exec_context, AccessContext& access_context, const BarrierSet& barrier_set,
                   ResourceUsageTag tag) {
     const bool has_buffer_barriers = !barrier_set.buffer_barriers.empty();
     const bool has_image_barriers = !barrier_set.image_barriers.empty();
@@ -522,12 +521,11 @@ void ApplyBarrier(CommandExecutionContext& exec_context, AccessContext& access_c
         ApplyMultipleBarriers(exec_context, access_context, barrier_set, tag);
     }
 
-    SyncEventsContext& events_context = exec_context.GetEventsContext();
     if (barrier_set.single_exec_scope) {
-        events_context.ApplyBarrier(barrier_set.src_exec_scope, barrier_set.dst_exec_scope, tag);
+        exec_context.events_context.ApplyBarrier(barrier_set.src_exec_scope, barrier_set.dst_exec_scope, tag);
     } else {
         for (const auto& barrier : barrier_set.memory_barriers) {
-            events_context.ApplyBarrier(barrier.src_exec_scope, barrier.dst_exec_scope, tag);
+            exec_context.events_context.ApplyBarrier(barrier.src_exec_scope, barrier.dst_exec_scope, tag);
         }
     }
 }

--- a/layers/sync/sync_barrier.h
+++ b/layers/sync/sync_barrier.h
@@ -25,7 +25,7 @@ namespace syncval {
 
 class AccessContext;
 class SyncValidator;
-class CommandExecutionContext;
+struct ExecutionContext;
 
 struct SyncExecScope {
     // The xxxStageMask parameter passed by the caller
@@ -162,7 +162,7 @@ struct SemaphoreScope : SyncExecScope {
     QueueId queue;
 };
 
-void ApplyBarrier(CommandExecutionContext& exec_context, AccessContext& access_context, const BarrierSet& barrier_set,
+void ApplyBarrier(ExecutionContext& exec_context, AccessContext& access_context, const BarrierSet& barrier_set,
                   ResourceUsageTag tag);
 
 }  // namespace syncval

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -255,12 +255,20 @@ static void UpdateVideoAccessState(AccessContext& access_context, const vvl::Vid
     access_context.UpdateAccessState(range_gen, current_usage, ResourceUsageTagEx{tag});
 }
 
-CommandExecutionContext::CommandExecutionContext(const SyncValidator& sync_validator, VkQueueFlags queue_flags)
-    : sync_state_(sync_validator), error_messages_(sync_validator.error_messages_), queue_flags_(queue_flags) {}
+ExecutionContext::ExecutionContext(const SyncValidator& validator, VkQueueFlags queue_flags, QueueId queue_id,
+                                   VulkanTypedHandle handle, SyncEventsContext& events_context,
+                                   const ResourceUsageInfoProvider& usage_info_provider)
+    : validator(validator),
+      queue_flags(queue_flags),
+      queue_id(queue_id),
+      handle(handle),
+      events_context(events_context),
+      usage_info_provider(usage_info_provider) {}
 
-CommandBufferAccessContext::CommandBufferAccessContext(const SyncValidator& sync_validator, VkQueueFlags queue_flags)
-    : CommandExecutionContext(sync_validator, queue_flags),
-      cb_state_(),
+CommandBufferAccessContext::CommandBufferAccessContext(const SyncValidator& sync_validator, VkQueueFlags queue_flags,
+                                                       VulkanTypedHandle handle)
+    : sync_state_(sync_validator),
+      error_messages_(sync_validator.error_messages_),
       access_log_(std::make_shared<AccessLog>()),
       cbs_referenced_(std::make_shared<CommandBufferSet>()),
       command_number_(0),
@@ -268,19 +276,20 @@ CommandBufferAccessContext::CommandBufferAccessContext(const SyncValidator& sync
       cb_access_context_(sync_validator),
       current_context_(&cb_access_context_),
       events_context_(),
+      execution_context_(sync_validator, queue_flags, kQueueIdInvalid, handle, events_context_, *this),
       render_pass_contexts_(),
       current_renderpass_context_(),
       sync_ops_() {}
 
 CommandBufferAccessContext::CommandBufferAccessContext(SyncValidator& sync_validator, vvl::CommandBuffer* cb_state)
-    : CommandBufferAccessContext(sync_validator, cb_state->GetQueueFlags()) {
+    : CommandBufferAccessContext(sync_validator, cb_state->GetQueueFlags(), cb_state->Handle()) {
     cb_state_ = cb_state;
     sync_state_.stats.AddCommandBufferContext();
 }
 
 // NOTE: Make sure the proxy doesn't outlive from, as the proxy is pointing directly to access contexts owned by from.
 CommandBufferAccessContext::CommandBufferAccessContext(const CommandBufferAccessContext& from, AsProxyContext dummy)
-    : CommandBufferAccessContext(from.sync_state_, from.cb_state_->GetQueueFlags()) {
+    : CommandBufferAccessContext(from.sync_state_, from.cb_state_->GetQueueFlags(), from.cb_state_->Handle()) {
     // Copy only the needed fields out of from for a temporary, proxy command buffer context
     cb_state_ = from.cb_state_;
     access_log_ = std::make_shared<AccessLog>(*from.access_log_);  // potentially large, but no choice given tagging lookup.
@@ -970,8 +979,9 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
         if (hazard.IsHazard()) {
             LogObjectList obj_list(cb_state_->Handle(), attachment.view->Handle());
             Location loc = attachment.GetLocation(location, output_location);
-            const std::string error = error_messages_.Error(
-                hazard, *this, location.function, sync_state_.FormatHandle(*attachment.view), "DynamicRenderingAttachmentError");
+            const std::string error =
+                error_messages_.Error(hazard, execution_context_, location.function, sync_state_.FormatHandle(*attachment.view),
+                                      "DynamicRenderingAttachmentError");
             skip |= sync_state_.SyncError(hazard.Hazard(), obj_list, loc.dot(vvl::Field::imageView), error);
         }
     }
@@ -994,7 +1004,7 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
                 LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
                 Location loc = attachment.GetLocation(location);
                 const std::string error =
-                    error_messages_.Error(hazard, *this, location.function, sync_state_.FormatHandle(*attachment.view),
+                    error_messages_.Error(hazard, execution_context_, location.function, sync_state_.FormatHandle(*attachment.view),
                                           "DynamicRenderingAttachmentError");
                 skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc.dot(vvl::Field::imageView), error);
             }
@@ -1320,8 +1330,9 @@ ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(
     const auto barrier_tag = NextCommandTag(command, SubCommandType::kSubpassTransition, 0);
     AddCommandHandle(barrier_tag, rp_state.Handle());
     const auto load_tag = NextSubCommandTag(command, SubCommandType::kLoadOp, 0);
-    render_pass_contexts_.emplace_back(std::make_unique<RenderPassAccessContext>(
-        rp_state, render_area, GetQueueFlags(), attachment_views, cb_access_context_, current_render_pass_instance_id_));
+    render_pass_contexts_.emplace_back(
+        std::make_unique<RenderPassAccessContext>(rp_state, render_area, execution_context_.queue_flags, attachment_views,
+                                                  cb_access_context_, current_render_pass_instance_id_));
     current_renderpass_context_ = render_pass_contexts_.back().get();
     current_renderpass_context_->RecordBeginRenderPass(barrier_tag, load_tag);
     current_context_ = &current_renderpass_context_->CurrentContext();
@@ -1359,7 +1370,7 @@ ResourceUsageTag CommandBufferAccessContext::RecordEndRenderPass(vvl::Func comma
     return barrier_tag;
 }
 
-void CommandBufferAccessContext::RecordDestroyEvent(vvl::Event* event_state) { GetEventsContext().Destroy(event_state); }
+void CommandBufferAccessContext::RecordDestroyEvent(vvl::Event* event_state) { events_context_.Destroy(event_state); }
 
 void CommandBufferAccessContext::RecordExecutedCommandBuffer(const CommandBufferAccessContext& recorded_cb_context) {
     const AccessContext& recorded_context = recorded_cb_context.GetCbAccessContext();
@@ -1369,7 +1380,7 @@ void CommandBufferAccessContext::RecordExecutedCommandBuffer(const CommandBuffer
     for (const auto& sync_op : recorded_cb_context.GetSyncOps()) {
         // we update the range to any include layout transition first use writes,
         // as they are stored along with the source scope (as effective barrier) when recorded
-        sync_op.sync_op->ReplayRecord(*this, *current_context_, base_tag + sync_op.tag);
+        sync_op.sync_op->ReplayRecord(execution_context_, *current_context_, base_tag + sync_op.tag);
     }
 
     ImportRecordedAccessLog(recorded_cb_context);
@@ -1569,7 +1580,7 @@ void CommandBufferSubState::End() {
 
     // For threads that are dedicated to recording command buffers but do not submit themselves,
     // the end of recording is a logical point to update memory stats
-    access_context.GetSyncState().stats.UpdateMemoryStats();
+    access_context.GetExecutionContext().validator.stats.UpdateMemoryStats();
 }
 
 void CommandBufferSubState::Destroy() {
@@ -1896,7 +1907,7 @@ void CommandBufferSubState::RecordDecodeVideo(vvl::VideoSession& vs_state, const
         context.UpdateAccessState(*src_buffer, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ, src_range, src_tag_ex);
     }
 
-    const auto* device_state = access_context.GetSyncState().device_state;
+    const vvl::DeviceState* device_state = access_context.GetExecutionContext().validator.device_state;
     auto dst_resource = vvl::VideoPictureResource(*device_state, decode_info.dstPictureResource);
     if (dst_resource) {
         UpdateVideoAccessState(context, vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE, tag);
@@ -1930,7 +1941,7 @@ void CommandBufferSubState::RecordEncodeVideo(vvl::VideoSession& vs_state, const
         context.UpdateAccessState(*src_buffer, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE, src_range, src_tag_ex);
     }
 
-    const auto* device_state = access_context.GetSyncState().device_state;
+    const vvl::DeviceState* device_state = access_context.GetExecutionContext().validator.device_state;
     auto src_resource = vvl::VideoPictureResource(*device_state, encode_info.srcPictureResource);
     if (src_resource) {
         UpdateVideoAccessState(context, vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ, tag);
@@ -1990,16 +2001,17 @@ void CommandBufferSubState::RecordBeginRenderPass(const VkRenderPassBeginInfo& r
     if (!base.IsPrimary()) {
         return;  // [core validation check]: only primary command buffer can begin render pass
     }
-    const SyncValidator& validator = access_context.GetSyncState();
+
+    const SyncValidator& validator = access_context.GetExecutionContext().validator;
     auto rp_state = validator.Get<vvl::RenderPass>(render_pass_begin.renderPass);
     if (!rp_state) {
         return;
     }
 
     std::vector<std::shared_ptr<const vvl::ImageView>> attachments;
-    auto fb_state = access_context.GetSyncState().Get<vvl::Framebuffer>(render_pass_begin.framebuffer);
+    auto fb_state = validator.Get<vvl::Framebuffer>(render_pass_begin.framebuffer);
     if (fb_state) {
-        attachments = access_context.GetSyncState().device_state->GetAttachmentViews(render_pass_begin, *fb_state);
+        attachments = validator.device_state->GetAttachmentViews(render_pass_begin, *fb_state);
     }
 
     const ResourceUsageTag begin_tag =

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -150,30 +150,26 @@ struct DebugNameProvider {
     virtual std::string GetDebugRegionName(const ResourceUsageRecord &record) const = 0;
 };
 
-// Command execution context is the base class for command buffer and queue contexts
-class CommandExecutionContext {
-  public:
-    using AccessLog = std::vector<ResourceUsageRecord>;
-    using CommandBufferSet = std::vector<std::shared_ptr<const vvl::CommandBuffer>>;
-    CommandExecutionContext(const SyncValidator &sync_validator, VkQueueFlags queue_flags);
-
-    virtual SyncEventsContext& GetEventsContext() = 0;
-    virtual const SyncEventsContext& GetEventsContext() const = 0;
-
-    virtual QueueId GetQueueId() const = 0;
-    virtual VulkanTypedHandle Handle() const = 0;
+struct ResourceUsageInfoProvider {
     virtual ResourceUsageInfo GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const = 0;
-
-    const SyncValidator &GetSyncState() const { return sync_state_; }
-    VkQueueFlags GetQueueFlags() const { return queue_flags_; }
-
-  protected:
-    const SyncValidator &sync_state_;
-    const syncval::ErrorMessages &error_messages_;
-    const VkQueueFlags queue_flags_;
 };
 
-class CommandBufferAccessContext final : public CommandExecutionContext, DebugNameProvider {
+using AccessLog = std::vector<ResourceUsageRecord>;
+using CommandBufferSet = std::vector<std::shared_ptr<const vvl::CommandBuffer>>;
+
+struct ExecutionContext {
+    ExecutionContext(const SyncValidator& validator, VkQueueFlags queue_flags, QueueId queue_id, VulkanTypedHandle handle,
+                     SyncEventsContext& events_context, const ResourceUsageInfoProvider& usage_info_provider);
+
+    const SyncValidator& validator;
+    const VkQueueFlags queue_flags;
+    const QueueId queue_id;
+    const VulkanTypedHandle handle;
+    SyncEventsContext& events_context;
+    const ResourceUsageInfoProvider& usage_info_provider;
+};
+
+class CommandBufferAccessContext final : public ResourceUsageInfoProvider, public DebugNameProvider {
   public:
     struct SyncOpEntry {
         ResourceUsageTag tag;
@@ -202,15 +198,16 @@ class CommandBufferAccessContext final : public CommandExecutionContext, DebugNa
 
     void Reset();
 
+    const SyncValidator& GetSyncState() const { return sync_state_; }
+
     ResourceUsageInfo GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const override;
 
     AccessContext& GetCurrentAccessContext() { return *current_context_; }
     const AccessContext& GetCurrentAccessContext() const { return *current_context_; }
+    QueueId GetQueueId() const ;
 
-    SyncEventsContext& GetEventsContext() override { return events_context_; }
-    const SyncEventsContext& GetEventsContext() const override { return events_context_; }
-
-    QueueId GetQueueId() const override;
+    ExecutionContext& GetExecutionContext() { return execution_context_; }
+    const ExecutionContext& GetExecutionContext() const { return execution_context_; }
 
     // The command buffer's own access context. Subpass contexts exist only inside a vkCmdBeginRenderPass
     // instance, so use this instead of GetCurrentAccessContext() anywhere else. Dynamic rendering has no
@@ -250,12 +247,6 @@ class CommandBufferAccessContext final : public CommandExecutionContext, DebugNa
     void ResolveExecutedCommandBuffer(const AccessContext &recorded_context, ResourceUsageTag offset);
 
     size_t GetTagCount() const { return access_log_->size(); }
-    VulkanTypedHandle Handle() const override {
-        if (cb_state_) {
-            return cb_state_->Handle();
-        }
-        return VulkanTypedHandle(static_cast<VkCommandBuffer>(VK_NULL_HANDLE), kVulkanObjectTypeCommandBuffer);
-    }
 
     ResourceUsageTag NextCommandTag(vvl::Func command, SubCommandType subcommand = SubCommandType::kNone,
                                     uint32_t subpass = vvl::kNoIndex32);
@@ -273,11 +264,7 @@ class CommandBufferAccessContext final : public CommandExecutionContext, DebugNa
     const std::vector<HandleRecord> &GetHandleRecords() const { return handles_; }
 
     std::shared_ptr<const vvl::CommandBuffer> GetCBStateShared() const { return cb_state_->shared_from_this(); }
-
-    const vvl::CommandBuffer &GetCBState() const {
-        assert(cb_state_);
-        return *cb_state_;
-    }
+    const vvl::CommandBuffer& GetCBState() const { return *cb_state_; }
 
     std::shared_ptr<AccessLog> GetAccessLogShared() const { return access_log_; }
     std::shared_ptr<CommandBufferSet> GetCBReferencesShared() const { return cbs_referenced_; }
@@ -292,7 +279,7 @@ class CommandBufferAccessContext final : public CommandExecutionContext, DebugNa
     void UpdateStats(AccessStats &access_stats) const;
 
   private:
-    CommandBufferAccessContext(const SyncValidator &sync_validator, VkQueueFlags queue_flags);
+    CommandBufferAccessContext(const SyncValidator& sync_validator, VkQueueFlags queue_flags, VulkanTypedHandle handle);
 
     uint32_t AddHandle(const VulkanTypedHandle &typed_handle, uint32_t index);
     AttachmentAccess GetAttachmentAccess(SyncOrdering ordering, AttachmentAccessType type = AttachmentAccessType::Access) const;
@@ -312,9 +299,12 @@ class CommandBufferAccessContext final : public CommandExecutionContext, DebugNa
     void CheckCommandTagDebugCheckpoint();
 
   private:
+    const SyncValidator& sync_state_;
+    const ErrorMessages& error_messages_;
+
     // Note: since every CommandBufferAccessContext is encapsulated in its CommandBuffer object,
     // a reference count is not needed here.
-    vvl::CommandBuffer *cb_state_;
+    vvl::CommandBuffer *cb_state_ = nullptr;
 
     std::shared_ptr<AccessLog> access_log_;
     std::shared_ptr<CommandBufferSet> cbs_referenced_;
@@ -331,6 +321,8 @@ class CommandBufferAccessContext final : public CommandExecutionContext, DebugNa
     AccessContext cb_access_context_;
     AccessContext *current_context_;
     SyncEventsContext events_context_;
+
+    ExecutionContext execution_context_;
 
     // Don't need the following for an active proxy cb context
     std::vector<std::unique_ptr<RenderPassAccessContext>> render_pass_contexts_;

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -30,7 +30,7 @@ namespace syncval {
 
 ErrorMessages::ErrorMessages(SyncValidator& validator) : validator_(validator) {}
 
-std::string ErrorMessages::Error(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
+std::string ErrorMessages::Error(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
                                  const std::string& resource_description, const char* message_type,
                                  const AdditionalMessageInfo& additional_info) const {
     std::string message = FormatErrorMessage(hazard, context, command, resource_description, additional_info);
@@ -55,7 +55,7 @@ std::string ErrorMessages::BufferError(const HazardResult& hazard, const Command
     ss << "}\n";
     additional_info.message_end_text += ss.str();
 
-    return Error(hazard, cb_context, command, resource_description, "BufferError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "BufferError", additional_info);
 }
 
 std::string ErrorMessages::BufferCopyError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -71,7 +71,7 @@ std::string ErrorMessages::BufferCopyError(const HazardResult& hazard, const Com
     ss << "}\n";
     additional_info.message_end_text = ss.str();
 
-    return Error(hazard, cb_context, command, resource_description, "BufferCopyError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "BufferCopyError", additional_info);
 }
 
 std::string ErrorMessages::AccelerationStructureError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -93,7 +93,8 @@ std::string ErrorMessages::AccelerationStructureError(const HazardResult& hazard
     ss2 << "}\n";
     additional_info.message_end_text += ss2.str();
 
-    return Error(hazard, cb_context, command, resource_description, "AccelerationStructureError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "AccelerationStructureError",
+                 additional_info);
 }
 
 std::string ErrorMessages::ImageCopyResolveBlitError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -124,7 +125,7 @@ std::string ErrorMessages::ImageCopyResolveBlitError(const HazardResult& hazard,
     additional_info.message_end_text = ss.str();
     additional_info.properties.Add(kPropertyRegionIndex, region_index);
 
-    return Error(hazard, cb_context, command, resource_description, message_type, additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, message_type, additional_info);
 }
 
 std::string ErrorMessages::ImageClearError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -140,7 +141,8 @@ std::string ErrorMessages::ImageClearError(const HazardResult& hazard, const Com
     additional_info.message_end_text = ss.str();
     additional_info.properties.Add(kPropertyRegionIndex, subresource_range_index);
 
-    return Error(hazard, cb_context, command, resource_description, "ImageSubresourceRangeError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "ImageSubresourceRangeError",
+                 additional_info);
 }
 
 static void PrepareCommonDescriptorMessage(Logger& logger, const vvl::Pipeline& pipeline, uint32_t descriptor_set_number,
@@ -177,7 +179,7 @@ std::string ErrorMessages::BufferDescriptorError(const HazardResult& hazard, con
     ss << ".";
 
     additional_info.pre_synchronization_text = ss.str();
-    return Error(hazard, cb_context, command, resource_description, "BufferDescriptorError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "BufferDescriptorError", additional_info);
 }
 
 std::string ErrorMessages::ImageDescriptorError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -194,7 +196,7 @@ std::string ErrorMessages::ImageDescriptorError(const HazardResult& hazard, cons
 
     additional_info.pre_synchronization_text = ss.str();
     additional_info.properties.Add(kPropertyImageLayout, string_VkImageLayout(image_layout));
-    return Error(hazard, cb_context, command, resource_description, "ImageDescriptorError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "ImageDescriptorError", additional_info);
 }
 
 std::string ErrorMessages::AccelerationStructureDescriptorError(
@@ -211,7 +213,8 @@ std::string ErrorMessages::AccelerationStructureDescriptorError(
     ss << ".";
     additional_info.pre_synchronization_text = ss.str();
 
-    return Error(hazard, cb_context, command, resource_description, "AccelerationStructureDescriptorError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "AccelerationStructureDescriptorError",
+                 additional_info);
 }
 
 std::string ErrorMessages::ClearAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -231,12 +234,12 @@ std::string ErrorMessages::ClearAttachmentError(const HazardResult& hazard, cons
     additional_info.access_action = "clears";
     additional_info.message_end_text = ss.str();
 
-    return Error(hazard, cb_context, command, resource_description, "ClearAttachmentError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "ClearAttachmentError", additional_info);
 }
 
 std::string ErrorMessages::RenderPassAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                      vvl::Func command, const std::string& resource_description) const {
-    return Error(hazard, cb_context, command, resource_description, "RenderPassAttachmentError");
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassAttachmentError");
 }
 
 static const char* GetLoadOpActionName(VkAttachmentLoadOp load_op) {
@@ -272,7 +275,7 @@ std::string ErrorMessages::BeginRenderingError(const HazardResult& hazard, const
     const char* load_op_str = string_VkAttachmentLoadOp(load_op);
     additional_info.properties.Add(kPropertyLoadOp, load_op_str);
     additional_info.access_action = GetLoadOpActionName(load_op);
-    return Error(hazard, cb_context, command, resource_description, "BeginRenderingError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "BeginRenderingError", additional_info);
 }
 
 std::string ErrorMessages::EndRenderingResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -282,7 +285,8 @@ std::string ErrorMessages::EndRenderingResolveError(const HazardResult& hazard, 
     const char* resolve_mode_str = string_VkResolveModeFlagBits(resolve_mode);
     additional_info.properties.Add(kPropertyResolveMode, resolve_mode_str);
     additional_info.access_action = resolve_write ? "writes to single sample resolve attachment" : "reads multisample attachment";
-    return Error(hazard, cb_context, command, resource_description, "EndRenderingResolveError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "EndRenderingResolveError",
+                 additional_info);
 }
 
 std::string ErrorMessages::EndRenderingStoreError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -291,7 +295,8 @@ std::string ErrorMessages::EndRenderingStoreError(const HazardResult& hazard, co
     AdditionalMessageInfo additional_info;
     const char* store_op_str = string_VkAttachmentStoreOp(store_op);
     additional_info.properties.Add(kPropertyStoreOp, store_op_str);
-    return Error(hazard, cb_context, command, resource_description, "EndRenderingStoreError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "EndRenderingStoreError",
+                 additional_info);
 }
 
 std::string ErrorMessages::RenderPassLoadOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -302,7 +307,7 @@ std::string ErrorMessages::RenderPassLoadOpError(const HazardResult& hazard, con
     additional_info.properties.Add(kPropertyLoadOp, load_op_str);
     additional_info.access_action = GetLoadOpActionName(load_op);
     CheckForLoadOpDontCareInsight(load_op, is_color, additional_info.message_end_text);
-    return Error(hazard, cb_context, command, resource_description, "RenderPassLoadOpError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassLoadOpError", additional_info);
 }
 
 std::string ErrorMessages::RenderPassLoadOpVsLayoutTransitionError(const HazardResult& hazard,
@@ -315,12 +320,13 @@ std::string ErrorMessages::RenderPassLoadOpVsLayoutTransitionError(const HazardR
     additional_info.hazard_overview = "attachment loadOp access is not synchronized with the attachment layout transition";
     additional_info.access_action = GetLoadOpActionName(load_op);
     CheckForLoadOpDontCareInsight(load_op, is_color, additional_info.message_end_text);
-    return Error(hazard, cb_context, command, resource_description, "RenderPassLoadOpVsLayoutTransitionError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassLoadOpVsLayoutTransitionError",
+                 additional_info);
 }
 
 std::string ErrorMessages::RenderPassResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                   vvl::Func command, const std::string& resource_description) const {
-    return Error(hazard, cb_context, command, resource_description, "RenderPassResolveError");
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassResolveError");
 }
 
 std::string ErrorMessages::RenderPassStoreOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -329,7 +335,8 @@ std::string ErrorMessages::RenderPassStoreOpError(const HazardResult& hazard, co
     AdditionalMessageInfo additional_info;
     const char* store_op_str = string_VkAttachmentStoreOp(store_op);
     additional_info.properties.Add(kPropertyStoreOp, store_op_str);
-    return Error(hazard, cb_context, command, resource_description, "RenderPassStoreOpError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassStoreOpError",
+                 additional_info);
 }
 
 std::string ErrorMessages::RenderPassLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -342,7 +349,8 @@ std::string ErrorMessages::RenderPassLayoutTransitionError(const HazardResult& h
     additional_info.properties.Add(kPropertyOldLayout, old_layout_str);
     additional_info.properties.Add(kPropertyNewLayout, new_layout_str);
     additional_info.access_action = "performs image layout transition";
-    return Error(hazard, cb_context, command, resource_description, "RenderPassLayoutTransitionError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassLayoutTransitionError",
+                 additional_info);
 }
 
 std::string ErrorMessages::RenderPassLayoutTransitionVsResolveError(const HazardResult& hazard,
@@ -361,7 +369,8 @@ std::string ErrorMessages::RenderPassLayoutTransitionVsResolveError(const Hazard
         validator_.FormatHandle(cb_context.GetCurrentRenderPassContext()->GetRenderPassState()->Handle());
     additional_info.brief_description_end_text = "during resolve operation in subpass ";
     additional_info.brief_description_end_text += std::to_string(resolve_subpass);
-    return Error(hazard, cb_context, command, resource_description, "RenderPassLayoutTransitionVsResolveError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description,
+                 "RenderPassLayoutTransitionVsResolveError", additional_info);
 }
 
 std::string ErrorMessages::RenderPassFinalLayoutTransitionError(const HazardResult& hazard,
@@ -377,7 +386,8 @@ std::string ErrorMessages::RenderPassFinalLayoutTransitionError(const HazardResu
     additional_info.access_action =
         "performs final image layout transition during " +
         validator_.FormatHandle(cb_context.GetCurrentRenderPassContext()->GetRenderPassState()->Handle());
-    return Error(hazard, cb_context, command, resource_description, "RenderPassFinalLayoutTransitionError", additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassFinalLayoutTransitionError",
+                 additional_info);
 }
 
 std::string ErrorMessages::RenderPassFinalLayoutTransitionVsStoreOrResolveError(const HazardResult& hazard,
@@ -398,11 +408,11 @@ std::string ErrorMessages::RenderPassFinalLayoutTransitionVsStoreOrResolveError(
     additional_info.brief_description_end_text = "during store/resolve operation in subpass ";
     additional_info.brief_description_end_text += std::to_string(store_resolve_subpass);
 
-    return Error(hazard, cb_context, command, resource_description, "RenderPassFinalLayoutTransitionVsStoreOrResolveError",
-                 additional_info);
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description,
+                 "RenderPassFinalLayoutTransitionVsStoreOrResolveError", additional_info);
 }
 
-std::string ErrorMessages::ImageBarrierError(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
+std::string ErrorMessages::ImageBarrierError(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
                                              const std::string& resource_description, const SyncImageBarrier& barrier) const {
     AdditionalMessageInfo additional_info;
     additional_info.access_action = "performs image layout transition on the";
@@ -419,9 +429,9 @@ std::string ErrorMessages::ImageBarrierError(const HazardResult& hazard, const C
     return Error(hazard, context, command, resource_description, "ImageBarrierError", additional_info);
 }
 
-std::string ErrorMessages::FirstUseError(const HazardResult& hazard, const CommandExecutionContext& exec_context,
+std::string ErrorMessages::FirstUseError(const HazardResult& hazard, const ExecutionContext& exec_context,
                                          const CommandBufferAccessContext& recorded_context, uint32_t command_buffer_index) const {
-    const ResourceUsageInfo prior_usage_info = exec_context.GetResourceUsageInfo(hazard.TagEx());
+    const ResourceUsageInfo prior_usage_info = exec_context.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
     const ResourceUsageInfo recorded_usage_info = recorded_context.GetResourceUsageInfo(hazard.RecordedAccess()->TagEx());
 
     AdditionalMessageInfo additional_info;
@@ -432,13 +442,13 @@ std::string ErrorMessages::FirstUseError(const HazardResult& hazard, const Comma
     if (!recorded_usage_info.debug_region_name.empty()) {
         ss << "[" << recorded_usage_info.debug_region_name << "]";
     }
-    if (exec_context.Handle().type == kVulkanObjectTypeQueue) {
-        ss << " (from " << validator_.FormatHandle(recorded_context.Handle());
+    if (exec_context.handle.type == kVulkanObjectTypeQueue) {
+        ss << " (from " << validator_.FormatHandle(recorded_context.GetCBState().Handle());
         ss << " submitted on the current ";
-        ss << validator_.FormatHandle(exec_context.Handle()) << ")";
+        ss << validator_.FormatHandle(exec_context.handle) << ")";
     } else {  // primary command buffer executes secondary one
-        assert(exec_context.Handle().type == kVulkanObjectTypeCommandBuffer);
-        ss << " (from the secondary " << validator_.FormatHandle(recorded_context.Handle()) << ")";
+        assert(exec_context.handle.type == kVulkanObjectTypeCommandBuffer);
+        ss << " (from the secondary " << validator_.FormatHandle(recorded_context.GetCBState().Handle()) << ")";
     }
     additional_info.access_initiator = ss.str();
 
@@ -474,12 +484,12 @@ std::string ErrorMessages::PresentError(const HazardResult& hazard, const QueueB
     AdditionalMessageInfo additional_info;
     additional_info.access_action = "presents";
     additional_info.properties.Add(kPropertySwapchainIndex, swapchain_index);
-    return Error(hazard, batch_context, command, resource_description, "PresentError", additional_info);
+    return Error(hazard, batch_context.GetExecutionContext(), command, resource_description, "PresentError", additional_info);
 }
 
 std::string ErrorMessages::VideoError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
                                       const std::string& resource_description) const {
-    return Error(hazard, cb_context, command, resource_description, "VideoError");
+    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "VideoError");
 }
 
 }  // namespace syncval

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -32,7 +32,7 @@ class Pipeline;
 namespace syncval {
 
 class CommandBufferAccessContext;
-class CommandExecutionContext;
+struct ExecutionContext;
 class HazardResult;
 class QueueBatchContext;
 class SyncValidator;
@@ -42,7 +42,7 @@ class ErrorMessages {
   public:
     explicit ErrorMessages(SyncValidator& validator);
 
-    std::string Error(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
+    std::string Error(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
                       const std::string& resource_description, const char* message_type,
                       const AdditionalMessageInfo& additional_info = {}) const;
 
@@ -128,10 +128,10 @@ class ErrorMessages {
                                                                      VkImageLayout old_layout, VkImageLayout new_layout,
                                                                      uint32_t store_resolve_subpass) const;
 
-    std::string ImageBarrierError(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
+    std::string ImageBarrierError(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
                                   const std::string& resource_description, const SyncImageBarrier& barrier) const;
 
-    std::string FirstUseError(const HazardResult& hazard, const CommandExecutionContext& exec_context,
+    std::string FirstUseError(const HazardResult& hazard, const ExecutionContext& exec_context,
                               const CommandBufferAccessContext& recorded_context, uint32_t command_buffer_index) const;
 
     std::string PresentError(const HazardResult& hazard, const QueueBatchContext& batch_context, vvl::Func command,

--- a/layers/sync/sync_event.cpp
+++ b/layers/sync/sync_event.cpp
@@ -186,15 +186,14 @@ static SyncBarrier RestrictToEvent(const SyncBarrier& barrier, const SyncEventSt
     return result;
 }
 
-void ApplyWaitEvents(CommandExecutionContext& exec_context, AccessContext& access_context,
+void ApplyWaitEvents(ExecutionContext& exec_context, AccessContext& access_context,
                      const std::vector<std::shared_ptr<const vvl::Event>>& events, vvl::span<const BarrierSet> barrier_sets,
                      ResourceUsageTag tag, vvl::Func command) {
     // Unlike PipelineBarrier, WaitEvent is *not* limited to accesses within the current subpass (if any) and thus needs to import
     // all accesses. Can instead import for all first_scopes, or a union of them, if this becomes a performance/memory issue,
     // but with no idea of the performance of the union, nor of whether it even matters... take the simplest approach here,
 
-    SyncEventsContext& events_context = exec_context.GetEventsContext();
-    const QueueId queue_id = exec_context.GetQueueId();
+    const QueueId queue_id = exec_context.queue_id;
 
     access_context.ResolveAllSubpassDependencies();
 
@@ -216,7 +215,7 @@ void ApplyWaitEvents(CommandExecutionContext& exec_context, AccessContext& acces
         if (!event_shared) {
             continue;
         }
-        auto* sync_event = events_context.GetFromShared(event_shared);
+        auto* sync_event = exec_context.events_context.GetFromShared(event_shared);
         if (!sync_event->first_scope) {
             continue;  // [core validation check]
         }
@@ -237,7 +236,7 @@ void ApplyWaitEvents(CommandExecutionContext& exec_context, AccessContext& acces
         for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
             const auto& sub_state = SubState(*barrier.image);
             const bool can_transition_depth_slices = CanTransitionDepthSlices(
-                exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+                exec_context.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
             ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
             EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
             ApplyMarkupFunctor markup_action(barrier.layout_transition);
@@ -257,7 +256,7 @@ void ApplyWaitEvents(CommandExecutionContext& exec_context, AccessContext& acces
         if (!event_shared.get()) {
             continue;
         }
-        auto* sync_event = events_context.GetFromShared(event_shared);
+        auto* sync_event = exec_context.events_context.GetFromShared(event_shared);
         if (!sync_event->first_scope) {
             continue;  // [core validation check]
         }
@@ -291,7 +290,7 @@ void ApplyWaitEvents(CommandExecutionContext& exec_context, AccessContext& acces
 
             const auto& sub_state = SubState(*barrier.image);
             const bool can_transition_depth_slices = CanTransitionDepthSlices(
-                exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+                exec_context.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
             ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
             EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
 

--- a/layers/sync/sync_event.h
+++ b/layers/sync/sync_event.h
@@ -30,9 +30,9 @@ class Event;
 namespace syncval {
 
 class AccessContext;
-class CommandExecutionContext;
+struct ExecutionContext;
 
-void ApplyWaitEvents(CommandExecutionContext& exec_context, AccessContext& access_context,
+void ApplyWaitEvents(ExecutionContext& exec_context, AccessContext& access_context,
                      const std::vector<std::shared_ptr<const vvl::Event>>& events, vvl::span<const BarrierSet> barrier_sets,
                      ResourceUsageTag tag, vvl::Func command);
 

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -36,7 +36,7 @@ namespace syncval {
 
 SyncOpPipelineBarrier::SyncOpPipelineBarrier(BarrierSet&& barrier_set) : barrier_set_(std::move(barrier_set)) {}
 
-void SyncOpPipelineBarrier::ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
+void SyncOpPipelineBarrier::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
                                          const ResourceUsageTag exec_tag) const {
     ApplyBarrier(exec_context, access_context, barrier_set_, exec_tag);
 }
@@ -55,60 +55,52 @@ SyncOpSetEvent::SyncOpSetEvent(std::shared_ptr<const vvl::Event>&& event, const 
       src_exec_scope_(src_exec_scope) {}
 
 bool SyncOpSetEvent::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    CommandExecutionContext& exec_context = replay.exec_context;
-    const SyncValidator& validator = exec_context.GetSyncState();
+    ExecutionContext& exec_context = replay.exec_context;
     const ResourceUsageTag exec_tag = replay.base_tag + recorded_tag;
-    return validator.ValidateCmdSetEvent(exec_context, event_, src_exec_scope_, exec_tag, Location(command_));
+    return exec_context.validator.ValidateCmdSetEvent(exec_context, event_, src_exec_scope_, exec_tag, Location(command_));
 }
 
-void SyncOpSetEvent::ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
-                                  ResourceUsageTag exec_tag) const {
+void SyncOpSetEvent::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const {
     // Create a copy of the current context, and merge in the state snapshot at record set event time
     // Note: we mustn't change the recorded context copy, as a given CB could be submitted more than once (in generaL)
-
-    const QueueId queue_id = exec_context.GetQueueId();
 
     // Note: merged_context is a copy of the access_context, combined with the recorded context
     auto merged_context = std::make_shared<AccessContext>(*access_context.validator);
     merged_context->InitFrom(access_context);
-    merged_context->ResolveFromContext(QueueTagOffsetBarrierAction(queue_id, exec_tag), *recorded_context_);
+    merged_context->ResolveFromContext(QueueTagOffsetBarrierAction(exec_context.queue_id, exec_tag), *recorded_context_);
     merged_context->TrimAndClearFirstAccess();  // Ensure the copy is minimal and normalized
 
-    const SyncValidator& validator = exec_context.GetSyncState();
-    validator.ApplySetEvent(exec_context, event_, src_exec_scope_, merged_context, exec_tag, command_);
+    exec_context.validator.ApplySetEvent(exec_context, event_, src_exec_scope_, merged_context, exec_tag, command_);
 }
 
 SyncOpResetEvent::SyncOpResetEvent(std::shared_ptr<const vvl::Event>&& event, const SyncExecScope& exec_scope, const Location& loc)
     : SyncOpBase(loc.function), event_(std::move(event)), exec_scope_(exec_scope) {}
 
 bool SyncOpResetEvent::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    CommandExecutionContext& exec_context = replay.exec_context;
-    const SyncValidator& validator = exec_context.GetSyncState();
+    ExecutionContext& exec_context = replay.exec_context;
     const ResourceUsageTag exec_tag = replay.base_tag + recorded_tag;
-    return validator.ValidateCmdResetEvent(exec_context, event_, exec_scope_, exec_tag, Location(command_));
+    return exec_context.validator.ValidateCmdResetEvent(exec_context, event_, exec_scope_, exec_tag, Location(command_));
 }
 
-void SyncOpResetEvent::ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
+void SyncOpResetEvent::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
                                     ResourceUsageTag exec_tag) const {
-    const SyncValidator& validator = exec_context.GetSyncState();
-    validator.ApplyResetEvent(exec_context, event_, exec_tag, command_);
+    exec_context.validator.ApplyResetEvent(exec_context, event_, exec_tag, command_);
 }
 
 SyncOpWaitEvents::SyncOpWaitEvents(std::vector<std::shared_ptr<const vvl::Event>>&& events, std::vector<BarrierSet>&& barrier_sets,
                                    const Location& loc)
     : SyncOpBase(loc.function), events_(std::move(events)), barrier_sets_(std::move(barrier_sets)) {}
 
-void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
+void SyncOpWaitEvents::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
                                     ResourceUsageTag exec_tag) const {
     ApplyWaitEvents(exec_context, access_context, events_, barrier_sets_, exec_tag, command_);
 }
 
 bool SyncOpWaitEvents::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    CommandExecutionContext& exec_context = replay.exec_context;
-    const SyncValidator& validator = exec_context.GetSyncState();
+    ExecutionContext& exec_context = replay.exec_context;
     const ResourceUsageTag exec_tag = replay.base_tag + recorded_tag;
-    return validator.ValidateCmdWaitEvents(exec_context, replay.GetReplayContext(), events_, barrier_sets_, exec_tag,
-                                           Location(command_));
+    return exec_context.validator.ValidateCmdWaitEvents(exec_context, replay.GetReplayContext(), events_, barrier_sets_, exec_tag,
+                                                        Location(command_));
 }
 
 SyncOpBeginRenderPass::SyncOpBeginRenderPass(std::shared_ptr<const vvl::RenderPass>&& rp_state,
@@ -117,15 +109,14 @@ SyncOpBeginRenderPass::SyncOpBeginRenderPass(std::shared_ptr<const vvl::RenderPa
     : SyncOpBase(loc.function), rp_state_(std::move(rp_state)), attachments_(std::move(attachments)), rp_context_(rp_context) {}
 
 bool SyncOpBeginRenderPass::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    QueueBatchContext& batch_context = replay.GetBatchContext();
-    replay.rp_replay.emplace(rp_context_, batch_context.GetAccessContext(), batch_context.GetQueueFlags());
+    replay.rp_replay.emplace(rp_context_, replay.replay_context, replay.exec_context.queue_flags);
 
     // Only the layout transitions happen at the replay tag, loadOp's happen at a subsequent tag
     ResourceUsageRange first_use_range = {recorded_tag, recorded_tag + 1};
     return replay.DetectFirstUseHazard(first_use_range);
 }
 
-void SyncOpBeginRenderPass::ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
+void SyncOpBeginRenderPass::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
                                          ResourceUsageTag exec_tag) const {
     // All the needed replay state changes (for the layout transition, and context update) have to happen in ReplayValidate
 }
@@ -148,7 +139,7 @@ bool SyncOpNextSubpass::ReplayValidate(ReplayState& replay, ResourceUsageTag rec
     return skip;
 }
 
-void SyncOpNextSubpass::ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
+void SyncOpNextSubpass::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
                                      ResourceUsageTag exec_tag) const {
     // All the needed replay state changes (for the layout transition, and context update) have to happen in ReplayValidate
 }
@@ -163,8 +154,7 @@ bool SyncOpEndRenderPass::ReplayValidate(ReplayState& replay, ResourceUsageTag r
     // Do a render pass cleanup. This also switches replay to command buffer context where we can
     // validate layout transition.
 
-    QueueBatchContext& batch_context = replay.GetBatchContext();
-    batch_context.GetAccessContext().ResolveChildContexts(replay.rp_replay->GetSubpassContexts());
+    replay.replay_context.ResolveChildContexts(replay.rp_replay->GetSubpassContexts());
     replay.rp_replay.reset();
 
     // Validate final layout transition
@@ -175,12 +165,12 @@ bool SyncOpEndRenderPass::ReplayValidate(ReplayState& replay, ResourceUsageTag r
     return skip;
 }
 
-void SyncOpEndRenderPass::ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
+void SyncOpEndRenderPass::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
                                        ResourceUsageTag exec_tag) const {}
 
 ReplayState::ReplayState(CommandBufferAccessContext& primary_cb_context, const CommandBufferAccessContext& recorded_context,
                          ResourceUsageTag base_tag, const Location& cb_loc)
-    : exec_context(primary_cb_context),
+    : exec_context(primary_cb_context.GetExecutionContext()),
       replay_context(primary_cb_context.GetCurrentAccessContext()),
       recorded_context(recorded_context),
       base_tag(base_tag),
@@ -188,7 +178,7 @@ ReplayState::ReplayState(CommandBufferAccessContext& primary_cb_context, const C
 
 ReplayState::ReplayState(QueueBatchContext& batch_context, const CommandBufferAccessContext& recorded_context,
                          ResourceUsageTag base_tag, const Location& cb_loc)
-    : exec_context(batch_context),
+    : exec_context(batch_context.GetExecutionContext()),
       replay_context(batch_context.GetAccessContext()),
       recorded_context(recorded_context),
       base_tag(base_tag),
@@ -202,10 +192,10 @@ bool ReplayState::DetectFirstUseHazard(const ResourceUsageRange& first_use_range
     const AccessContext& recorded_access_context =
         rp_replay ? rp_replay->GetCurrentRecordedContext() : recorded_context.GetCbAccessContext();
     const HazardResult hazard =
-        recorded_access_context.DetectFirstUseHazard(exec_context.GetQueueId(), first_use_range, GetReplayContext());
+        recorded_access_context.DetectFirstUseHazard(exec_context.queue_id, first_use_range, GetReplayContext());
     if (hazard.IsHazard()) {
-        const SyncValidator& sync_state = exec_context.GetSyncState();
-        LogObjectList objlist(exec_context.Handle(), recorded_context.Handle());
+        const SyncValidator& sync_state = exec_context.validator;
+        LogObjectList objlist(exec_context.handle, recorded_context.GetCBState().Handle());
         const std::string error = sync_state.error_messages_.FirstUseError(hazard, exec_context, recorded_context, cb_loc.index);
         skip |= sync_state.SyncError(hazard.Hazard(), objlist, cb_loc, error);
     }
@@ -244,13 +234,6 @@ bool ReplayState::ValidateFirstUse() {
     first_use_range.end = ResourceUsageRecord::kMaxIndex;
     skip |= DetectFirstUseHazard(first_use_range);
     return skip;
-}
-
-QueueBatchContext& ReplayState::GetBatchContext() {
-    // This is called for render pass ops which are not allowed in secondary
-    // command buffers, so batch context is valid
-    assert(exec_context.Handle().type == kVulkanObjectTypeQueue);
-    return static_cast<QueueBatchContext&>(exec_context);
 }
 
 const AccessContext& ReplayState::GetReplayContext() const {

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -32,7 +32,7 @@ class RenderPass;
 namespace syncval {
 
 class CommandBufferAccessContext;
-class CommandExecutionContext;
+struct ExecutionContext;
 class QueueBatchContext;
 class RenderPassAccessContext;
 class SyncValidator;
@@ -120,8 +120,7 @@ class SyncOpBase {
     SyncOpBase(vvl::Func command) : command_(command) {}
     virtual ~SyncOpBase() = default;
     virtual bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const = 0;
-    virtual void ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
-                              ResourceUsageTag exec_tag) const = 0;
+    virtual void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const = 0;
 
   protected:
     vvl::Func command_ = vvl::Func::Empty;
@@ -131,8 +130,7 @@ class SyncOpPipelineBarrier : public SyncOpBase {
   public:
     SyncOpPipelineBarrier(BarrierSet&& barrier_set);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
-                      ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 
   private:
     BarrierSet barrier_set_;
@@ -143,8 +141,7 @@ class SyncOpSetEvent : public SyncOpBase {
     SyncOpSetEvent(std::shared_ptr<const vvl::Event>&& event, const SyncExecScope& src_exec_scope,
                    std::shared_ptr<const AccessContext>&& src_access_context, const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
-                      ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 
   private:
     std::shared_ptr<const vvl::Event> event_;
@@ -157,8 +154,7 @@ class SyncOpResetEvent : public SyncOpBase {
   public:
     SyncOpResetEvent(std::shared_ptr<const vvl::Event>&& event, const SyncExecScope& exec_scope, const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
-                      ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 
   private:
     std::shared_ptr<const vvl::Event> event_;
@@ -170,8 +166,7 @@ class SyncOpWaitEvents : public SyncOpBase {
     SyncOpWaitEvents(std::vector<std::shared_ptr<const vvl::Event>>&& events, std::vector<BarrierSet>&& barrier_sets,
                      const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
-                      ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 
   private:
     // TODO PHASE2 This is the wrong thing to use for "replay".. as the event state will have moved on since the record
@@ -187,8 +182,7 @@ class SyncOpBeginRenderPass : public SyncOpBase {
                           std::vector<std::shared_ptr<const vvl::ImageView>>&& attachments,
                           const RenderPassAccessContext* rp_context, const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
-                      ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
     const RenderPassAccessContext* GetRenderPassAccessContext() const { return rp_context_; }
 
   protected:
@@ -205,16 +199,14 @@ class SyncOpNextSubpass : public SyncOpBase {
   public:
     SyncOpNextSubpass(const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
-                      ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 };
 
 class SyncOpEndRenderPass : public SyncOpBase {
   public:
     SyncOpEndRenderPass(const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(CommandExecutionContext& exec_context, AccessContext& access_context,
-                      ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 };
 
 // Render pass state for submit-time replay. The accesses come from RenderPassAccessContext's
@@ -245,11 +237,10 @@ struct ReplayState {
 
     bool ValidateFirstUse();
     bool DetectFirstUseHazard(const ResourceUsageRange& first_use_range) const;
-    QueueBatchContext& GetBatchContext();
     AccessContext& GetReplayContext();
     const AccessContext& GetReplayContext() const;
 
-    CommandExecutionContext& exec_context;
+    ExecutionContext& exec_context;
     AccessContext& replay_context;
     const CommandBufferAccessContext& recorded_context;
     std::optional<RenderPassReplayState> rp_replay;

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -315,9 +315,9 @@ static std::vector<std::pair<VkPipelineStageFlags2, VkAccessFlags2>> ConvertSync
 // by the synchronization. If applied synchronization covers at least stage or access component
 // then we can provide more precise message by focusing on the other component.
 static std::pair<bool, bool> GetPartialProtectedInfo(const SyncAccessInfo& access, const SyncAccessFlags& write_barriers,
-                                                     const CommandExecutionContext& context) {
+                                                     const ExecutionContext& context) {
     const auto protected_stage_access_pairs =
-        ConvertSyncAccessesToCompactVkForm(write_barriers, context.GetSyncState(), context.GetQueueFlags());
+        ConvertSyncAccessesToCompactVkForm(write_barriers, context.validator, context.queue_flags);
     bool is_stage_protected = false;
     bool is_access_protected = false;
     for (const auto& protected_stage_access : protected_stage_access_pairs) {
@@ -387,17 +387,17 @@ std::string ReportProperties::FormatExtraPropertiesSection() const {
     return ss.str();
 }
 
-ReportProperties GetErrorMessageProperties(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
+ReportProperties GetErrorMessageProperties(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
                                            const char* message_type, const AdditionalMessageInfo& additional_info) {
     ReportProperties properties;
     properties.Add(kPropertyMessageType, message_type);
     properties.Add(kPropertyHazardType, string_SyncHazard(hazard.Hazard()));
     properties.Add(kPropertyCommand, vvl::String(command));
 
-    GetAccessProperties(hazard, context.GetSyncState(), context.GetQueueFlags(), properties);
+    GetAccessProperties(hazard, context.validator, context.queue_flags, properties);
 
     if (hazard.Tag() != kInvalidTag) {
-        ResourceUsageInfo prior_usage_info = context.GetResourceUsageInfo(hazard.TagEx());
+        ResourceUsageInfo prior_usage_info = context.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
         GetPriorUsageProperties(prior_usage_info, properties);
     }
     for (const auto& property : additional_info.properties.name_values) {
@@ -406,7 +406,7 @@ ReportProperties GetErrorMessageProperties(const HazardResult& hazard, const Com
     return properties;
 }
 
-std::string FormatErrorMessage(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
+std::string FormatErrorMessage(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
                                const std::string& resouce_description, const AdditionalMessageInfo& additional_info) {
     const SyncHazard hazard_type = hazard.Hazard();
     const SyncHazardInfo hazard_info = GetSyncHazardInfo(hazard_type);
@@ -458,7 +458,7 @@ std::string FormatErrorMessage(const HazardResult& hazard, const CommandExecutio
         // resolve before ILT or ILT after storeOp.
         ss << "by the same command";
     } else {
-        const ResourceUsageInfo prior_usage_info = context.GetResourceUsageInfo(hazard.TagEx());
+        const ResourceUsageInfo prior_usage_info = context.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
         const vvl::Func prior_command = prior_usage_info.command;
         if (prior_usage_info.sub_command_type == SubCommandType::kLoadOp) {
             if (prior_usage_info.subpass != vvl::kNoIndex32) {
@@ -507,7 +507,7 @@ std::string FormatErrorMessage(const HazardResult& hazard, const CommandExecutio
     }
 
     // Synchronization information
-    const bool cross_queue_racing_hazard = hazard_info.IsRacingHazard() && context.GetQueueId() != kQueueIdInvalid;
+    const bool cross_queue_racing_hazard = hazard_info.IsRacingHazard() && context.queue_id != kQueueIdInvalid;
     ss << "\n";
     if (cross_queue_racing_hazard) {
         ss << "The RACING hazard means the two submissions on different queues are not synchronized with each other, so the order "
@@ -561,7 +561,7 @@ std::string FormatErrorMessage(const HazardResult& hazard, const CommandExecutio
         ss << ".";
     } else if (hazard_info.IsPriorWrite()) {  // RAW/WAW hazards
         ss << "The current synchronization allows ";
-        ss << FormatSyncAccesses(write_barriers, context.GetSyncState(), context.GetQueueFlags(), false);
+        ss << FormatSyncAccesses(write_barriers, context.validator, context.queue_flags, false);
         auto [is_stage_protected, is_access_protected] = GetPartialProtectedInfo(access, write_barriers, context);
         if (is_access_protected) {
             ss << ", but to prevent this hazard, it must allow these accesses at ";

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -24,7 +24,7 @@ class Logger;
 
 namespace syncval {
 
-class CommandExecutionContext;
+struct ExecutionContext;
 class HazardResult;
 class SyncValidator;
 
@@ -63,11 +63,11 @@ struct AdditionalMessageInfo {
     std::string message_end_text;
 };
 
-ReportProperties GetErrorMessageProperties(const HazardResult &hazard, const CommandExecutionContext &context, vvl::Func command,
-                                           const char *message_type, const AdditionalMessageInfo &additional_info);
+ReportProperties GetErrorMessageProperties(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
+                                           const char* message_type, const AdditionalMessageInfo& additional_info);
 
-std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutionContext &context, vvl::Func command,
-                               const std::string &resouce_description, const AdditionalMessageInfo &additional_info);
+std::string FormatErrorMessage(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
+                               const std::string& resouce_description, const AdditionalMessageInfo& additional_info);
 
 std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const SyncValidator &device, VkQueueFlags allowed_queue_flags,
                                bool format_as_extra_property);

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -261,18 +261,21 @@ void LastSynchronizedPresent::OnDestroySwapchain(VkSwapchainKHR swapchain) {
 }
 
 QueueBatchContext::QueueBatchContext(const SyncValidator& sync_state, const QueueState& queue_state)
-    : CommandExecutionContext(sync_state, queue_state.GetQueue()->GetQueueFlags()),
+    : sync_state_(sync_state),
       queue_state_(&queue_state),
       tag_range_(0, 0),
       access_context_(sync_state),
+      execution_context_(sync_state, queue_state.GetQueue()->GetQueueFlags(), queue_state.GetQueueId(),
+                         queue_state.GetQueue()->Handle(), events_context_, *this),
       queue_sync_tag_(sync_state.GetQueueIdLimit(), ResourceUsageTag(0)) {
     sync_state_.stats.AddQueueBatchContext();
 }
 
 QueueBatchContext::QueueBatchContext(const SyncValidator& sync_state)
-    : CommandExecutionContext(sync_state, 0),
+    : sync_state_(sync_state),
       tag_range_(0, 0),
       access_context_(sync_state),
+      execution_context_(sync_state, 0, kQueueIdInvalid, NullVulkanTypedHandle, events_context_, *this),
       queue_sync_tag_(sync_state.GetQueueIdLimit(), ResourceUsageTag(0)) {
     sync_state_.stats.AddQueueBatchContext();
 }
@@ -296,8 +299,6 @@ void QueueBatchContext::Trim() {
 void QueueBatchContext::ResolveSubmittedCommandBuffer(const AccessContext& recorded_context, ResourceUsageTag offset) {
     GetAccessContext().ResolveFromContext(QueueTagOffsetBarrierAction(GetQueueId(), offset), recorded_context);
 }
-
-VulkanTypedHandle QueueBatchContext::Handle() const { return queue_state_->GetQueue()->Handle(); }
 
 template <typename Predicate>
 void QueueBatchContext::ApplyPredicatedWait(Predicate& predicate, const LastSynchronizedPresent& last_synchronized_present) {
@@ -807,8 +808,7 @@ void BatchAccessLog::Import(const BatchAccessLog& other) {
     }
 }
 
-void BatchAccessLog::Insert(const BatchRecord& batch, const ResourceUsageRange& range,
-                            std::shared_ptr<const CommandExecutionContext::AccessLog> log) {
+void BatchAccessLog::Insert(const BatchRecord& batch, const ResourceUsageRange& range, std::shared_ptr<const AccessLog> log) {
     log_map_.insert(std::make_pair(range, CBSubmitLog(batch, nullptr, std::move(log))));
 }
 
@@ -892,9 +892,8 @@ BatchAccessLog::AccessRecord BatchAccessLog::CBSubmitLog::GetAccessRecord(Resour
     return AccessRecord{&batch_, record, debug_name_provider};
 }
 
-BatchAccessLog::CBSubmitLog::CBSubmitLog(const BatchRecord& batch,
-                                         std::shared_ptr<const CommandExecutionContext::CommandBufferSet> cbs,
-                                         std::shared_ptr<const CommandExecutionContext::AccessLog> log)
+BatchAccessLog::CBSubmitLog::CBSubmitLog(const BatchRecord& batch, std::shared_ptr<const CommandBufferSet> cbs,
+                                         std::shared_ptr<const AccessLog> log)
     : batch_(batch), cbs_(cbs), log_(log) {}
 
 BatchAccessLog::CBSubmitLog::CBSubmitLog(const BatchRecord& batch, const CommandBufferAccessContext& cb,

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -205,10 +205,9 @@ class BatchAccessLog {
         CBSubmitLog(CBSubmitLog &&other) = default;
         CBSubmitLog &operator=(const CBSubmitLog &other) = default;
         CBSubmitLog &operator=(CBSubmitLog &&other) = default;
-        CBSubmitLog(const BatchRecord &batch, std::shared_ptr<const CommandExecutionContext::CommandBufferSet> cbs,
-                    std::shared_ptr<const CommandExecutionContext::AccessLog> log);
-        CBSubmitLog(const BatchRecord &batch, const CommandBufferAccessContext &cb,
-                    const std::vector<std::string> &initial_label_stack);
+        CBSubmitLog(const BatchRecord& batch, std::shared_ptr<const CommandBufferSet> cbs, std::shared_ptr<const AccessLog> log);
+        CBSubmitLog(const BatchRecord& batch, const CommandBufferAccessContext& cb,
+                    const std::vector<std::string>& initial_label_stack);
         size_t Size() const { return log_->size(); }
         AccessRecord GetAccessRecord(ResourceUsageTag tag) const;
 
@@ -217,8 +216,8 @@ class BatchAccessLog {
 
       private:
         BatchRecord batch_;
-        std::shared_ptr<const CommandExecutionContext::CommandBufferSet> cbs_;
-        std::shared_ptr<const CommandExecutionContext::AccessLog> log_;
+        std::shared_ptr<const CommandBufferSet> cbs_;
+        std::shared_ptr<const AccessLog> log_;
         // label stack at the point when command buffer is submitted to the queue
         std::vector<std::string> initial_label_stack_;
     };
@@ -226,8 +225,7 @@ class BatchAccessLog {
     void Import(const BatchRecord &batch, const CommandBufferAccessContext &cb_access,
                 const std::vector<std::string> &initial_label_stack);
     void Import(const BatchAccessLog &other);
-    void Insert(const BatchRecord &batch, const ResourceUsageRange &range,
-                std::shared_ptr<const CommandExecutionContext::AccessLog> log);
+    void Insert(const BatchRecord& batch, const ResourceUsageRange& range, std::shared_ptr<const AccessLog> log);
 
     void Trim(const ResourceUsageTagSet &used);
     // AccessRecord lookup is based on global tags
@@ -310,7 +308,7 @@ class QueueState {
     std::vector<UnresolvedBatch> unresolved_batches_;
 };
 
-class QueueBatchContext final : public CommandExecutionContext, public std::enable_shared_from_this<QueueBatchContext> {
+class QueueBatchContext final : public ResourceUsageInfoProvider, public std::enable_shared_from_this<QueueBatchContext> {
   public:
     class PresentResourceRecord : public AlternateResourceUsage::RecordBase {
       public:
@@ -346,13 +344,13 @@ class QueueBatchContext final : public CommandExecutionContext, public std::enab
     ~QueueBatchContext();
     void Trim();
 
-    QueueId GetQueueId() const override;
     ResourceUsageInfo GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const override;
 
-    SyncEventsContext& GetEventsContext() override { return events_context_; }
-    const SyncEventsContext& GetEventsContext() const override { return events_context_; }
-
     VkQueueFlags GetQueueFlags() const { return queue_state_->GetQueue()->GetQueueFlags(); }
+    QueueId GetQueueId() const;
+    ExecutionContext& GetExecutionContext() { return execution_context_; }
+    const ExecutionContext& GetExecutionContext() const { return execution_context_; }
+    SyncEventsContext& GetEventsContext() { return events_context_; }
 
     ResourceUsageRange GetTagRange() const { return tag_range_; }
     const std::vector<ResourceUsageTag> &GetQueueSyncTags() const { return queue_sync_tag_; }
@@ -401,16 +399,18 @@ class QueueBatchContext final : public CommandExecutionContext, public std::enab
     LastSynchronizedPresent last_synchronized_present;
 
   private:
-    VulkanTypedHandle Handle() const override;
     const QueueState* GetQueueState() const { return queue_state_; }
     void ResolvePresentSemaphoreWait(const SignalInfo& signal_info, const PresentedImages& presented_images);
 
   private:
+    const SyncValidator& sync_state_;
     const QueueState *queue_state_ = nullptr;
     ResourceUsageRange tag_range_ = ResourceUsageRange(0, 0);  // Range of tags referenced by cbs_referenced
 
     AccessContext access_context_;
     SyncEventsContext events_context_;
+    ExecutionContext execution_context_;
+
     BatchAccessLog batch_log_;
 
     // Indexed by queue id. Each element stores the tag location of the last synchronization

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -566,8 +566,8 @@ bool SyncValidator::ValidateCmdPipelineBarrier(const CommandBufferAccessContext&
             LogObjectList objlist(cb_context.GetCBState().Handle(), image_state.Handle());
             const SyncValidator& sync_state = cb_context.GetSyncState();
             const std::string resource_description = sync_state.FormatHandle(image_state.Handle());
-            const std::string error =
-                sync_state.error_messages_.ImageBarrierError(hazard, cb_context, loc.function, resource_description, image_barrier);
+            const std::string error = sync_state.error_messages_.ImageBarrierError(
+                hazard, cb_context.GetExecutionContext(), loc.function, resource_description, image_barrier);
             skip |= sync_state.SyncError(hazard.Hazard(), objlist, loc, error);
         }
     }
@@ -583,7 +583,7 @@ bool SyncValidator::PreCallValidateCmdPipelineBarrier(
 
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const VkQueueFlags queue_flags = cb_access_context.GetQueueFlags();
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     const SyncExecScope src_exec_scope(SyncExecScope::MakeSrc(queue_flags, srcStageMask));
     const SyncExecScope dst_exec_scope(SyncExecScope::MakeDst(queue_flags, dstStageMask));
@@ -608,7 +608,7 @@ void SyncValidator::RecordCmdPipelineBarrier(CommandBufferAccessContext& cb_cont
             image_barrier.handle_index = tag_ex.handle_index;
         }
     }
-    ApplyBarrier(cb_context, cb_context.GetCurrentAccessContext(), barrier_set, tag);
+    ApplyBarrier(cb_context.GetExecutionContext(), cb_context.GetCurrentAccessContext(), barrier_set, tag);
     auto sync_op = std::make_shared<SyncOpPipelineBarrier>(std::move(barrier_set));
     cb_context.AddSyncOp(tag, std::move(sync_op));
 }
@@ -619,9 +619,9 @@ void SyncValidator::PostCallRecordCmdPipelineBarrier(
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
 
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
     const SyncExecScope src_exec_scope(SyncExecScope::MakeSrc(queue_flags, srcStageMask));
     const SyncExecScope dst_exec_scope(SyncExecScope::MakeDst(queue_flags, dstStageMask));
 
@@ -643,9 +643,9 @@ bool SyncValidator::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBu
         return skip;
     }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const VkQueueFlags queue_flags = cb_access_context.GetQueueFlags();
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
+    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
     const BarrierSet barrier_set(*this, queue_flags, *pDependencyInfo);
 
     skip |= ValidateCmdPipelineBarrier(cb_access_context, barrier_set, error_obj.location);
@@ -666,10 +666,8 @@ void SyncValidator::PostCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuf
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
     BarrierSet barrier_set(*this, queue_flags, *pDependencyInfo);
-
     RecordCmdPipelineBarrier(cb_context, std::move(barrier_set), record_obj.location);
 }
 
@@ -757,6 +755,7 @@ bool SyncValidator::ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const
 
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     const uint32_t subpass_zero = 0;
     const uint32_t view_mask = rp_state->create_info.pSubpasses[0].viewMask;
@@ -766,8 +765,7 @@ bool SyncValidator::ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const
 
     // TODO: investigate if using nullptr in InitFrom is safe (this just follows the initial implementation - it assumes
     // that array of subpass dependencies won't be indexed, but it's not obvious).
-    temp_context.InitFrom(subpass_zero, cb_context.GetQueueFlags(), rp_state->subpass_dependency_infos, nullptr,
-                          cb_context.GetCbAccessContext());
+    temp_context.InitFrom(subpass_zero, queue_flags, rp_state->subpass_dependency_infos, nullptr, cb_context.GetCbAccessContext());
 
     // Validate attachment operations
     const uint32_t render_pass_instance_id = cb_context.GetCurrentRenderPassInstanceId();
@@ -2210,14 +2208,13 @@ void SyncValidator::PostCallRecordResetEvent(VkDevice device, VkEvent event, con
     }
 }
 
-bool SyncValidator::ValidateCmdSetEvent(const CommandExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+bool SyncValidator::ValidateCmdSetEvent(const ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
                                         const SyncExecScope& src_exec_scope, ResourceUsageTag base_tag, const Location& loc) const {
     bool skip = false;
 
-    const SyncValidator& sync_state = exec_context.GetSyncState();
-    const SyncEventsContext& events_context = exec_context.GetEventsContext();
+    const SyncValidator& sync_state = exec_context.validator;
 
-    const auto* sync_event = events_context.Get(event);
+    const auto* sync_event = exec_context.events_context.Get(event);
     if (!sync_event) {
         return skip;
     }
@@ -2251,16 +2248,16 @@ bool SyncValidator::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, Vk
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
     auto event_state = Get<vvl::Event>(event);
-    const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(cb_context.GetQueueFlags(), stageMask);
-    return ValidateCmdSetEvent(cb_context, event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex, error_obj.location);
+    const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(cb_state->GetQueueFlags(), stageMask);
+    return ValidateCmdSetEvent(cb_context.GetExecutionContext(), event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex,
+                               error_obj.location);
 }
 
-void SyncValidator::ApplySetEvent(CommandExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+void SyncValidator::ApplySetEvent(ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
                                   const SyncExecScope& src_exec_scope,
                                   const std::shared_ptr<const AccessContext>& src_access_context, ResourceUsageTag tag,
                                   vvl::Func command) const {
-    SyncEventsContext& events_context = exec_context.GetEventsContext();
-    SyncEventState* sync_event = events_context.GetFromShared(event);
+    SyncEventState* sync_event = exec_context.events_context.GetFromShared(event);
     if (!sync_event) {
         return;
     }
@@ -2298,7 +2295,7 @@ void SyncValidator::RecordCmdSetEvent(CommandBufferAccessContext& cb_context, st
     auto src_access_context = std::make_shared<AccessContext>(*this);
     src_access_context->InitFrom(cb_context.GetCbAccessContext());
 
-    ApplySetEvent(cb_context, event, src_exec_scope, src_access_context, tag, loc.function);
+    ApplySetEvent(cb_context.GetExecutionContext(), event, src_exec_scope, src_access_context, tag, loc.function);
 
     auto sync_op = std::make_shared<SyncOpSetEvent>(std::move(event), src_exec_scope, std::move(src_access_context), loc);
     cb_context.AddSyncOp(tag, std::move(sync_op));
@@ -2308,9 +2305,10 @@ void SyncValidator::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkE
                                               const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     auto event_state = Get<vvl::Event>(event);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+
     const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, stageMask);
     RecordCmdSetEvent(cb_context, std::move(event_state), src_exec_scope, record_obj.location);
 }
@@ -2328,11 +2326,13 @@ bool SyncValidator::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, V
     }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     auto event_state = Get<vvl::Event>(event);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+
     const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, sync_utils::GetExecScopes(*pDependencyInfo).src);
-    return ValidateCmdSetEvent(cb_context, event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex, error_obj.location);
+    return ValidateCmdSetEvent(cb_context.GetExecutionContext(), event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex,
+                               error_obj.location);
 }
 
 void SyncValidator::PostCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
@@ -2347,18 +2347,19 @@ void SyncValidator::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, Vk
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     auto event_state = Get<vvl::Event>(event);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+
     const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, sync_utils::GetExecScopes(*pDependencyInfo).src);
     RecordCmdSetEvent(cb_context, std::move(event_state), src_exec_scope, record_obj.location);
 }
 
-bool SyncValidator::ValidateCmdResetEvent(const CommandExecutionContext& exec_context,
-                                          const std::shared_ptr<const vvl::Event>& event, const SyncExecScope& exec_scope,
-                                          const ResourceUsageTag base_tag, const Location& loc) const {
+bool SyncValidator::ValidateCmdResetEvent(const ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+                                          const SyncExecScope& exec_scope, const ResourceUsageTag base_tag,
+                                          const Location& loc) const {
     bool skip = false;
-    const auto* sync_event = exec_context.GetEventsContext().Get(event);
+    const auto* sync_event = exec_context.events_context.Get(event);
     if (!sync_event) {
         return skip;
     }
@@ -2380,14 +2381,14 @@ bool SyncValidator::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, 
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
     auto event_state = Get<vvl::Event>(event);
-    const SyncExecScope exec_scope = SyncExecScope::MakeSrc(cb_context.GetQueueFlags(), stageMask);
-    return ValidateCmdResetEvent(cb_context, event_state, exec_scope, ResourceUsageRecord::kMaxIndex, error_obj.location);
+    const SyncExecScope exec_scope = SyncExecScope::MakeSrc(cb_state->GetQueueFlags(), stageMask);
+    return ValidateCmdResetEvent(cb_context.GetExecutionContext(), event_state, exec_scope, ResourceUsageRecord::kMaxIndex,
+                                 error_obj.location);
 }
 
-void SyncValidator::ApplyResetEvent(CommandExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+void SyncValidator::ApplyResetEvent(ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
                                     ResourceUsageTag tag, vvl::Func command) const {
-    SyncEventsContext& events_context = exec_context.GetEventsContext();
-    SyncEventState* sync_event = events_context.GetFromShared(event);
+    SyncEventState* sync_event = exec_context.events_context.GetFromShared(event);
     if (!sync_event) {
         return;
     }
@@ -2401,7 +2402,7 @@ void SyncValidator::ApplyResetEvent(CommandExecutionContext& exec_context, const
 void SyncValidator::RecordCmdResetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
                                         const SyncExecScope& exec_scope, const Location& loc) const {
     const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
-    ApplyResetEvent(cb_context, event, tag, loc.function);
+    ApplyResetEvent(cb_context.GetExecutionContext(), event, tag, loc.function);
     auto sync_op = std::make_shared<SyncOpResetEvent>(std::move(event), exec_scope, loc);
     cb_context.AddSyncOp(tag, std::move(sync_op));
 }
@@ -2410,9 +2411,10 @@ void SyncValidator::PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, V
                                                 const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     auto event_state = Get<vvl::Event>(event);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+
     const SyncExecScope exec_scope = SyncExecScope::MakeSrc(queue_flags, stageMask);
     RecordCmdResetEvent(cb_context, std::move(event_state), exec_scope, record_obj.location);
 }
@@ -2422,8 +2424,9 @@ bool SyncValidator::PreCallValidateCmdResetEvent2(VkCommandBuffer commandBuffer,
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
     auto event_state = Get<vvl::Event>(event);
-    const SyncExecScope exec_scope = SyncExecScope::MakeSrc(cb_context.GetQueueFlags(), stageMask);
-    return ValidateCmdResetEvent(cb_context, event_state, exec_scope, ResourceUsageRecord::kMaxIndex, error_obj.location);
+    const SyncExecScope exec_scope = SyncExecScope::MakeSrc(cb_state->GetQueueFlags(), stageMask);
+    return ValidateCmdResetEvent(cb_context.GetExecutionContext(), event_state, exec_scope, ResourceUsageRecord::kMaxIndex,
+                                 error_obj.location);
 }
 
 bool SyncValidator::PreCallValidateCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
@@ -2440,20 +2443,20 @@ void SyncValidator::PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, 
                                                  const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     auto event_state = Get<vvl::Event>(event);
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
+
     const SyncExecScope exec_scope = SyncExecScope::MakeSrc(queue_flags, stageMask);
     RecordCmdResetEvent(cb_context, std::move(event_state), exec_scope, record_obj.location);
 }
 
-bool SyncValidator::ValidateCmdWaitEvents(const CommandExecutionContext& exec_context, const AccessContext& access_context,
+bool SyncValidator::ValidateCmdWaitEvents(const ExecutionContext& exec_context, const AccessContext& access_context,
                                           const std::vector<std::shared_ptr<const vvl::Event>>& events,
                                           const vvl::span<const BarrierSet>& barrier_sets, const ResourceUsageTag base_tag,
                                           const Location& loc) const {
     bool skip = false;
-    const auto& sync_state = exec_context.GetSyncState();
-    const QueueId queue_id = exec_context.GetQueueId();
+    const auto& sync_state = exec_context.validator;
 
     // This is only interesting at record and not replay (Execute/Submit) time
     if (base_tag == ResourceUsageRecord::kMaxIndex) {
@@ -2463,7 +2466,7 @@ bool SyncValidator::ValidateCmdWaitEvents(const CommandExecutionContext& exec_co
                 if (barrier_set.src_exec_scope.stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
                     const std::string vuid =
                         std::string("SYNC-") + vvl::String(loc.function) + std::string("-hostevent-unsupported");
-                    sync_state.LogInfo(vuid, exec_context.Handle(), loc,
+                    sync_state.LogInfo(vuid, exec_context.handle, loc,
                                        "srcStageMask includes %s, unsupported by synchronization validation.",
                                        string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT));
                 } else {
@@ -2474,7 +2477,7 @@ bool SyncValidator::ValidateCmdWaitEvents(const CommandExecutionContext& exec_co
                             const std::string vuid =
                                 std::string("SYNC-") + vvl::String(loc.function) + std::string("-hostevent-unsupported");
 
-                            sync_state.LogInfo(vuid, exec_context.Handle(), loc,
+                            sync_state.LogInfo(vuid, exec_context.handle, loc,
                                                "srcStageMask %s of %s %zu, %s %zu, unsupported by synchronization validation.",
                                                string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT), "pDependencyInfo",
                                                barrier_set_index, "pMemoryBarriers", barrier_index);
@@ -2486,11 +2489,10 @@ bool SyncValidator::ValidateCmdWaitEvents(const CommandExecutionContext& exec_co
     }
 
     // The rest is common to record time and replay time
-    const SyncEventsContext& events_context = exec_context.GetEventsContext();
     size_t barrier_set_index = 0;
     size_t barrier_set_incr = (barrier_sets.size() == 1) ? 0 : 1;
     for (const auto& event : events) {
-        const auto* sync_event = events_context.Get(event);
+        const auto* sync_event = exec_context.events_context.Get(event);
         const auto& barrier_set = barrier_sets[barrier_set_index];
         if (!sync_event || !sync_event->first_scope) {
             barrier_set_index += barrier_set_incr;
@@ -2523,10 +2525,10 @@ bool SyncValidator::ValidateCmdWaitEvents(const CommandExecutionContext& exec_co
                 const auto& subresource_range = image_memory_barrier.subresource_range;
                 const auto& src_access_scope = image_memory_barrier.barrier.src_access_scope;
                 const auto hazard = access_context.DetectImageBarrierHazard(
-                    *image_state, subresource_range, sync_event->scope.exec_scope, src_access_scope, queue_id,
+                    *image_state, subresource_range, sync_event->scope.exec_scope, src_access_scope, exec_context.queue_id,
                     sync_event->FirstScope(), sync_event->first_scope_tag, AccessContext::DetectOptions::kDetectAll);
                 if (hazard.IsHazard()) {
-                    LogObjectList objlist(exec_context.Handle(), image_state->Handle());
+                    LogObjectList objlist(exec_context.handle, image_state->Handle());
                     const std::string resource_description = sync_state.FormatHandle(image_state->Handle());
                     const std::string error = sync_state.error_messages_.ImageBarrierError(
                         hazard, exec_context, loc.function, resource_description, image_memory_barrier);
@@ -2549,8 +2551,8 @@ bool SyncValidator::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, 
                                                  const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
     const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, srcStageMask);
     const SyncExecScope dst_exec_scope = SyncExecScope::MakeDst(queue_flags, dstStageMask);
     const BarrierSet barrier_set =
@@ -2562,15 +2564,16 @@ bool SyncValidator::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, 
         events[i] = Get<vvl::Event>(pEvents[i]);
     }
 
-    return ValidateCmdWaitEvents(cb_context, cb_context.GetCurrentAccessContext(), events, vvl::make_span(&barrier_set, 1),
-                                 ResourceUsageRecord::kMaxIndex, error_obj.location);
+    return ValidateCmdWaitEvents(cb_context.GetExecutionContext(), cb_context.GetCurrentAccessContext(), events,
+                                 vvl::make_span(&barrier_set, 1), ResourceUsageRecord::kMaxIndex, error_obj.location);
 }
 
 void SyncValidator::RecordCmdWaitEvents(CommandBufferAccessContext& cb_context,
                                         std::vector<std::shared_ptr<const vvl::Event>>&& events,
                                         std::vector<BarrierSet>&& barrier_sets, const Location& loc) const {
     const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
-    ApplyWaitEvents(cb_context, cb_context.GetCurrentAccessContext(), events, barrier_sets, tag, loc.function);
+    ApplyWaitEvents(cb_context.GetExecutionContext(), cb_context.GetCurrentAccessContext(), events, barrier_sets, tag,
+                    loc.function);
     auto sync_op = std::make_shared<SyncOpWaitEvents>(std::move(events), std::move(barrier_sets), loc);
     cb_context.AddSyncOp(tag, std::move(sync_op));
 }
@@ -2584,13 +2587,13 @@ void SyncValidator::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, u
                                                 const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     std::vector<std::shared_ptr<const vvl::Event>> events(eventCount);
     for (uint32_t i = 0; i < eventCount; i++) {
         events[i] = Get<vvl::Event>(pEvents[i]);
     }
 
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
     const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, srcStageMask);
     const SyncExecScope dst_exec_scope = SyncExecScope::MakeDst(queue_flags, dstStageMask);
     std::vector<BarrierSet> barrier_sets;
@@ -2619,17 +2622,17 @@ bool SyncValidator::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer,
     }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     std::vector<std::shared_ptr<const vvl::Event>> events(eventCount);
     for (uint32_t i = 0; i < eventCount; i++) {
         events[i] = Get<vvl::Event>(pEvents[i]);
     }
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
     std::vector<BarrierSet> barrier_sets(eventCount);
     for (uint32_t i = 0; i < eventCount; i++) {
         barrier_sets[i] = BarrierSet(*this, queue_flags, pDependencyInfos[i]);
     }
-    return ValidateCmdWaitEvents(cb_context, cb_context.GetCurrentAccessContext(), events, barrier_sets,
+    return ValidateCmdWaitEvents(cb_context.GetExecutionContext(), cb_context.GetCurrentAccessContext(), events, barrier_sets,
                                  ResourceUsageRecord::kMaxIndex, error_obj.location);
 }
 
@@ -2640,12 +2643,12 @@ void SyncValidator::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, 
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     std::vector<std::shared_ptr<const vvl::Event>> events(eventCount);
     for (uint32_t i = 0; i < eventCount; i++) {
         events[i] = Get<vvl::Event>(pEvents[i]);
     }
-    const VkQueueFlags queue_flags = cb_context.GetQueueFlags();
     std::vector<BarrierSet> barrier_sets(eventCount);
     for (uint32_t i = 0; i < eventCount; i++) {
         barrier_sets[i] = BarrierSet(*this, queue_flags, pDependencyInfos[i]);

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -446,12 +446,12 @@ class SyncValidator : public vvl::DeviceProxy {
     void PostCallRecordResetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) override;
 
 
-    bool ValidateCmdSetEvent(const CommandExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+    bool ValidateCmdSetEvent(const ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
                              const SyncExecScope& src_exec_scope, ResourceUsageTag base_tag, const Location& loc) const;
     bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
-                                    const ErrorObject &error_obj) const override;
+                                    const ErrorObject& error_obj) const override;
 
-    void ApplySetEvent(CommandExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+    void ApplySetEvent(ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
                        const SyncExecScope& src_exec_scope, const std::shared_ptr<const AccessContext>& src_access_context,
                        ResourceUsageTag tag, vvl::Func command) const;
     void RecordCmdSetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
@@ -467,13 +467,13 @@ class SyncValidator : public vvl::DeviceProxy {
     void PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo *pDependencyInfo,
                                     const RecordObject &record_obj) override;
 
-    bool ValidateCmdResetEvent(const CommandExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+    bool ValidateCmdResetEvent(const ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
                                const SyncExecScope& exec_scope, ResourceUsageTag base_tag, const Location& loc) const;
     bool PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
-                                      const ErrorObject &error_obj) const override;
+                                      const ErrorObject& error_obj) const override;
 
-    void ApplyResetEvent(CommandExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
-                         ResourceUsageTag tag, vvl::Func command) const;
+    void ApplyResetEvent(ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event, ResourceUsageTag tag,
+                         vvl::Func command) const;
     void RecordCmdResetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
                              const SyncExecScope& exec_scope, const Location& loc) const;
     void PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
@@ -487,7 +487,7 @@ class SyncValidator : public vvl::DeviceProxy {
     void PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                       const RecordObject &record_obj) override;
 
-    bool ValidateCmdWaitEvents(const CommandExecutionContext& exec_context, const AccessContext& access_context,
+    bool ValidateCmdWaitEvents(const ExecutionContext& exec_context, const AccessContext& access_context,
                                const std::vector<std::shared_ptr<const vvl::Event>>& events,
                                const vvl::span<const BarrierSet>& barrier_sets, const ResourceUsageTag base_tag,
                                const Location& loc) const;


### PR DESCRIPTION
The main change here is that `CommandBufferAccessContext` and `QueueBatchContext` do not implement `CommandExecutionContext` interface, instead they provide required information as a simple `ExecutionContext` struct. The goal is to show that these classes are more different than similar (common interface makes you search similarities). The similarity was mostly about returning specific data, not functional. This data is now provided as a POD struct.