### PR TITLE
layers: Validate 13362 even without descriptors bound

### DIFF
--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -745,20 +745,20 @@ bool CoreChecks::ValidateDrawShaderObjectFlags(const LastBound& last_bound_state
     }
 
     if (shader_with_independent_sets && last_bound_state.desc_set_pipeline_layout) {
-        // TODO - figure out if this is correct or not
-        // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4848
-        const bool uses_descriptor = !shader_with_independent_sets->active_slots.empty();
-
-        if (uses_descriptor &&
-            !(last_bound_state.desc_set_pipeline_layout->create_flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT)) {
+        if (!(last_bound_state.desc_set_pipeline_layout->create_flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT)) {
             const LogObjectList objlist(last_bound_state.cb_state.Handle(), last_bound_state.desc_set_pipeline_layout->VkHandle(),
                                         shader_with_independent_sets->VkHandle());
+            // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4848
+            const bool uses_descriptor = !shader_with_independent_sets->active_slots.empty();
             skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::INDEPENDENT_SETS_13362), objlist, loc,
                              "Shader object bound at stage %s has flag VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR but the "
                              "VkPipelineLayout (bound with %s) "
-                             "was created without the VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT flag\nCreate flags: %s.",
+                             "was created without the VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT flag%s\nCreate flags: %s.",
                              string_VkShaderStageFlagBits(shader_with_independent_sets->safe_create_info.stage),
                              vvl::String(last_bound_state.GetDescriptorModeFunc()),
+                             uses_descriptor ? ""
+                                             : "\nNote: Even though the shader doesn't use any descriptors, some drivers use the "
+                                               "INDEPENDENT_SETS to adjust various data layouts, not limited to descriptors.",
                              string_VkPipelineLayoutCreateFlags(last_bound_state.desc_set_pipeline_layout->create_flags).c_str());
         }
 

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -15,6 +15,7 @@
 
 #include <vulkan/vulkan_core.h>
 #include <cstdint>
+#include "shader_object_helper.h"
 #include "utils/cast_utils.h"
 #include "layer_validation_tests.h"
 #include "pipeline_helper.h"
@@ -2270,6 +2271,70 @@ TEST_F(NegativeDescriptorBuffer, NoCmdSetDescriptorBufferOffsets) {
     m_errorMonitor->SetDesiredWarning("WARNING-Missing-vkCmdSetDescriptorBufferOffsets");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+// See https://gitlab.khronos.org/vulkan/vulkan/-/issues/4848
+TEST_F(NegativeDescriptorBuffer, IndependentSetMixShaderObject) {
+    TEST_DESCRIPTION("From Zink with dEQP-GLES2.functional.fragment_ops.interaction.basic_shader.29");
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_11_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::maintenance11);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::shaderObject);
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
+    InitDynamicRenderTarget();
+
+    const VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
+    const vkt::DescriptorSetLayout set_layout(*m_device, {binding}, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+    const vkt::PipelineLayout pipeline_layout(*m_device, {&set_layout});
+
+    vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
+    VkDescriptorBufferBindingInfoEXT buffer_binding_info = vku::InitStructHelper();
+    buffer_binding_info.address = buffer.Address();
+    buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
+
+    // Shader object have INDEPENDENT_SETS but have no descriptors actually
+    const auto vert_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
+    VkShaderCreateInfoEXT create_info = ShaderCreateInfo(vert_spv, VK_SHADER_STAGE_VERTEX_BIT);
+    create_info.flags = VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR;
+    const vkt::Shader vert_shader(*m_device, create_info);
+
+    const auto frag_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
+    create_info = ShaderCreateInfo(frag_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
+    create_info.flags = VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR;
+    const vkt::Shader frag_shader(*m_device, create_info);
+
+    VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
+    VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
+    pipeline_rendering_info.colorAttachmentCount = 1;
+    pipeline_rendering_info.pColorAttachmentFormats = &color_format;
+
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
+    pipe.gp_ci_.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    pipe.gp_ci_.layout = pipeline_layout;
+    pipe.CreateGraphicsPipeline();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+
+    const uint32_t index = 0;
+    const VkDeviceSize offset = 0;
+    vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 1, &buffer_binding_info);
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &index, &offset);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+
+    SetDefaultDynamicStatesExclude();
+    const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
+    VkShaderEXT shaders[] = {vert_shader, frag_shader};
+    vk::CmdBindShadersEXT(m_command_buffer, 2u, stages, shaders);
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-flags-13362");
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.EndRendering();
     m_command_buffer.End();
 }
 

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -14,7 +14,6 @@
 #include "layer_validation_tests.h"
 #include "pipeline_helper.h"
 #include "render_pass_helper.h"
-#include "shader_object_helper.h"
 #include "shader_templates.h"
 
 void DescriptorBufferTest::InitBasicDescriptorBuffer(void* instance_pnext) {
@@ -2173,67 +2172,6 @@ TEST_F(PositiveDescriptorBuffer, SetPushConstsWithDifferentLayout) {
                                          &offset);
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.End();
-}
-
-TEST_F(PositiveDescriptorBuffer, IndependentSetMixShaderObject) {
-    TEST_DESCRIPTION("From Zink with dEQP-GLES2.functional.fragment_ops.interaction.basic_shader.29");
-    AddRequiredExtensions(VK_KHR_MAINTENANCE_11_EXTENSION_NAME);
-    AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
-    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::maintenance11);
-    AddRequiredFeature(vkt::Feature::dynamicRendering);
-    AddRequiredFeature(vkt::Feature::shaderObject);
-    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
-    InitDynamicRenderTarget();
-
-    const VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
-    const vkt::DescriptorSetLayout set_layout(*m_device, {binding}, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
-    const vkt::PipelineLayout pipeline_layout(*m_device, {&set_layout});
-
-    vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
-    VkDescriptorBufferBindingInfoEXT buffer_binding_info = vku::InitStructHelper();
-    buffer_binding_info.address = buffer.Address();
-    buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-
-    // Shader object have INDEPENDENT_SETS but have no descriptors actually
-    const auto vert_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
-    VkShaderCreateInfoEXT create_info = ShaderCreateInfo(vert_spv, VK_SHADER_STAGE_VERTEX_BIT);
-    create_info.flags = VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR;
-    const vkt::Shader vert_shader(*m_device, create_info);
-
-    const auto frag_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
-    create_info = ShaderCreateInfo(frag_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
-    create_info.flags = VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR;
-    const vkt::Shader frag_shader(*m_device, create_info);
-
-    VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
-    VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
-    pipeline_rendering_info.colorAttachmentCount = 1;
-    pipeline_rendering_info.pColorAttachmentFormats = &color_format;
-
-    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
-    pipe.gp_ci_.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-    pipe.gp_ci_.layout = pipeline_layout;
-    pipe.CreateGraphicsPipeline();
-
-    m_command_buffer.Begin();
-    m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
-    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
-
-    const uint32_t index = 0;
-    const VkDeviceSize offset = 0;
-    vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 1, &buffer_binding_info);
-    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &index, &offset);
-    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
-
-    SetDefaultDynamicStatesExclude();
-    const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
-    VkShaderEXT shaders[] = {vert_shader, frag_shader};
-    vk::CmdBindShadersEXT(m_command_buffer, 2u, stages, shaders);
-
-    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
-    m_command_buffer.EndRendering();
     m_command_buffer.End();
 }
 


### PR DESCRIPTION
From https://gitlab.khronos.org/vulkan/vulkan/-/issues/4848#note_621791

slight revert of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12314 now that the WG said this should be banned

NOT MERGING until Mike gets his say in the Spec issue