### PR TITLE
layers: Only validate ImageToMemory when dst

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -4418,16 +4418,23 @@ bool CoreChecks::ValidateCmdCopyMemoryToImage(VkCommandBuffer command_buffer,
                                                region.imageExtent.depth, region.imageLayout, region_loc.dot(Field::imageLayout),
                                                "VUID-VkCopyDeviceMemoryImageInfoKHR-imageLayout-13028");
 
-        vvl::range<VkDeviceAddress> region_range{region.addressRange.address,
-                                                 region.addressRange.address + region.addressRange.size};
-        for (uint32_t j = i + 1; j < copy_memory_info.regionCount; ++j) {
-            const VkDeviceMemoryImageCopyKHR& other_region = copy_memory_info.pRegions[j];
-            vvl::range<VkDeviceAddress> other_region_range{other_region.addressRange.address,
-                                                           other_region.addressRange.address + other_region.addressRange.size};
-            if (region_range.intersects(other_region_range)) {
-                skip |= LogError("VUID-VkCopyDeviceMemoryImageInfoKHR-pRegions-12473", objlist, region_loc.dot(Field::addressRange),
-                                 "%s overlaps with pRegions[%" PRIu32 "].addressRange %s", string_range_hex(region_range).c_str(),
-                                 j, string_range_hex(other_region_range).c_str());
+        // only the dst can't overlap, the src can (no such thing as a read-after-read hazard)
+        // the image as a dst is a TODO tracked in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10125
+        if (!is_memory_to_image) {
+            vvl::range<VkDeviceAddress> region_range{region.addressRange.address,
+                                                     region.addressRange.address + region.addressRange.size};
+            for (uint32_t j = i + 1; j < copy_memory_info.regionCount; ++j) {
+                const VkDeviceMemoryImageCopyKHR& other_region = copy_memory_info.pRegions[j];
+                vvl::range<VkDeviceAddress> other_region_range{other_region.addressRange.address,
+                                                               other_region.addressRange.address + other_region.addressRange.size};
+                if (region_range.intersects(other_region_range)) {
+                    skip |=
+                        LogError("VUID-VkCopyDeviceMemoryImageInfoKHR-pRegions-12473", objlist, region_loc.dot(Field::addressRange),
+                                 "%s overlaps with pRegions[%" PRIu32
+                                 "].addressRange %s\nThis will cause a write-after-write memory hazard for buffers:\n%s",
+                                 string_range_hex(region_range).c_str(), j, string_range_hex(other_region_range).c_str(),
+                                 string_BuffersFromAddress(*device_state, region.addressRange.address).c_str());
+                }
             }
         }
 

--- a/tests/unit/device_address_commands.cpp
+++ b/tests/unit/device_address_commands.cpp
@@ -2885,28 +2885,31 @@ TEST_F(NegativeDeviceAddressCommands, CopyImageLayout) {
 TEST_F(NegativeDeviceAddressCommands, CopyAddressRangeOverlap) {
     RETURN_IF_SKIP(InitBasicDeviceAddressCommands());
 
-    vkt::Buffer buffer(*m_device, 32u * 32u * 4u, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, vkt::device_address);
-    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Buffer buffer(*m_device, 32u * 32u * 4u, VK_BUFFER_USAGE_TRANSFER_DST_BIT, vkt::device_address);
+    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+
+    VkDeviceAddressRangeEXT range_0 = {buffer.Address(), 64};
+    VkDeviceAddressRangeEXT range_1 = {buffer.Address() + 32, 64};
 
     VkDeviceMemoryImageCopyKHR regions[2];
     regions[0] = vku::InitStructHelper();
-    regions[0].addressRange = buffer.AddressRange();
+    regions[0].addressRange = range_0;
     regions[0].addressFlags = 0u;
     regions[0].addressRowLength = 0u;
     regions[0].addressImageHeight = 0u;
     regions[0].imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 0u, 1u};
     regions[0].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
     regions[0].imageOffset = {0, 0, 0};
-    regions[0].imageExtent = {32u, 4u, 1u};
+    regions[0].imageExtent = {2u, 2u, 1u};
     regions[1] = vku::InitStructHelper();
-    regions[1].addressRange = buffer.AddressRange();
+    regions[1].addressRange = range_1;
     regions[1].addressFlags = 0u;
     regions[1].addressRowLength = 0u;
     regions[1].addressImageHeight = 0u;
     regions[1].imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 0u, 1u};
     regions[1].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-    regions[1].imageOffset = {0, 4, 0};
-    regions[1].imageExtent = {32u, 4u, 1u};
+    regions[1].imageOffset = {4, 4, 0};
+    regions[1].imageExtent = {2u, 2u, 1u};
 
     VkCopyDeviceMemoryImageInfoKHR copy_memory_info = vku::InitStructHelper();
     copy_memory_info.image = image;
@@ -2915,7 +2918,7 @@ TEST_F(NegativeDeviceAddressCommands, CopyAddressRangeOverlap) {
 
     m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkCopyDeviceMemoryImageInfoKHR-pRegions-12473");
-    vk::CmdCopyMemoryToImageKHR(m_command_buffer, &copy_memory_info);
+    vk::CmdCopyImageToMemoryKHR(m_command_buffer, &copy_memory_info);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }

--- a/tests/unit/device_address_commands_positive.cpp
+++ b/tests/unit/device_address_commands_positive.cpp
@@ -227,6 +227,43 @@ TEST_F(PositiveDeviceAddressCommands, BindVertexBuffers3Stride) {
     m_command_buffer.End();
 }
 
+TEST_F(PositiveDeviceAddressCommands, CopyAddressRangeOverlap) {
+    TEST_DESCRIPTION("the src memory can overlap so this is valid");
+    RETURN_IF_SKIP(InitBasicDeviceAddressCommands());
+
+    vkt::Buffer buffer(*m_device, 32u * 32u * 4u, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, vkt::device_address);
+    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
+    VkDeviceMemoryImageCopyKHR regions[2];
+    regions[0] = vku::InitStructHelper();
+    regions[0].addressRange = buffer.AddressRange();
+    regions[0].addressFlags = 0u;
+    regions[0].addressRowLength = 0u;
+    regions[0].addressImageHeight = 0u;
+    regions[0].imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 0u, 1u};
+    regions[0].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    regions[0].imageOffset = {0, 0, 0};
+    regions[0].imageExtent = {32u, 4u, 1u};
+    regions[1] = vku::InitStructHelper();
+    regions[1].addressRange = buffer.AddressRange();
+    regions[1].addressFlags = 0u;
+    regions[1].addressRowLength = 0u;
+    regions[1].addressImageHeight = 0u;
+    regions[1].imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 0u, 1u};
+    regions[1].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    regions[1].imageOffset = {0, 4, 0};
+    regions[1].imageExtent = {32u, 4u, 1u};
+
+    VkCopyDeviceMemoryImageInfoKHR copy_memory_info = vku::InitStructHelper();
+    copy_memory_info.image = image;
+    copy_memory_info.regionCount = 2u;
+    copy_memory_info.pRegions = regions;
+
+    m_command_buffer.Begin();
+    vk::CmdCopyMemoryToImageKHR(m_command_buffer, &copy_memory_info);
+    m_command_buffer.End();
+}
+
 TEST_F(PositiveDeviceAddressCommands, MultipleRegions) {
     RETURN_IF_SKIP(InitBasicDeviceAddressCommands());
 


### PR DESCRIPTION
this is from https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8382

<img width="911" height="89" alt="image" src="https://github.com/user-attachments/assets/b711b244-9cca-45e3-807d-cbc7dca44d3c" />

The VU is only there to detect Write-after-Write hazard on the copy from `Image to Memory`

when it is `Memory to Image` you can overlap the source memory addresses