### PR TITLE
layers: Fix typo in status message

### DIFF
--- a/layers/chassis/chassis_manual.cpp
+++ b/layers/chassis/chassis_manual.cpp
@@ -93,7 +93,7 @@ void OutputLayerStatusInfo(vvl::DispatchInstance* context, const Location& loc) 
 
     std::ostringstream ss;
     const auto& settings = context->settings;
-    ss << "Current Validaiton Enabled:\n";
+    ss << "Current Validation Enabled:\n";
 
     // Match the order in vkconfig
     // The goal here is to not print ALL the settings, just which parts of validation are turned on


### PR DESCRIPTION
I noticed a typo in a message that got printed every time I ran my program with validation layers on so I fixed it.