### PR TITLE
sync: Rename ExecutionContext to SyncEnvironment

### DIFF
--- a/layers/sync/sync_barrier.cpp
+++ b/layers/sync/sync_barrier.cpp
@@ -378,9 +378,8 @@ void BarrierSet::MakeImageMemoryBarriers(const SyncValidator& sync_state, VkQueu
 // A single barrier can be applied more efficently (immidiately) compared to multiple barrier.
 // The latter are applied in two steps (collect and then apply)
 //
-static void ApplySingleBufferBarrier(ExecutionContext& exec_context, AccessContext& access_context,
-                                     const SyncBufferBarrier& buffer_barrier, const SyncBarrier& exec_dep_barrier) {
-    const QueueId queue_id = exec_context.queue_id;
+static void ApplySingleBufferBarrier(QueueId queue_id, AccessContext& access_context, const SyncBufferBarrier& buffer_barrier,
+                                     const SyncBarrier& exec_dep_barrier) {
     if (SimpleBinding(*buffer_barrier.buffer)) {
         const BarrierScope barrier_scope(buffer_barrier.barrier, queue_id);
         ApplySingleBufferBarrierFunctor apply_barrier(access_context, barrier_scope, buffer_barrier.barrier);
@@ -393,35 +392,31 @@ static void ApplySingleBufferBarrier(ExecutionContext& exec_context, AccessConte
     access_context.RegisterGlobalBarrier(exec_dep_barrier, queue_id);
 }
 
-static void ApplySingleImageBarrier(ExecutionContext& exec_context, AccessContext& access_context,
+static void ApplySingleImageBarrier(const DeviceExtensions& extensions, QueueId queue_id, AccessContext& access_context,
                                     const SyncImageBarrier& image_barrier, const SyncBarrier& exec_dep_barrier,
                                     ResourceUsageTag tag) {
-    const QueueId queue_id = exec_context.queue_id;
     const BarrierScope barrier_scope(image_barrier.barrier, queue_id);
     ApplySingleImageBarrierFunctor apply_barrier(access_context, barrier_scope, image_barrier.barrier,
                                                  image_barrier.layout_transition, image_barrier.handle_index, tag);
 
     const auto& sub_state = SubState(*image_barrier.image);
     const bool can_transition_depth_slices =
-        CanTransitionDepthSlices(exec_context.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+        CanTransitionDepthSlices(extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
     auto range_gen = sub_state.MakeImageRangeGen(image_barrier.subresource_range, can_transition_depth_slices);
 
     access_context.UpdateMemoryAccessState(apply_barrier, range_gen);
     access_context.RegisterGlobalBarrier(exec_dep_barrier, queue_id);
 }
 
-static void ApplySingleMemoryBarrier(ExecutionContext& exec_context, AccessContext& access_context,
-                                     const SyncBarrier& memory_barrier) {
-    access_context.RegisterGlobalBarrier(memory_barrier, exec_context.queue_id);
+static void ApplySingleMemoryBarrier(QueueId queue_id, AccessContext& access_context, const SyncBarrier& memory_barrier) {
+    access_context.RegisterGlobalBarrier(memory_barrier, queue_id);
 }
 
 // This handles all configurations where barriers cannot be applied immidiately and need to use
 // the PendingBarriers helper to ensure independent barrier application. All such configurations
 // use more than one barrier.
-static void ApplyMultipleBarriers(ExecutionContext& exec_context, AccessContext& access_context, const BarrierSet& barrier_set,
-                                  ResourceUsageTag tag) {
-    const QueueId queue_id = exec_context.queue_id;
-
+static void ApplyMultipleBarriers(const DeviceExtensions& extensions, QueueId queue_id, AccessContext& access_context,
+                                  const BarrierSet& barrier_set, ResourceUsageTag tag) {
     // Apply markup action.
     // The markup action does not change any access state but it can trim the access map according to the
     // provided range and creates infill ranges if necessary (for layout transitions). The purpose of all
@@ -442,7 +437,7 @@ static void ApplyMultipleBarriers(ExecutionContext& exec_context, AccessContext&
     for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
         const auto& sub_state = SubState(*barrier.image);
         const bool can_transition_depth_slices =
-            CanTransitionDepthSlices(exec_context.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+            CanTransitionDepthSlices(extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
         auto range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
         // TODO: check if we need: barrier.layout_transition && (queue_id == kQueueIdInvalid)
         ApplyMarkupFunctor markup_action(barrier.layout_transition);
@@ -470,7 +465,7 @@ static void ApplyMultipleBarriers(ExecutionContext& exec_context, AccessContext&
 
         const auto& sub_state = SubState(*barrier.image);
         const bool can_transition_depth_slices =
-            CanTransitionDepthSlices(exec_context.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+            CanTransitionDepthSlices(extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
         auto range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
 
         access_context.UpdateMemoryAccessState(collect_barriers, range_gen);
@@ -496,8 +491,7 @@ static void ApplyMultipleBarriers(ExecutionContext& exec_context, AccessContext&
     }
 }
 
-void ApplyBarrier(ExecutionContext& exec_context, AccessContext& access_context, const BarrierSet& barrier_set,
-                  ResourceUsageTag tag) {
+void ApplyBarrier(SyncEnvironment& env, AccessContext& access_context, const BarrierSet& barrier_set, ResourceUsageTag tag) {
     const bool has_buffer_barriers = !barrier_set.buffer_barriers.empty();
     const bool has_image_barriers = !barrier_set.image_barriers.empty();
 
@@ -512,20 +506,24 @@ void ApplyBarrier(ExecutionContext& exec_context, AccessContext& access_context,
     const bool single_memory_barrier = barrier_set.memory_barriers.size() == 1 && !has_buffer_barriers && !has_image_barriers;
 
     if (single_buffer_barrier) {
-        ApplySingleBufferBarrier(exec_context, access_context, barrier_set.buffer_barriers[0], barrier_set.memory_barriers[0]);
+        const SyncBufferBarrier& buffer_barrier = barrier_set.buffer_barriers[0];
+        const SyncBarrier& exec_dep_barrier = barrier_set.memory_barriers[0];
+        ApplySingleBufferBarrier(env.queue_id, access_context, buffer_barrier, exec_dep_barrier);
     } else if (single_image_barrier) {
-        ApplySingleImageBarrier(exec_context, access_context, barrier_set.image_barriers[0], barrier_set.memory_barriers[0], tag);
+        const SyncImageBarrier& image_barrier = barrier_set.image_barriers[0];
+        const SyncBarrier& exec_dep_barrier = barrier_set.memory_barriers[0];
+        ApplySingleImageBarrier(env.validator.extensions, env.queue_id, access_context, image_barrier, exec_dep_barrier, tag);
     } else if (single_memory_barrier) {
-        ApplySingleMemoryBarrier(exec_context, access_context, barrier_set.memory_barriers[0]);
+        ApplySingleMemoryBarrier(env.queue_id, access_context, barrier_set.memory_barriers[0]);
     } else {
-        ApplyMultipleBarriers(exec_context, access_context, barrier_set, tag);
+        ApplyMultipleBarriers(env.validator.extensions, env.queue_id, access_context, barrier_set, tag);
     }
 
     if (barrier_set.single_exec_scope) {
-        exec_context.events_context.ApplyBarrier(barrier_set.src_exec_scope, barrier_set.dst_exec_scope, tag);
+        env.events_context.ApplyBarrier(barrier_set.src_exec_scope, barrier_set.dst_exec_scope, tag);
     } else {
         for (const auto& barrier : barrier_set.memory_barriers) {
-            exec_context.events_context.ApplyBarrier(barrier.src_exec_scope, barrier.dst_exec_scope, tag);
+            env.events_context.ApplyBarrier(barrier.src_exec_scope, barrier.dst_exec_scope, tag);
         }
     }
 }

--- a/layers/sync/sync_barrier.h
+++ b/layers/sync/sync_barrier.h
@@ -25,7 +25,7 @@ namespace syncval {
 
 class AccessContext;
 class SyncValidator;
-struct ExecutionContext;
+struct SyncEnvironment;
 
 struct SyncExecScope {
     // The xxxStageMask parameter passed by the caller
@@ -162,7 +162,6 @@ struct SemaphoreScope : SyncExecScope {
     QueueId queue;
 };
 
-void ApplyBarrier(ExecutionContext& exec_context, AccessContext& access_context, const BarrierSet& barrier_set,
-                  ResourceUsageTag tag);
+void ApplyBarrier(SyncEnvironment& env, AccessContext& access_context, const BarrierSet& barrier_set, ResourceUsageTag tag);
 
 }  // namespace syncval

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -255,9 +255,9 @@ static void UpdateVideoAccessState(AccessContext& access_context, const vvl::Vid
     access_context.UpdateAccessState(range_gen, current_usage, ResourceUsageTagEx{tag});
 }
 
-ExecutionContext::ExecutionContext(const SyncValidator& validator, VkQueueFlags queue_flags, QueueId queue_id,
-                                   VulkanTypedHandle handle, SyncEventsContext& events_context,
-                                   const ResourceUsageInfoProvider& usage_info_provider)
+SyncEnvironment::SyncEnvironment(const SyncValidator& validator, VkQueueFlags queue_flags, QueueId queue_id,
+                                 VulkanTypedHandle handle, SyncEventsContext& events_context,
+                                 const ResourceUsageInfoProvider& usage_info_provider)
     : validator(validator),
       queue_flags(queue_flags),
       queue_id(queue_id),
@@ -276,7 +276,7 @@ CommandBufferAccessContext::CommandBufferAccessContext(const SyncValidator& sync
       cb_access_context_(sync_validator),
       current_context_(&cb_access_context_),
       events_context_(),
-      execution_context_(sync_validator, queue_flags, kQueueIdInvalid, handle, events_context_, *this),
+      environment_(sync_validator, queue_flags, kQueueIdInvalid, handle, events_context_, *this),
       render_pass_contexts_(),
       current_renderpass_context_(),
       sync_ops_() {}
@@ -980,7 +980,7 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
             LogObjectList obj_list(cb_state_->Handle(), attachment.view->Handle());
             Location loc = attachment.GetLocation(location, output_location);
             const std::string error =
-                error_messages_.Error(hazard, execution_context_, location.function, sync_state_.FormatHandle(*attachment.view),
+                error_messages_.Error(environment_, hazard, location.function, sync_state_.FormatHandle(*attachment.view),
                                       "DynamicRenderingAttachmentError");
             skip |= sync_state_.SyncError(hazard.Hazard(), obj_list, loc.dot(vvl::Field::imageView), error);
         }
@@ -1004,7 +1004,7 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
                 LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
                 Location loc = attachment.GetLocation(location);
                 const std::string error =
-                    error_messages_.Error(hazard, execution_context_, location.function, sync_state_.FormatHandle(*attachment.view),
+                    error_messages_.Error(environment_, hazard, location.function, sync_state_.FormatHandle(*attachment.view),
                                           "DynamicRenderingAttachmentError");
                 skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc.dot(vvl::Field::imageView), error);
             }
@@ -1330,9 +1330,8 @@ ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(
     const auto barrier_tag = NextCommandTag(command, SubCommandType::kSubpassTransition, 0);
     AddCommandHandle(barrier_tag, rp_state.Handle());
     const auto load_tag = NextSubCommandTag(command, SubCommandType::kLoadOp, 0);
-    render_pass_contexts_.emplace_back(
-        std::make_unique<RenderPassAccessContext>(rp_state, render_area, execution_context_.queue_flags, attachment_views,
-                                                  cb_access_context_, current_render_pass_instance_id_));
+    render_pass_contexts_.emplace_back(std::make_unique<RenderPassAccessContext>(
+        rp_state, render_area, environment_.queue_flags, attachment_views, cb_access_context_, current_render_pass_instance_id_));
     current_renderpass_context_ = render_pass_contexts_.back().get();
     current_renderpass_context_->RecordBeginRenderPass(barrier_tag, load_tag);
     current_context_ = &current_renderpass_context_->CurrentContext();
@@ -1380,7 +1379,7 @@ void CommandBufferAccessContext::RecordExecutedCommandBuffer(const CommandBuffer
     for (const auto& sync_op : recorded_cb_context.GetSyncOps()) {
         // we update the range to any include layout transition first use writes,
         // as they are stored along with the source scope (as effective barrier) when recorded
-        sync_op.sync_op->ReplayRecord(execution_context_, *current_context_, base_tag + sync_op.tag);
+        sync_op.sync_op->ReplayRecord(environment_, *current_context_, base_tag + sync_op.tag);
     }
 
     ImportRecordedAccessLog(recorded_cb_context);
@@ -1580,7 +1579,7 @@ void CommandBufferSubState::End() {
 
     // For threads that are dedicated to recording command buffers but do not submit themselves,
     // the end of recording is a logical point to update memory stats
-    access_context.GetExecutionContext().validator.stats.UpdateMemoryStats();
+    access_context.GetSyncState().stats.UpdateMemoryStats();
 }
 
 void CommandBufferSubState::Destroy() {
@@ -1907,7 +1906,7 @@ void CommandBufferSubState::RecordDecodeVideo(vvl::VideoSession& vs_state, const
         context.UpdateAccessState(*src_buffer, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ, src_range, src_tag_ex);
     }
 
-    const vvl::DeviceState* device_state = access_context.GetExecutionContext().validator.device_state;
+    const vvl::DeviceState* device_state = access_context.GetSyncState().device_state;
     auto dst_resource = vvl::VideoPictureResource(*device_state, decode_info.dstPictureResource);
     if (dst_resource) {
         UpdateVideoAccessState(context, vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE, tag);
@@ -1941,7 +1940,7 @@ void CommandBufferSubState::RecordEncodeVideo(vvl::VideoSession& vs_state, const
         context.UpdateAccessState(*src_buffer, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE, src_range, src_tag_ex);
     }
 
-    const vvl::DeviceState* device_state = access_context.GetExecutionContext().validator.device_state;
+    const vvl::DeviceState* device_state = access_context.GetSyncState().device_state;
     auto src_resource = vvl::VideoPictureResource(*device_state, encode_info.srcPictureResource);
     if (src_resource) {
         UpdateVideoAccessState(context, vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ, tag);
@@ -2002,7 +2001,7 @@ void CommandBufferSubState::RecordBeginRenderPass(const VkRenderPassBeginInfo& r
         return;  // [core validation check]: only primary command buffer can begin render pass
     }
 
-    const SyncValidator& validator = access_context.GetExecutionContext().validator;
+    const SyncValidator& validator = access_context.GetSyncState();
     auto rp_state = validator.Get<vvl::RenderPass>(render_pass_begin.renderPass);
     if (!rp_state) {
         return;

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -157,9 +157,9 @@ struct ResourceUsageInfoProvider {
 using AccessLog = std::vector<ResourceUsageRecord>;
 using CommandBufferSet = std::vector<std::shared_ptr<const vvl::CommandBuffer>>;
 
-struct ExecutionContext {
-    ExecutionContext(const SyncValidator& validator, VkQueueFlags queue_flags, QueueId queue_id, VulkanTypedHandle handle,
-                     SyncEventsContext& events_context, const ResourceUsageInfoProvider& usage_info_provider);
+struct SyncEnvironment {
+    SyncEnvironment(const SyncValidator& validator, VkQueueFlags queue_flags, QueueId queue_id, VulkanTypedHandle handle,
+                    SyncEventsContext& events_context, const ResourceUsageInfoProvider& usage_info_provider);
 
     const SyncValidator& validator;
     const VkQueueFlags queue_flags;
@@ -206,8 +206,8 @@ class CommandBufferAccessContext final : public ResourceUsageInfoProvider, publi
     const AccessContext& GetCurrentAccessContext() const { return *current_context_; }
     QueueId GetQueueId() const ;
 
-    ExecutionContext& GetExecutionContext() { return execution_context_; }
-    const ExecutionContext& GetExecutionContext() const { return execution_context_; }
+    SyncEnvironment& GetSyncEnvironment() { return environment_; }
+    const SyncEnvironment& GetSyncEnvironment() const { return environment_; }
 
     // The command buffer's own access context. Subpass contexts exist only inside a vkCmdBeginRenderPass
     // instance, so use this instead of GetCurrentAccessContext() anywhere else. Dynamic rendering has no
@@ -322,7 +322,7 @@ class CommandBufferAccessContext final : public ResourceUsageInfoProvider, publi
     AccessContext *current_context_;
     SyncEventsContext events_context_;
 
-    ExecutionContext execution_context_;
+    SyncEnvironment environment_;
 
     // Don't need the following for an active proxy cb context
     std::vector<std::unique_ptr<RenderPassAccessContext>> render_pass_contexts_;

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -30,16 +30,16 @@ namespace syncval {
 
 ErrorMessages::ErrorMessages(SyncValidator& validator) : validator_(validator) {}
 
-std::string ErrorMessages::Error(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
+std::string ErrorMessages::Error(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                                  const std::string& resource_description, const char* message_type,
                                  const AdditionalMessageInfo& additional_info) const {
-    std::string message = FormatErrorMessage(hazard, context, command, resource_description, additional_info);
+    std::string message = FormatErrorMessage(env, hazard, command, resource_description, additional_info);
 
     if (validator_.syncval_settings.message_extra_properties) {
         if (!message.empty() && message.back() != '\n') {
             message += '\n';
         }
-        const ReportProperties properties = GetErrorMessageProperties(hazard, context, command, message_type, additional_info);
+        const ReportProperties properties = GetErrorMessageProperties(env, hazard, command, message_type, additional_info);
         message += properties.FormatExtraPropertiesSection();
     }
     return message;
@@ -55,7 +55,7 @@ std::string ErrorMessages::BufferError(const HazardResult& hazard, const Command
     ss << "}\n";
     additional_info.message_end_text += ss.str();
 
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "BufferError", additional_info);
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "BufferError", additional_info);
 }
 
 std::string ErrorMessages::BufferCopyError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -71,7 +71,7 @@ std::string ErrorMessages::BufferCopyError(const HazardResult& hazard, const Com
     ss << "}\n";
     additional_info.message_end_text = ss.str();
 
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "BufferCopyError", additional_info);
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "BufferCopyError", additional_info);
 }
 
 std::string ErrorMessages::AccelerationStructureError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -93,7 +93,7 @@ std::string ErrorMessages::AccelerationStructureError(const HazardResult& hazard
     ss2 << "}\n";
     additional_info.message_end_text += ss2.str();
 
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "AccelerationStructureError",
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "AccelerationStructureError",
                  additional_info);
 }
 
@@ -125,7 +125,7 @@ std::string ErrorMessages::ImageCopyResolveBlitError(const HazardResult& hazard,
     additional_info.message_end_text = ss.str();
     additional_info.properties.Add(kPropertyRegionIndex, region_index);
 
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, message_type, additional_info);
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, message_type, additional_info);
 }
 
 std::string ErrorMessages::ImageClearError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -141,7 +141,7 @@ std::string ErrorMessages::ImageClearError(const HazardResult& hazard, const Com
     additional_info.message_end_text = ss.str();
     additional_info.properties.Add(kPropertyRegionIndex, subresource_range_index);
 
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "ImageSubresourceRangeError",
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "ImageSubresourceRangeError",
                  additional_info);
 }
 
@@ -179,7 +179,7 @@ std::string ErrorMessages::BufferDescriptorError(const HazardResult& hazard, con
     ss << ".";
 
     additional_info.pre_synchronization_text = ss.str();
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "BufferDescriptorError", additional_info);
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "BufferDescriptorError", additional_info);
 }
 
 std::string ErrorMessages::ImageDescriptorError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -196,7 +196,7 @@ std::string ErrorMessages::ImageDescriptorError(const HazardResult& hazard, cons
 
     additional_info.pre_synchronization_text = ss.str();
     additional_info.properties.Add(kPropertyImageLayout, string_VkImageLayout(image_layout));
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "ImageDescriptorError", additional_info);
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "ImageDescriptorError", additional_info);
 }
 
 std::string ErrorMessages::AccelerationStructureDescriptorError(
@@ -213,7 +213,7 @@ std::string ErrorMessages::AccelerationStructureDescriptorError(
     ss << ".";
     additional_info.pre_synchronization_text = ss.str();
 
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "AccelerationStructureDescriptorError",
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "AccelerationStructureDescriptorError",
                  additional_info);
 }
 
@@ -234,12 +234,12 @@ std::string ErrorMessages::ClearAttachmentError(const HazardResult& hazard, cons
     additional_info.access_action = "clears";
     additional_info.message_end_text = ss.str();
 
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "ClearAttachmentError", additional_info);
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "ClearAttachmentError", additional_info);
 }
 
 std::string ErrorMessages::RenderPassAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                      vvl::Func command, const std::string& resource_description) const {
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassAttachmentError");
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassAttachmentError");
 }
 
 static const char* GetLoadOpActionName(VkAttachmentLoadOp load_op) {
@@ -275,7 +275,7 @@ std::string ErrorMessages::BeginRenderingError(const HazardResult& hazard, const
     const char* load_op_str = string_VkAttachmentLoadOp(load_op);
     additional_info.properties.Add(kPropertyLoadOp, load_op_str);
     additional_info.access_action = GetLoadOpActionName(load_op);
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "BeginRenderingError", additional_info);
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "BeginRenderingError", additional_info);
 }
 
 std::string ErrorMessages::EndRenderingResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -285,7 +285,7 @@ std::string ErrorMessages::EndRenderingResolveError(const HazardResult& hazard, 
     const char* resolve_mode_str = string_VkResolveModeFlagBits(resolve_mode);
     additional_info.properties.Add(kPropertyResolveMode, resolve_mode_str);
     additional_info.access_action = resolve_write ? "writes to single sample resolve attachment" : "reads multisample attachment";
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "EndRenderingResolveError",
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "EndRenderingResolveError",
                  additional_info);
 }
 
@@ -295,8 +295,7 @@ std::string ErrorMessages::EndRenderingStoreError(const HazardResult& hazard, co
     AdditionalMessageInfo additional_info;
     const char* store_op_str = string_VkAttachmentStoreOp(store_op);
     additional_info.properties.Add(kPropertyStoreOp, store_op_str);
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "EndRenderingStoreError",
-                 additional_info);
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "EndRenderingStoreError", additional_info);
 }
 
 std::string ErrorMessages::RenderPassLoadOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -307,7 +306,7 @@ std::string ErrorMessages::RenderPassLoadOpError(const HazardResult& hazard, con
     additional_info.properties.Add(kPropertyLoadOp, load_op_str);
     additional_info.access_action = GetLoadOpActionName(load_op);
     CheckForLoadOpDontCareInsight(load_op, is_color, additional_info.message_end_text);
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassLoadOpError", additional_info);
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassLoadOpError", additional_info);
 }
 
 std::string ErrorMessages::RenderPassLoadOpVsLayoutTransitionError(const HazardResult& hazard,
@@ -320,13 +319,13 @@ std::string ErrorMessages::RenderPassLoadOpVsLayoutTransitionError(const HazardR
     additional_info.hazard_overview = "attachment loadOp access is not synchronized with the attachment layout transition";
     additional_info.access_action = GetLoadOpActionName(load_op);
     CheckForLoadOpDontCareInsight(load_op, is_color, additional_info.message_end_text);
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassLoadOpVsLayoutTransitionError",
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassLoadOpVsLayoutTransitionError",
                  additional_info);
 }
 
 std::string ErrorMessages::RenderPassResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                   vvl::Func command, const std::string& resource_description) const {
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassResolveError");
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassResolveError");
 }
 
 std::string ErrorMessages::RenderPassStoreOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -335,8 +334,7 @@ std::string ErrorMessages::RenderPassStoreOpError(const HazardResult& hazard, co
     AdditionalMessageInfo additional_info;
     const char* store_op_str = string_VkAttachmentStoreOp(store_op);
     additional_info.properties.Add(kPropertyStoreOp, store_op_str);
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassStoreOpError",
-                 additional_info);
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassStoreOpError", additional_info);
 }
 
 std::string ErrorMessages::RenderPassLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -349,7 +347,7 @@ std::string ErrorMessages::RenderPassLayoutTransitionError(const HazardResult& h
     additional_info.properties.Add(kPropertyOldLayout, old_layout_str);
     additional_info.properties.Add(kPropertyNewLayout, new_layout_str);
     additional_info.access_action = "performs image layout transition";
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassLayoutTransitionError",
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassLayoutTransitionError",
                  additional_info);
 }
 
@@ -369,8 +367,8 @@ std::string ErrorMessages::RenderPassLayoutTransitionVsResolveError(const Hazard
         validator_.FormatHandle(cb_context.GetCurrentRenderPassContext()->GetRenderPassState()->Handle());
     additional_info.brief_description_end_text = "during resolve operation in subpass ";
     additional_info.brief_description_end_text += std::to_string(resolve_subpass);
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description,
-                 "RenderPassLayoutTransitionVsResolveError", additional_info);
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassLayoutTransitionVsResolveError",
+                 additional_info);
 }
 
 std::string ErrorMessages::RenderPassFinalLayoutTransitionError(const HazardResult& hazard,
@@ -386,7 +384,7 @@ std::string ErrorMessages::RenderPassFinalLayoutTransitionError(const HazardResu
     additional_info.access_action =
         "performs final image layout transition during " +
         validator_.FormatHandle(cb_context.GetCurrentRenderPassContext()->GetRenderPassState()->Handle());
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "RenderPassFinalLayoutTransitionError",
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassFinalLayoutTransitionError",
                  additional_info);
 }
 
@@ -408,11 +406,11 @@ std::string ErrorMessages::RenderPassFinalLayoutTransitionVsStoreOrResolveError(
     additional_info.brief_description_end_text = "during store/resolve operation in subpass ";
     additional_info.brief_description_end_text += std::to_string(store_resolve_subpass);
 
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description,
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description,
                  "RenderPassFinalLayoutTransitionVsStoreOrResolveError", additional_info);
 }
 
-std::string ErrorMessages::ImageBarrierError(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
+std::string ErrorMessages::ImageBarrierError(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                                              const std::string& resource_description, const SyncImageBarrier& barrier) const {
     AdditionalMessageInfo additional_info;
     additional_info.access_action = "performs image layout transition on the";
@@ -426,12 +424,12 @@ std::string ErrorMessages::ImageBarrierError(const HazardResult& hazard, const E
     ss << "}\n";
     additional_info.message_end_text = ss.str();
 
-    return Error(hazard, context, command, resource_description, "ImageBarrierError", additional_info);
+    return Error(env, hazard, command, resource_description, "ImageBarrierError", additional_info);
 }
 
-std::string ErrorMessages::FirstUseError(const HazardResult& hazard, const ExecutionContext& exec_context,
+std::string ErrorMessages::FirstUseError(const SyncEnvironment& env, const HazardResult& hazard,
                                          const CommandBufferAccessContext& recorded_context, uint32_t command_buffer_index) const {
-    const ResourceUsageInfo prior_usage_info = exec_context.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
+    const ResourceUsageInfo prior_usage_info = env.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
     const ResourceUsageInfo recorded_usage_info = recorded_context.GetResourceUsageInfo(hazard.RecordedAccess()->TagEx());
 
     AdditionalMessageInfo additional_info;
@@ -442,12 +440,12 @@ std::string ErrorMessages::FirstUseError(const HazardResult& hazard, const Execu
     if (!recorded_usage_info.debug_region_name.empty()) {
         ss << "[" << recorded_usage_info.debug_region_name << "]";
     }
-    if (exec_context.handle.type == kVulkanObjectTypeQueue) {
+    if (env.handle.type == kVulkanObjectTypeQueue) {
         ss << " (from " << validator_.FormatHandle(recorded_context.GetCBState().Handle());
         ss << " submitted on the current ";
-        ss << validator_.FormatHandle(exec_context.handle) << ")";
+        ss << validator_.FormatHandle(env.handle) << ")";
     } else {  // primary command buffer executes secondary one
-        assert(exec_context.handle.type == kVulkanObjectTypeCommandBuffer);
+        assert(env.handle.type == kVulkanObjectTypeCommandBuffer);
         ss << " (from the secondary " << validator_.FormatHandle(recorded_context.GetCBState().Handle()) << ")";
     }
     additional_info.access_initiator = ss.str();
@@ -476,7 +474,7 @@ std::string ErrorMessages::FirstUseError(const HazardResult& hazard, const Execu
     const std::string resource_description = (recorded_usage_info.resource_handle != NullVulkanTypedHandle)
                                                  ? validator_.FormatHandle(recorded_usage_info.resource_handle)
                                                  : "resource";
-    return Error(hazard, exec_context, recorded_usage_info.command, resource_description, "SubmitTimeError", additional_info);
+    return Error(env, hazard, recorded_usage_info.command, resource_description, "SubmitTimeError", additional_info);
 }
 
 std::string ErrorMessages::PresentError(const HazardResult& hazard, const QueueBatchContext& batch_context, vvl::Func command,
@@ -484,12 +482,12 @@ std::string ErrorMessages::PresentError(const HazardResult& hazard, const QueueB
     AdditionalMessageInfo additional_info;
     additional_info.access_action = "presents";
     additional_info.properties.Add(kPropertySwapchainIndex, swapchain_index);
-    return Error(hazard, batch_context.GetExecutionContext(), command, resource_description, "PresentError", additional_info);
+    return Error(batch_context.GetSyncEnvironment(), hazard, command, resource_description, "PresentError", additional_info);
 }
 
 std::string ErrorMessages::VideoError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
                                       const std::string& resource_description) const {
-    return Error(hazard, cb_context.GetExecutionContext(), command, resource_description, "VideoError");
+    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "VideoError");
 }
 
 }  // namespace syncval

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -32,17 +32,17 @@ class Pipeline;
 namespace syncval {
 
 class CommandBufferAccessContext;
-struct ExecutionContext;
 class HazardResult;
 class QueueBatchContext;
 class SyncValidator;
+struct SyncEnvironment;
 struct SyncImageBarrier;
 
 class ErrorMessages {
   public:
     explicit ErrorMessages(SyncValidator& validator);
 
-    std::string Error(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
+    std::string Error(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                       const std::string& resource_description, const char* message_type,
                       const AdditionalMessageInfo& additional_info = {}) const;
 
@@ -128,10 +128,10 @@ class ErrorMessages {
                                                                      VkImageLayout old_layout, VkImageLayout new_layout,
                                                                      uint32_t store_resolve_subpass) const;
 
-    std::string ImageBarrierError(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
+    std::string ImageBarrierError(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                                   const std::string& resource_description, const SyncImageBarrier& barrier) const;
 
-    std::string FirstUseError(const HazardResult& hazard, const ExecutionContext& exec_context,
+    std::string FirstUseError(const SyncEnvironment& env, const HazardResult& hazard,
                               const CommandBufferAccessContext& recorded_context, uint32_t command_buffer_index) const;
 
     std::string PresentError(const HazardResult& hazard, const QueueBatchContext& batch_context, vvl::Func command,

--- a/layers/sync/sync_event.cpp
+++ b/layers/sync/sync_event.cpp
@@ -186,14 +186,12 @@ static SyncBarrier RestrictToEvent(const SyncBarrier& barrier, const SyncEventSt
     return result;
 }
 
-void ApplyWaitEvents(ExecutionContext& exec_context, AccessContext& access_context,
+void ApplyWaitEvents(SyncEnvironment& env, AccessContext& access_context,
                      const std::vector<std::shared_ptr<const vvl::Event>>& events, vvl::span<const BarrierSet> barrier_sets,
                      ResourceUsageTag tag, vvl::Func command) {
     // Unlike PipelineBarrier, WaitEvent is *not* limited to accesses within the current subpass (if any) and thus needs to import
     // all accesses. Can instead import for all first_scopes, or a union of them, if this becomes a performance/memory issue,
     // but with no idea of the performance of the union, nor of whether it even matters... take the simplest approach here,
-
-    const QueueId queue_id = exec_context.queue_id;
 
     access_context.ResolveAllSubpassDependencies();
 
@@ -215,7 +213,7 @@ void ApplyWaitEvents(ExecutionContext& exec_context, AccessContext& access_conte
         if (!event_shared) {
             continue;
         }
-        auto* sync_event = exec_context.events_context.GetFromShared(event_shared);
+        auto* sync_event = env.events_context.GetFromShared(event_shared);
         if (!sync_event->first_scope) {
             continue;  // [core validation check]
         }
@@ -235,8 +233,8 @@ void ApplyWaitEvents(ExecutionContext& exec_context, AccessContext& access_conte
         }
         for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
             const auto& sub_state = SubState(*barrier.image);
-            const bool can_transition_depth_slices = CanTransitionDepthSlices(
-                exec_context.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+            const bool can_transition_depth_slices =
+                CanTransitionDepthSlices(env.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
             ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
             EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
             ApplyMarkupFunctor markup_action(barrier.layout_transition);
@@ -256,7 +254,7 @@ void ApplyWaitEvents(ExecutionContext& exec_context, AccessContext& access_conte
         if (!event_shared.get()) {
             continue;
         }
-        auto* sync_event = exec_context.events_context.GetFromShared(event_shared);
+        auto* sync_event = env.events_context.GetFromShared(event_shared);
         if (!sync_event->first_scope) {
             continue;  // [core validation check]
         }
@@ -271,7 +269,7 @@ void ApplyWaitEvents(ExecutionContext& exec_context, AccessContext& access_conte
         for (const SyncBufferBarrier& barrier : barrier_set.buffer_barriers) {
             if (SimpleBinding(*barrier.buffer)) {
                 const SyncBarrier event_barrier = RestrictToEvent(barrier.barrier, *sync_event);
-                const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
+                const BarrierScope barrier_scope(event_barrier, env.queue_id, sync_event->first_scope_tag);
                 CollectBarriersFunctor collect_barriers(access_context, barrier_scope, event_barrier, false, vvl::kNoIndex32,
                                                         pending_barriers);
 
@@ -284,13 +282,13 @@ void ApplyWaitEvents(ExecutionContext& exec_context, AccessContext& access_conte
         }
         for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
             const SyncBarrier event_barrier = RestrictToEvent(barrier.barrier, *sync_event);
-            const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
+            const BarrierScope barrier_scope(event_barrier, env.queue_id, sync_event->first_scope_tag);
             CollectBarriersFunctor collect_barriers(access_context, barrier_scope, event_barrier, barrier.layout_transition,
                                                     barrier.handle_index, pending_barriers);
 
             const auto& sub_state = SubState(*barrier.image);
-            const bool can_transition_depth_slices = CanTransitionDepthSlices(
-                exec_context.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+            const bool can_transition_depth_slices =
+                CanTransitionDepthSlices(env.validator.extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
             ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
             EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
 
@@ -301,7 +299,7 @@ void ApplyWaitEvents(ExecutionContext& exec_context, AccessContext& access_conte
         auto global_range_gen = EventSimpleRangeGenerator(sync_event->FirstScope(), kFullRange);
         for (const auto& barrier : barrier_set.memory_barriers) {
             const SyncBarrier event_barrier = RestrictToEvent(barrier, *sync_event);
-            const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
+            const BarrierScope barrier_scope(event_barrier, env.queue_id, sync_event->first_scope_tag);
             CollectBarriersFunctor collect_barriers(access_context, barrier_scope, event_barrier, false, vvl::kNoIndex32,
                                                     pending_barriers);
 

--- a/layers/sync/sync_event.cpp
+++ b/layers/sync/sync_event.cpp
@@ -186,9 +186,199 @@ static SyncBarrier RestrictToEvent(const SyncBarrier& barrier, const SyncEventSt
     return result;
 }
 
-void ApplyWaitEvents(SyncEnvironment& env, AccessContext& access_context,
-                     const std::vector<std::shared_ptr<const vvl::Event>>& events, vvl::span<const BarrierSet> barrier_sets,
-                     ResourceUsageTag tag, vvl::Func command) {
+bool ValidateCmdSetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
+                         const SyncExecScope& src_exec_scope, ResourceUsageTag base_tag, const Location& loc) {
+    bool skip = false;
+
+    const auto* sync_event = env.events_context.Get(event);
+    if (!sync_event) {
+        return skip;
+    }
+    if (sync_event->last_command_tag >= base_tag) {
+        return skip;  // for replay we don't want to revalidate internal "last commmand"
+    }
+    if (!sync_event->HasBarrier(src_exec_scope.stage_mask, src_exec_scope.exec_scope)) {
+        const std::string vuid_prefix = std::string("SYNC-") + vvl::String(loc.function);
+        if (IsValueIn(sync_event->last_command,
+                      {vvl::Func::vkCmdResetEvent, vvl::Func::vkCmdResetEvent2, vvl::Func::vkCmdResetEvent2KHR})) {
+            skip |=
+                env.validator.LogError(vuid_prefix + "-reset-race", event->Handle(), loc,
+                                       "%s is set after %s without an intervening execution dependency. This is a race condition "
+                                       "and may result in data hazards.",
+                                       env.validator.FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
+        } else if (IsValueIn(sync_event->last_command,
+                             {vvl::Func::vkCmdSetEvent, vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
+            skip |=
+                env.validator.LogError(vuid_prefix + "-set-race", event->Handle(), loc,
+                                       "%s is set after a previous %s without an intervening execution dependency. This is a race "
+                                       "condition and may result in data hazards.",
+                                       env.validator.FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
+        } else if (IsValueIn(sync_event->last_command,
+                             {vvl::Func::vkCmdWaitEvents, vvl::Func::vkCmdWaitEvents2, vvl::Func::vkCmdWaitEvents2KHR})) {
+            skip |=
+                env.validator.LogError(vuid_prefix + "-wait", event->Handle(), loc,
+                                       "%s is set after %s without intervening vkCmdResetEvent, may result in data hazard.",
+                                       env.validator.FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
+        }
+    }
+    return skip;
+}
+
+bool ValidateCmdResetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
+                           const SyncExecScope& exec_scope, const ResourceUsageTag base_tag, const Location& loc) {
+    bool skip = false;
+    const auto* sync_event = env.events_context.Get(event);
+    if (!sync_event) {
+        return skip;
+    }
+    if (sync_event->last_command_tag > base_tag) {
+        return skip;  // if we validated this in recording of the secondary, don't repeat
+    }
+    if (IsValueIn(sync_event->last_command, {vvl::Func::vkCmdSetEvent, vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR}) &&
+        !sync_event->HasBarrier(exec_scope.stage_mask, exec_scope.exec_scope)) {
+        skip |= env.validator.LogError("SYNC-vkCmdResetEvent-set-race", event->Handle(), loc,
+                                       "%s is reset after %s without an intervening execution dependency. This is a race condition "
+                                       "and may result in data hazards.",
+                                       env.validator.FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
+    }
+    return skip;
+}
+
+bool ValidateCmdWaitEvents(const SyncEnvironment& env, const AccessContext& access_context,
+                           const std::vector<std::shared_ptr<const vvl::Event>>& events,
+                           const vvl::span<const BarrierSet>& barrier_sets, const ResourceUsageTag base_tag, const Location& loc) {
+    bool skip = false;
+
+    // This is only interesting at record and not replay (Execute/Submit) time
+    if (base_tag == ResourceUsageRecord::kMaxIndex) {
+        for (size_t barrier_set_index = 0; barrier_set_index < barrier_sets.size(); barrier_set_index++) {
+            const auto& barrier_set = barrier_sets[barrier_set_index];
+            if (barrier_set.single_exec_scope) {
+                if (barrier_set.src_exec_scope.stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
+                    const std::string vuid =
+                        std::string("SYNC-") + vvl::String(loc.function) + std::string("-hostevent-unsupported");
+                    env.validator.LogInfo(vuid, env.handle, loc,
+                                          "srcStageMask includes %s, unsupported by synchronization validation.",
+                                          string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT));
+                } else {
+                    const auto& barriers = barrier_set.memory_barriers;
+                    for (size_t barrier_index = 0; barrier_index < barriers.size(); barrier_index++) {
+                        const auto& barrier = barriers[barrier_index];
+                        if (barrier.src_exec_scope.stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
+                            const std::string vuid =
+                                std::string("SYNC-") + vvl::String(loc.function) + std::string("-hostevent-unsupported");
+
+                            env.validator.LogInfo(vuid, env.handle, loc,
+                                                  "srcStageMask %s of %s %zu, %s %zu, unsupported by synchronization validation.",
+                                                  string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT), "pDependencyInfo",
+                                                  barrier_set_index, "pMemoryBarriers", barrier_index);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // The rest is common to record time and replay time
+    size_t barrier_set_index = 0;
+    size_t barrier_set_incr = (barrier_sets.size() == 1) ? 0 : 1;
+    for (const auto& event : events) {
+        const auto* sync_event = env.events_context.Get(event);
+        const auto& barrier_set = barrier_sets[barrier_set_index];
+        if (!sync_event || !sync_event->first_scope) {
+            barrier_set_index += barrier_set_incr;
+            continue;  // Core, Lifetimes, or Param check needs to catch invalid events.
+        }
+
+        // For replay calls, don't revalidate "same command buffer" events
+        if (sync_event->last_command_tag >= base_tag) {
+            continue;
+        }
+
+        const VkEvent event_handle = sync_event->event->VkHandle();
+
+        // TODO: Cleanup this error message
+        if (sync_event->unsynchronized_set != vvl::Func::Empty) {
+            // Issue error message that Wait is waiting on an signal subject to race condition, and is thus ignored for
+            // this event
+            const char* const vuid = "SYNC-vkCmdWaitEvents-unsynchronized-setops";
+            const char* const message = "%s Unsychronized %s calls result in race conditions w.r.t. event signalling, %s %s";
+            const char* const reason = "First synchronization scope is undefined.";
+            skip |=
+                env.validator.LogError(vuid, event_handle, loc, message, env.validator.FormatHandle(event_handle).c_str(),
+                                       vvl::String(sync_event->last_command), reason, "Wait operation is ignored for this event.");
+        }
+        if (barrier_set.image_barriers.size()) {
+            const auto& image_memory_barriers = barrier_set.image_barriers;
+            for (const auto& image_memory_barrier : image_memory_barriers) {
+                if (!image_memory_barrier.layout_transition) continue;
+                const auto* image_state = image_memory_barrier.image.get();
+                if (!image_state) continue;
+                const auto& subresource_range = image_memory_barrier.subresource_range;
+                const auto& src_access_scope = image_memory_barrier.barrier.src_access_scope;
+                const auto hazard = access_context.DetectImageBarrierHazard(
+                    *image_state, subresource_range, sync_event->scope.exec_scope, src_access_scope, env.queue_id,
+                    sync_event->FirstScope(), sync_event->first_scope_tag, AccessContext::DetectOptions::kDetectAll);
+                if (hazard.IsHazard()) {
+                    LogObjectList objlist(env.handle, image_state->Handle());
+                    const std::string resource_description = env.validator.FormatHandle(image_state->Handle());
+                    const std::string error = env.validator.error_messages_.ImageBarrierError(
+                        env, hazard, loc.function, resource_description, image_memory_barrier);
+                    skip |= env.validator.SyncError(hazard.Hazard(), image_state->Handle(), loc, error);
+                    break;
+                }
+            }
+        }
+        barrier_set_index += barrier_set_incr;
+    }
+    return skip;
+}
+
+void ApplyCmdSetEvent(SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event, const SyncExecScope& src_exec_scope,
+                      const std::shared_ptr<const AccessContext>& src_access_context, ResourceUsageTag tag, vvl::Func command) {
+    SyncEventState* sync_event = env.events_context.GetFromShared(event);
+    if (!sync_event) {
+        return;
+    }
+
+    // What happens with two SetEvent is that one cannot know what group of operations will be waited for.
+    // Given:
+    //     Stuff1; SetEvent; Stuff2; SetEvent; WaitEvents;
+    // WaitEvents cannot know which of Stuff1, Stuff2, or both has completed execution.
+
+    if (!sync_event->HasBarrier(src_exec_scope.stage_mask, src_exec_scope.exec_scope)) {
+        sync_event->unsynchronized_set = sync_event->last_command;
+        sync_event->ResetFirstScope();
+    } else if (!sync_event->first_scope) {
+        // We only set the scope if there isn't one
+        sync_event->scope = src_exec_scope;
+
+        // Save the shared_ptr to copy of the access_context present at set time (sent us by the caller)
+        sync_event->first_scope = src_access_context;
+        sync_event->unsynchronized_set = vvl::Func::Empty;
+        sync_event->first_scope_tag = tag;
+    }
+    sync_event->last_command = command;
+    sync_event->last_command_tag = tag;
+    sync_event->barriers = 0;
+}
+
+void ApplyCmdResetEvent(SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event, ResourceUsageTag tag,
+                        vvl::Func command) {
+    SyncEventState* sync_event = env.events_context.GetFromShared(event);
+    if (!sync_event) {
+        return;
+    }
+    sync_event->last_command = command;
+    sync_event->last_command_tag = tag;
+    sync_event->unsynchronized_set = vvl::Func::Empty;
+    sync_event->ResetFirstScope();
+    sync_event->barriers = 0;
+}
+
+void ApplyCmdWaitEvents(SyncEnvironment& env, AccessContext& access_context,
+                        const std::vector<std::shared_ptr<const vvl::Event>>& events, vvl::span<const BarrierSet> barrier_sets,
+                        ResourceUsageTag tag, vvl::Func command) {
     // Unlike PipelineBarrier, WaitEvent is *not* limited to accesses within the current subpass (if any) and thus needs to import
     // all accesses. Can instead import for all first_scopes, or a union of them, if this becomes a performance/memory issue,
     // but with no idea of the performance of the union, nor of whether it even matters... take the simplest approach here,

--- a/layers/sync/sync_event.h
+++ b/layers/sync/sync_event.h
@@ -27,13 +27,32 @@ namespace vvl {
 class Event;
 }
 
+struct Location;
+
 namespace syncval {
 
 class AccessContext;
 struct SyncEnvironment;
 
-void ApplyWaitEvents(SyncEnvironment& env, AccessContext& access_context,
-                     const std::vector<std::shared_ptr<const vvl::Event>>& events, vvl::span<const BarrierSet> barrier_sets,
-                     ResourceUsageTag tag, vvl::Func command);
+bool ValidateCmdSetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
+                         const SyncExecScope& src_exec_scope, ResourceUsageTag base_tag, const Location& loc);
+
+bool ValidateCmdResetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
+                           const SyncExecScope& exec_scope, ResourceUsageTag base_tag, const Location& loc);
+
+bool ValidateCmdWaitEvents(const SyncEnvironment& env, const AccessContext& access_context,
+                           const std::vector<std::shared_ptr<const vvl::Event>>& events,
+                           const vvl::span<const BarrierSet>& barrier_sets, const ResourceUsageTag base_tag, const Location& loc);
+
+// Main functionality of the correspodning Record methods, which perform additional setup
+void ApplyCmdSetEvent(SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event, const SyncExecScope& src_exec_scope,
+                      const std::shared_ptr<const AccessContext>& src_access_context, ResourceUsageTag tag, vvl::Func command);
+
+void ApplyCmdResetEvent(SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event, ResourceUsageTag tag,
+                        vvl::Func command);
+
+void ApplyCmdWaitEvents(SyncEnvironment& env, AccessContext& access_context,
+                        const std::vector<std::shared_ptr<const vvl::Event>>& events, vvl::span<const BarrierSet> barrier_sets,
+                        ResourceUsageTag tag, vvl::Func command);
 
 }  // namespace syncval

--- a/layers/sync/sync_event.h
+++ b/layers/sync/sync_event.h
@@ -30,9 +30,9 @@ class Event;
 namespace syncval {
 
 class AccessContext;
-struct ExecutionContext;
+struct SyncEnvironment;
 
-void ApplyWaitEvents(ExecutionContext& exec_context, AccessContext& access_context,
+void ApplyWaitEvents(SyncEnvironment& env, AccessContext& access_context,
                      const std::vector<std::shared_ptr<const vvl::Event>>& events, vvl::span<const BarrierSet> barrier_sets,
                      ResourceUsageTag tag, vvl::Func command);
 

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -36,9 +36,9 @@ namespace syncval {
 
 SyncOpPipelineBarrier::SyncOpPipelineBarrier(BarrierSet&& barrier_set) : barrier_set_(std::move(barrier_set)) {}
 
-void SyncOpPipelineBarrier::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
+void SyncOpPipelineBarrier::ReplayRecord(SyncEnvironment& env, AccessContext& access_context,
                                          const ResourceUsageTag exec_tag) const {
-    ApplyBarrier(exec_context, access_context, barrier_set_, exec_tag);
+    ApplyBarrier(env, access_context, barrier_set_, exec_tag);
 }
 
 bool SyncOpPipelineBarrier::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
@@ -55,52 +55,47 @@ SyncOpSetEvent::SyncOpSetEvent(std::shared_ptr<const vvl::Event>&& event, const 
       src_exec_scope_(src_exec_scope) {}
 
 bool SyncOpSetEvent::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    ExecutionContext& exec_context = replay.exec_context;
     const ResourceUsageTag exec_tag = replay.base_tag + recorded_tag;
-    return exec_context.validator.ValidateCmdSetEvent(exec_context, event_, src_exec_scope_, exec_tag, Location(command_));
+    return replay.env.validator.ValidateCmdSetEvent(replay.env, event_, src_exec_scope_, exec_tag, Location(command_));
 }
 
-void SyncOpSetEvent::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const {
+void SyncOpSetEvent::ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const {
     // Create a copy of the current context, and merge in the state snapshot at record set event time
     // Note: we mustn't change the recorded context copy, as a given CB could be submitted more than once (in generaL)
 
     // Note: merged_context is a copy of the access_context, combined with the recorded context
     auto merged_context = std::make_shared<AccessContext>(*access_context.validator);
     merged_context->InitFrom(access_context);
-    merged_context->ResolveFromContext(QueueTagOffsetBarrierAction(exec_context.queue_id, exec_tag), *recorded_context_);
+    merged_context->ResolveFromContext(QueueTagOffsetBarrierAction(env.queue_id, exec_tag), *recorded_context_);
     merged_context->TrimAndClearFirstAccess();  // Ensure the copy is minimal and normalized
 
-    exec_context.validator.ApplySetEvent(exec_context, event_, src_exec_scope_, merged_context, exec_tag, command_);
+    env.validator.ApplySetEvent(env, event_, src_exec_scope_, merged_context, exec_tag, command_);
 }
 
 SyncOpResetEvent::SyncOpResetEvent(std::shared_ptr<const vvl::Event>&& event, const SyncExecScope& exec_scope, const Location& loc)
     : SyncOpBase(loc.function), event_(std::move(event)), exec_scope_(exec_scope) {}
 
 bool SyncOpResetEvent::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    ExecutionContext& exec_context = replay.exec_context;
     const ResourceUsageTag exec_tag = replay.base_tag + recorded_tag;
-    return exec_context.validator.ValidateCmdResetEvent(exec_context, event_, exec_scope_, exec_tag, Location(command_));
+    return replay.env.validator.ValidateCmdResetEvent(replay.env, event_, exec_scope_, exec_tag, Location(command_));
 }
 
-void SyncOpResetEvent::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
-                                    ResourceUsageTag exec_tag) const {
-    exec_context.validator.ApplyResetEvent(exec_context, event_, exec_tag, command_);
+void SyncOpResetEvent::ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const {
+    env.validator.ApplyResetEvent(env, event_, exec_tag, command_);
 }
 
 SyncOpWaitEvents::SyncOpWaitEvents(std::vector<std::shared_ptr<const vvl::Event>>&& events, std::vector<BarrierSet>&& barrier_sets,
                                    const Location& loc)
     : SyncOpBase(loc.function), events_(std::move(events)), barrier_sets_(std::move(barrier_sets)) {}
 
-void SyncOpWaitEvents::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
-                                    ResourceUsageTag exec_tag) const {
-    ApplyWaitEvents(exec_context, access_context, events_, barrier_sets_, exec_tag, command_);
+void SyncOpWaitEvents::ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const {
+    ApplyWaitEvents(env, access_context, events_, barrier_sets_, exec_tag, command_);
 }
 
 bool SyncOpWaitEvents::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    ExecutionContext& exec_context = replay.exec_context;
     const ResourceUsageTag exec_tag = replay.base_tag + recorded_tag;
-    return exec_context.validator.ValidateCmdWaitEvents(exec_context, replay.GetReplayContext(), events_, barrier_sets_, exec_tag,
-                                                        Location(command_));
+    return replay.env.validator.ValidateCmdWaitEvents(replay.env, replay.GetReplayContext(), events_, barrier_sets_, exec_tag,
+                                                      Location(command_));
 }
 
 SyncOpBeginRenderPass::SyncOpBeginRenderPass(std::shared_ptr<const vvl::RenderPass>&& rp_state,
@@ -109,15 +104,14 @@ SyncOpBeginRenderPass::SyncOpBeginRenderPass(std::shared_ptr<const vvl::RenderPa
     : SyncOpBase(loc.function), rp_state_(std::move(rp_state)), attachments_(std::move(attachments)), rp_context_(rp_context) {}
 
 bool SyncOpBeginRenderPass::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    replay.rp_replay.emplace(rp_context_, replay.replay_context, replay.exec_context.queue_flags);
+    replay.rp_replay.emplace(rp_context_, replay.replay_context, replay.env.queue_flags);
 
     // Only the layout transitions happen at the replay tag, loadOp's happen at a subsequent tag
     ResourceUsageRange first_use_range = {recorded_tag, recorded_tag + 1};
     return replay.DetectFirstUseHazard(first_use_range);
 }
 
-void SyncOpBeginRenderPass::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
-                                         ResourceUsageTag exec_tag) const {
+void SyncOpBeginRenderPass::ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const {
     // All the needed replay state changes (for the layout transition, and context update) have to happen in ReplayValidate
 }
 
@@ -139,8 +133,7 @@ bool SyncOpNextSubpass::ReplayValidate(ReplayState& replay, ResourceUsageTag rec
     return skip;
 }
 
-void SyncOpNextSubpass::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
-                                     ResourceUsageTag exec_tag) const {
+void SyncOpNextSubpass::ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const {
     // All the needed replay state changes (for the layout transition, and context update) have to happen in ReplayValidate
 }
 
@@ -165,12 +158,11 @@ bool SyncOpEndRenderPass::ReplayValidate(ReplayState& replay, ResourceUsageTag r
     return skip;
 }
 
-void SyncOpEndRenderPass::ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context,
-                                       ResourceUsageTag exec_tag) const {}
+void SyncOpEndRenderPass::ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const {}
 
 ReplayState::ReplayState(CommandBufferAccessContext& primary_cb_context, const CommandBufferAccessContext& recorded_context,
                          ResourceUsageTag base_tag, const Location& cb_loc)
-    : exec_context(primary_cb_context.GetExecutionContext()),
+    : env(primary_cb_context.GetSyncEnvironment()),
       replay_context(primary_cb_context.GetCurrentAccessContext()),
       recorded_context(recorded_context),
       base_tag(base_tag),
@@ -178,7 +170,7 @@ ReplayState::ReplayState(CommandBufferAccessContext& primary_cb_context, const C
 
 ReplayState::ReplayState(QueueBatchContext& batch_context, const CommandBufferAccessContext& recorded_context,
                          ResourceUsageTag base_tag, const Location& cb_loc)
-    : exec_context(batch_context.GetExecutionContext()),
+    : env(batch_context.GetSyncEnvironment()),
       replay_context(batch_context.GetAccessContext()),
       recorded_context(recorded_context),
       base_tag(base_tag),
@@ -191,13 +183,11 @@ bool ReplayState::DetectFirstUseHazard(const ResourceUsageRange& first_use_range
     }
     const AccessContext& recorded_access_context =
         rp_replay ? rp_replay->GetCurrentRecordedContext() : recorded_context.GetCbAccessContext();
-    const HazardResult hazard =
-        recorded_access_context.DetectFirstUseHazard(exec_context.queue_id, first_use_range, GetReplayContext());
+    const HazardResult hazard = recorded_access_context.DetectFirstUseHazard(env.queue_id, first_use_range, GetReplayContext());
     if (hazard.IsHazard()) {
-        const SyncValidator& sync_state = exec_context.validator;
-        LogObjectList objlist(exec_context.handle, recorded_context.GetCBState().Handle());
-        const std::string error = sync_state.error_messages_.FirstUseError(hazard, exec_context, recorded_context, cb_loc.index);
-        skip |= sync_state.SyncError(hazard.Hazard(), objlist, cb_loc, error);
+        LogObjectList objlist(env.handle, recorded_context.GetCBState().Handle());
+        const std::string error = env.validator.error_messages_.FirstUseError(env, hazard, recorded_context, cb_loc.index);
+        skip |= env.validator.SyncError(hazard.Hazard(), objlist, cb_loc, error);
     }
     return skip;
 }
@@ -224,7 +214,7 @@ bool ReplayState::ValidateFirstUse() {
 
         // Validate and record sync_ops that make memory accesses (for example, image layout transition)
         skip |= sync_op.sync_op->ReplayValidate(*this, sync_op.tag);
-        sync_op.sync_op->ReplayRecord(exec_context, GetReplayContext(), base_tag + sync_op.tag);
+        sync_op.sync_op->ReplayRecord(env, GetReplayContext(), base_tag + sync_op.tag);
 
         // Advance past sync_op
         first_use_range.begin = sync_op.tag + 1;

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -56,7 +56,7 @@ SyncOpSetEvent::SyncOpSetEvent(std::shared_ptr<const vvl::Event>&& event, const 
 
 bool SyncOpSetEvent::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
     const ResourceUsageTag exec_tag = replay.base_tag + recorded_tag;
-    return replay.env.validator.ValidateCmdSetEvent(replay.env, event_, src_exec_scope_, exec_tag, Location(command_));
+    return ValidateCmdSetEvent(replay.env, event_, src_exec_scope_, exec_tag, Location(command_));
 }
 
 void SyncOpSetEvent::ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const {
@@ -69,7 +69,7 @@ void SyncOpSetEvent::ReplayRecord(SyncEnvironment& env, AccessContext& access_co
     merged_context->ResolveFromContext(QueueTagOffsetBarrierAction(env.queue_id, exec_tag), *recorded_context_);
     merged_context->TrimAndClearFirstAccess();  // Ensure the copy is minimal and normalized
 
-    env.validator.ApplySetEvent(env, event_, src_exec_scope_, merged_context, exec_tag, command_);
+    ApplyCmdSetEvent(env, event_, src_exec_scope_, merged_context, exec_tag, command_);
 }
 
 SyncOpResetEvent::SyncOpResetEvent(std::shared_ptr<const vvl::Event>&& event, const SyncExecScope& exec_scope, const Location& loc)
@@ -77,11 +77,11 @@ SyncOpResetEvent::SyncOpResetEvent(std::shared_ptr<const vvl::Event>&& event, co
 
 bool SyncOpResetEvent::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
     const ResourceUsageTag exec_tag = replay.base_tag + recorded_tag;
-    return replay.env.validator.ValidateCmdResetEvent(replay.env, event_, exec_scope_, exec_tag, Location(command_));
+    return ValidateCmdResetEvent(replay.env, event_, exec_scope_, exec_tag, Location(command_));
 }
 
 void SyncOpResetEvent::ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const {
-    env.validator.ApplyResetEvent(env, event_, exec_tag, command_);
+    ApplyCmdResetEvent(env, event_, exec_tag, command_);
 }
 
 SyncOpWaitEvents::SyncOpWaitEvents(std::vector<std::shared_ptr<const vvl::Event>>&& events, std::vector<BarrierSet>&& barrier_sets,
@@ -89,13 +89,12 @@ SyncOpWaitEvents::SyncOpWaitEvents(std::vector<std::shared_ptr<const vvl::Event>
     : SyncOpBase(loc.function), events_(std::move(events)), barrier_sets_(std::move(barrier_sets)) {}
 
 void SyncOpWaitEvents::ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const {
-    ApplyWaitEvents(env, access_context, events_, barrier_sets_, exec_tag, command_);
+    ApplyCmdWaitEvents(env, access_context, events_, barrier_sets_, exec_tag, command_);
 }
 
 bool SyncOpWaitEvents::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
     const ResourceUsageTag exec_tag = replay.base_tag + recorded_tag;
-    return replay.env.validator.ValidateCmdWaitEvents(replay.env, replay.GetReplayContext(), events_, barrier_sets_, exec_tag,
-                                                      Location(command_));
+    return ValidateCmdWaitEvents(replay.env, replay.GetReplayContext(), events_, barrier_sets_, exec_tag, Location(command_));
 }
 
 SyncOpBeginRenderPass::SyncOpBeginRenderPass(std::shared_ptr<const vvl::RenderPass>&& rp_state,

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -32,7 +32,7 @@ class RenderPass;
 namespace syncval {
 
 class CommandBufferAccessContext;
-struct ExecutionContext;
+struct SyncEnvironment;
 class QueueBatchContext;
 class RenderPassAccessContext;
 class SyncValidator;
@@ -120,7 +120,7 @@ class SyncOpBase {
     SyncOpBase(vvl::Func command) : command_(command) {}
     virtual ~SyncOpBase() = default;
     virtual bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const = 0;
-    virtual void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const = 0;
+    virtual void ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const = 0;
 
   protected:
     vvl::Func command_ = vvl::Func::Empty;
@@ -130,7 +130,7 @@ class SyncOpPipelineBarrier : public SyncOpBase {
   public:
     SyncOpPipelineBarrier(BarrierSet&& barrier_set);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 
   private:
     BarrierSet barrier_set_;
@@ -141,7 +141,7 @@ class SyncOpSetEvent : public SyncOpBase {
     SyncOpSetEvent(std::shared_ptr<const vvl::Event>&& event, const SyncExecScope& src_exec_scope,
                    std::shared_ptr<const AccessContext>&& src_access_context, const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 
   private:
     std::shared_ptr<const vvl::Event> event_;
@@ -154,7 +154,7 @@ class SyncOpResetEvent : public SyncOpBase {
   public:
     SyncOpResetEvent(std::shared_ptr<const vvl::Event>&& event, const SyncExecScope& exec_scope, const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 
   private:
     std::shared_ptr<const vvl::Event> event_;
@@ -166,7 +166,7 @@ class SyncOpWaitEvents : public SyncOpBase {
     SyncOpWaitEvents(std::vector<std::shared_ptr<const vvl::Event>>&& events, std::vector<BarrierSet>&& barrier_sets,
                      const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 
   private:
     // TODO PHASE2 This is the wrong thing to use for "replay".. as the event state will have moved on since the record
@@ -182,7 +182,7 @@ class SyncOpBeginRenderPass : public SyncOpBase {
                           std::vector<std::shared_ptr<const vvl::ImageView>>&& attachments,
                           const RenderPassAccessContext* rp_context, const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
     const RenderPassAccessContext* GetRenderPassAccessContext() const { return rp_context_; }
 
   protected:
@@ -199,14 +199,14 @@ class SyncOpNextSubpass : public SyncOpBase {
   public:
     SyncOpNextSubpass(const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 };
 
 class SyncOpEndRenderPass : public SyncOpBase {
   public:
     SyncOpEndRenderPass(const Location& loc);
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
-    void ReplayRecord(ExecutionContext& exec_context, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
+    void ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const override;
 };
 
 // Render pass state for submit-time replay. The accesses come from RenderPassAccessContext's
@@ -240,7 +240,7 @@ struct ReplayState {
     AccessContext& GetReplayContext();
     const AccessContext& GetReplayContext() const;
 
-    ExecutionContext& exec_context;
+    SyncEnvironment& env;
     AccessContext& replay_context;
     const CommandBufferAccessContext& recorded_context;
     std::optional<RenderPassReplayState> rp_replay;

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -119,7 +119,7 @@ static std::string FormatAccessProperty(const SyncAccessInfo& access) {
     return ss.str();
 }
 
-static void GetAccessProperties(const HazardResult& hazard_result, const SyncValidator& device, VkQueueFlags allowed_queue_flags,
+static void GetAccessProperties(const SyncValidator& validator, const HazardResult& hazard_result, VkQueueFlags allowed_queue_flags,
                                 ReportProperties& properties) {
     const HazardResult::HazardState& hazard = hazard_result.State();
     const SyncAccessInfo& access_info = GetAccessInfo(hazard.access_index);
@@ -136,7 +136,7 @@ static void GetAccessProperties(const HazardResult& hazard_result, const SyncVal
         properties.Add(kPropertyReadBarriers, barriers ? barriers_str : "0");
     } else {
         const SyncAccessFlags barriers = hazard.access_state->GetWriteBarriers();
-        const std::string property_barriers_str = FormatSyncAccesses(barriers, device, allowed_queue_flags, true);
+        const std::string property_barriers_str = FormatSyncAccesses(validator, barriers, allowed_queue_flags, true);
         properties.Add(kPropertyWriteBarriers, property_barriers_str);
     }
 }
@@ -212,15 +212,16 @@ static void ReplaceExpandBitsWithMetaMask(VkFlags64& mask, VkFlags64 expand_bits
 }
 
 static std::vector<std::pair<VkPipelineStageFlags2, VkAccessFlags2>> ConvertSyncAccessesToCompactVkForm(
-    const SyncAccessFlags& sync_accesses, const SyncValidator& device, VkQueueFlags allowed_queue_flags) {
+    const SyncValidator& validator, const SyncAccessFlags& sync_accesses, VkQueueFlags allowed_queue_flags) {
     if (sync_accesses.none()) {
         return {};
     }
 
-    const VkPipelineStageFlags2 disabled_stages = sync_utils::DisabledPipelineStages(device.enabled_features, device.extensions);
+    const VkPipelineStageFlags2 disabled_stages =
+        sync_utils::DisabledPipelineStages(validator.enabled_features, validator.extensions);
     const VkPipelineStageFlags2 all_transfer_expand_bits = kAllTransferExpandBits & ~disabled_stages;
 
-    const VkAccessFlags2 disabled_accesses = sync_utils::DisabledAccesses(device.extensions);
+    const VkAccessFlags2 disabled_accesses = sync_utils::DisabledAccesses(validator.extensions);
     const VkAccessFlags2 all_shader_read_bits = kShaderReadExpandBits & ~disabled_accesses;
 
     // Build stage -> accesses mapping. OR-merge accesses that happen on the same stage.
@@ -279,7 +280,7 @@ static std::vector<std::pair<VkPipelineStageFlags2, VkAccessFlags2>> ConvertSync
             all_accesses_supported_by_stages &= ~VK_ACCESS_2_SHADER_WRITE_BIT;
             // Remove unsupported accesses, otherwise the access mask won't be detected as the one that covers ALL accesses
             // TODO: ideally this should be integrated into utilities logic (need to revisit all use cases)
-            if (!IsExtEnabled(device.extensions.vk_ext_blend_operation_advanced)) {
+            if (!IsExtEnabled(validator.extensions.vk_ext_blend_operation_advanced)) {
                 all_accesses_supported_by_stages &= ~VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT;
             }
         }
@@ -314,10 +315,9 @@ static std::vector<std::pair<VkPipelineStageFlags2, VkAccessFlags2>> ConvertSync
 // Given that access is hazardous, we check if at least stage or access part of it is covered
 // by the synchronization. If applied synchronization covers at least stage or access component
 // then we can provide more precise message by focusing on the other component.
-static std::pair<bool, bool> GetPartialProtectedInfo(const SyncAccessInfo& access, const SyncAccessFlags& write_barriers,
-                                                     const ExecutionContext& context) {
-    const auto protected_stage_access_pairs =
-        ConvertSyncAccessesToCompactVkForm(write_barriers, context.validator, context.queue_flags);
+static std::pair<bool, bool> GetPartialProtectedInfo(const SyncEnvironment& env, const SyncAccessInfo& access,
+                                                     const SyncAccessFlags& write_barriers) {
+    const auto protected_stage_access_pairs = ConvertSyncAccessesToCompactVkForm(env.validator, write_barriers, env.queue_flags);
     bool is_stage_protected = false;
     bool is_access_protected = false;
     for (const auto& protected_stage_access : protected_stage_access_pairs) {
@@ -387,17 +387,17 @@ std::string ReportProperties::FormatExtraPropertiesSection() const {
     return ss.str();
 }
 
-ReportProperties GetErrorMessageProperties(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
+ReportProperties GetErrorMessageProperties(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                                            const char* message_type, const AdditionalMessageInfo& additional_info) {
     ReportProperties properties;
     properties.Add(kPropertyMessageType, message_type);
     properties.Add(kPropertyHazardType, string_SyncHazard(hazard.Hazard()));
     properties.Add(kPropertyCommand, vvl::String(command));
 
-    GetAccessProperties(hazard, context.validator, context.queue_flags, properties);
+    GetAccessProperties(env.validator, hazard, env.queue_flags, properties);
 
     if (hazard.Tag() != kInvalidTag) {
-        ResourceUsageInfo prior_usage_info = context.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
+        ResourceUsageInfo prior_usage_info = env.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
         GetPriorUsageProperties(prior_usage_info, properties);
     }
     for (const auto& property : additional_info.properties.name_values) {
@@ -406,7 +406,7 @@ ReportProperties GetErrorMessageProperties(const HazardResult& hazard, const Exe
     return properties;
 }
 
-std::string FormatErrorMessage(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
+std::string FormatErrorMessage(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                                const std::string& resouce_description, const AdditionalMessageInfo& additional_info) {
     const SyncHazard hazard_type = hazard.Hazard();
     const SyncHazardInfo hazard_info = GetSyncHazardInfo(hazard_type);
@@ -458,7 +458,7 @@ std::string FormatErrorMessage(const HazardResult& hazard, const ExecutionContex
         // resolve before ILT or ILT after storeOp.
         ss << "by the same command";
     } else {
-        const ResourceUsageInfo prior_usage_info = context.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
+        const ResourceUsageInfo prior_usage_info = env.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
         const vvl::Func prior_command = prior_usage_info.command;
         if (prior_usage_info.sub_command_type == SubCommandType::kLoadOp) {
             if (prior_usage_info.subpass != vvl::kNoIndex32) {
@@ -507,7 +507,7 @@ std::string FormatErrorMessage(const HazardResult& hazard, const ExecutionContex
     }
 
     // Synchronization information
-    const bool cross_queue_racing_hazard = hazard_info.IsRacingHazard() && context.queue_id != kQueueIdInvalid;
+    const bool cross_queue_racing_hazard = hazard_info.IsRacingHazard() && env.queue_id != kQueueIdInvalid;
     ss << "\n";
     if (cross_queue_racing_hazard) {
         ss << "The RACING hazard means the two submissions on different queues are not synchronized with each other, so the order "
@@ -561,8 +561,8 @@ std::string FormatErrorMessage(const HazardResult& hazard, const ExecutionContex
         ss << ".";
     } else if (hazard_info.IsPriorWrite()) {  // RAW/WAW hazards
         ss << "The current synchronization allows ";
-        ss << FormatSyncAccesses(write_barriers, context.validator, context.queue_flags, false);
-        auto [is_stage_protected, is_access_protected] = GetPartialProtectedInfo(access, write_barriers, context);
+        ss << FormatSyncAccesses(env.validator, write_barriers, env.queue_flags, false);
+        auto [is_stage_protected, is_access_protected] = GetPartialProtectedInfo(env, access, write_barriers);
         if (is_access_protected) {
             ss << ", but to prevent this hazard, it must allow these accesses at ";
             ss << string_VkPipelineStageFlagBits2(access.stage_mask) << ".";
@@ -614,9 +614,9 @@ std::string FormatErrorMessage(const HazardResult& hazard, const ExecutionContex
     return ss.str();
 }
 
-std::string FormatSyncAccesses(const SyncAccessFlags& sync_accesses, const SyncValidator& device, VkQueueFlags allowed_queue_flags,
-                               bool format_as_extra_property) {
-    const auto report_accesses = ConvertSyncAccessesToCompactVkForm(sync_accesses, device, allowed_queue_flags);
+std::string FormatSyncAccesses(const SyncValidator& validator, const SyncAccessFlags& sync_accesses,
+                               VkQueueFlags allowed_queue_flags, bool format_as_extra_property) {
+    const auto report_accesses = ConvertSyncAccessesToCompactVkForm(validator, sync_accesses, allowed_queue_flags);
     if (report_accesses.empty()) {
         return "0";
     }

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -24,7 +24,7 @@ class Logger;
 
 namespace syncval {
 
-struct ExecutionContext;
+struct SyncEnvironment;
 class HazardResult;
 class SyncValidator;
 
@@ -63,14 +63,14 @@ struct AdditionalMessageInfo {
     std::string message_end_text;
 };
 
-ReportProperties GetErrorMessageProperties(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
+ReportProperties GetErrorMessageProperties(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                                            const char* message_type, const AdditionalMessageInfo& additional_info);
 
-std::string FormatErrorMessage(const HazardResult& hazard, const ExecutionContext& context, vvl::Func command,
+std::string FormatErrorMessage(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                                const std::string& resouce_description, const AdditionalMessageInfo& additional_info);
 
-std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const SyncValidator &device, VkQueueFlags allowed_queue_flags,
-                               bool format_as_extra_property);
+std::string FormatSyncAccesses(const SyncValidator& validator, const SyncAccessFlags& sync_accesses,
+                               VkQueueFlags allowed_queue_flags, bool format_as_extra_property);
 
 void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourceInfoKHR &video_picture, std::ostringstream &ss);
 void FormatVideoQuantizationMap(const Logger &logger, const VkVideoEncodeQuantizationMapInfoKHR &quantization_map,

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -265,8 +265,8 @@ QueueBatchContext::QueueBatchContext(const SyncValidator& sync_state, const Queu
       queue_state_(&queue_state),
       tag_range_(0, 0),
       access_context_(sync_state),
-      execution_context_(sync_state, queue_state.GetQueue()->GetQueueFlags(), queue_state.GetQueueId(),
-                         queue_state.GetQueue()->Handle(), events_context_, *this),
+      environment_(sync_state, queue_state.GetQueue()->GetQueueFlags(), queue_state.GetQueueId(), queue_state.GetQueue()->Handle(),
+                   events_context_, *this),
       queue_sync_tag_(sync_state.GetQueueIdLimit(), ResourceUsageTag(0)) {
     sync_state_.stats.AddQueueBatchContext();
 }
@@ -275,7 +275,7 @@ QueueBatchContext::QueueBatchContext(const SyncValidator& sync_state)
     : sync_state_(sync_state),
       tag_range_(0, 0),
       access_context_(sync_state),
-      execution_context_(sync_state, 0, kQueueIdInvalid, NullVulkanTypedHandle, events_context_, *this),
+      environment_(sync_state, 0, kQueueIdInvalid, NullVulkanTypedHandle, events_context_, *this),
       queue_sync_tag_(sync_state.GetQueueIdLimit(), ResourceUsageTag(0)) {
     sync_state_.stats.AddQueueBatchContext();
 }

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -348,8 +348,8 @@ class QueueBatchContext final : public ResourceUsageInfoProvider, public std::en
 
     VkQueueFlags GetQueueFlags() const { return queue_state_->GetQueue()->GetQueueFlags(); }
     QueueId GetQueueId() const;
-    ExecutionContext& GetExecutionContext() { return execution_context_; }
-    const ExecutionContext& GetExecutionContext() const { return execution_context_; }
+    SyncEnvironment& GetSyncEnvironment() { return environment_; }
+    const SyncEnvironment& GetSyncEnvironment() const { return environment_; }
     SyncEventsContext& GetEventsContext() { return events_context_; }
 
     ResourceUsageRange GetTagRange() const { return tag_range_; }
@@ -409,7 +409,7 @@ class QueueBatchContext final : public ResourceUsageInfoProvider, public std::en
 
     AccessContext access_context_;
     SyncEventsContext events_context_;
-    ExecutionContext execution_context_;
+    SyncEnvironment environment_;
 
     BatchAccessLog batch_log_;
 

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2208,39 +2208,6 @@ void SyncValidator::PostCallRecordResetEvent(VkDevice device, VkEvent event, con
     }
 }
 
-bool SyncValidator::ValidateCmdSetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
-                                        const SyncExecScope& src_exec_scope, ResourceUsageTag base_tag, const Location& loc) const {
-    bool skip = false;
-
-    const auto* sync_event = env.events_context.Get(event);
-    if (!sync_event) {
-        return skip;
-    }
-    if (sync_event->last_command_tag >= base_tag) {
-        return skip;  // for replay we don't want to revalidate internal "last commmand"
-    }
-    if (!sync_event->HasBarrier(src_exec_scope.stage_mask, src_exec_scope.exec_scope)) {
-        const std::string vuid_prefix = std::string("SYNC-") + vvl::String(loc.function);
-        if (IsValueIn(sync_event->last_command, {Func::vkCmdResetEvent, Func::vkCmdResetEvent2, Func::vkCmdResetEvent2KHR})) {
-            skip |= LogError(vuid_prefix + "-reset-race", event->Handle(), loc,
-                             "%s is set after %s without an intervening execution dependency. This is a race condition "
-                             "and may result in data hazards.",
-                             FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
-        } else if (IsValueIn(sync_event->last_command, {Func::vkCmdSetEvent, Func::vkCmdSetEvent2, Func::vkCmdSetEvent2KHR})) {
-            skip |= LogError(vuid_prefix + "-set-race", event->Handle(), loc,
-                             "%s is set after a previous %s without an intervening execution dependency. This is a race "
-                             "condition and may result in data hazards.",
-                             FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
-        } else if (IsValueIn(sync_event->last_command,
-                             {Func::vkCmdWaitEvents, Func::vkCmdWaitEvents2, Func::vkCmdWaitEvents2KHR})) {
-            skip |= LogError(vuid_prefix + "-wait", event->Handle(), loc,
-                             "%s is set after %s without intervening vkCmdResetEvent, may result in data hazard.",
-                             FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
-        }
-    }
-    return skip;
-}
-
 bool SyncValidator::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                                const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
@@ -2249,37 +2216,6 @@ bool SyncValidator::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, Vk
     const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(cb_state->GetQueueFlags(), stageMask);
     return ValidateCmdSetEvent(cb_context.GetSyncEnvironment(), event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex,
                                error_obj.location);
-}
-
-void SyncValidator::ApplySetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
-                                  const SyncExecScope& src_exec_scope,
-                                  const std::shared_ptr<const AccessContext>& src_access_context, ResourceUsageTag tag,
-                                  vvl::Func command) const {
-    SyncEventState* sync_event = env.events_context.GetFromShared(event);
-    if (!sync_event) {
-        return;
-    }
-
-    // What happens with two SetEvent is that one cannot know what group of operations will be waited for.
-    // Given:
-    //     Stuff1; SetEvent; Stuff2; SetEvent; WaitEvents;
-    // WaitEvents cannot know which of Stuff1, Stuff2, or both has completed execution.
-
-    if (!sync_event->HasBarrier(src_exec_scope.stage_mask, src_exec_scope.exec_scope)) {
-        sync_event->unsynchronized_set = sync_event->last_command;
-        sync_event->ResetFirstScope();
-    } else if (!sync_event->first_scope) {
-        // We only set the scope if there isn't one
-        sync_event->scope = src_exec_scope;
-
-        // Save the shared_ptr to copy of the access_context present at set time (sent us by the caller)
-        sync_event->first_scope = src_access_context;
-        sync_event->unsynchronized_set = vvl::Func::Empty;
-        sync_event->first_scope_tag = tag;
-    }
-    sync_event->last_command = command;
-    sync_event->last_command_tag = tag;
-    sync_event->barriers = 0;
 }
 
 void SyncValidator::RecordCmdSetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
@@ -2293,7 +2229,7 @@ void SyncValidator::RecordCmdSetEvent(CommandBufferAccessContext& cb_context, st
     auto src_access_context = std::make_shared<AccessContext>(*this);
     src_access_context->InitFrom(cb_context.GetCbAccessContext());
 
-    ApplySetEvent(cb_context.GetSyncEnvironment(), event, src_exec_scope, src_access_context, tag, loc.function);
+    ApplyCmdSetEvent(cb_context.GetSyncEnvironment(), event, src_exec_scope, src_access_context, tag, loc.function);
 
     auto sync_op = std::make_shared<SyncOpSetEvent>(std::move(event), src_exec_scope, std::move(src_access_context), loc);
     cb_context.AddSyncOp(tag, std::move(sync_op));
@@ -2353,27 +2289,6 @@ void SyncValidator::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, Vk
     RecordCmdSetEvent(cb_context, std::move(event_state), src_exec_scope, record_obj.location);
 }
 
-bool SyncValidator::ValidateCmdResetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
-                                          const SyncExecScope& exec_scope, const ResourceUsageTag base_tag,
-                                          const Location& loc) const {
-    bool skip = false;
-    const auto* sync_event = env.events_context.Get(event);
-    if (!sync_event) {
-        return skip;
-    }
-    if (sync_event->last_command_tag > base_tag) {
-        return skip;  // if we validated this in recording of the secondary, don't repeat
-    }
-    if (IsValueIn(sync_event->last_command, {Func::vkCmdSetEvent, Func::vkCmdSetEvent2, Func::vkCmdSetEvent2KHR}) &&
-        !sync_event->HasBarrier(exec_scope.stage_mask, exec_scope.exec_scope)) {
-        skip |= LogError("SYNC-vkCmdResetEvent-set-race", event->Handle(), loc,
-                         "%s is reset after %s without an intervening execution dependency. This is a race condition "
-                         "and may result in data hazards.",
-                         FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
-    }
-    return skip;
-}
-
 bool SyncValidator::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                                  const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
@@ -2384,23 +2299,10 @@ bool SyncValidator::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, 
                                  error_obj.location);
 }
 
-void SyncValidator::ApplyResetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
-                                    ResourceUsageTag tag, vvl::Func command) const {
-    SyncEventState* sync_event = env.events_context.GetFromShared(event);
-    if (!sync_event) {
-        return;
-    }
-    sync_event->last_command = command;
-    sync_event->last_command_tag = tag;
-    sync_event->unsynchronized_set = vvl::Func::Empty;
-    sync_event->ResetFirstScope();
-    sync_event->barriers = 0;
-}
-
 void SyncValidator::RecordCmdResetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
                                         const SyncExecScope& exec_scope, const Location& loc) const {
     const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
-    ApplyResetEvent(cb_context.GetSyncEnvironment(), event, tag, loc.function);
+    ApplyCmdResetEvent(cb_context.GetSyncEnvironment(), event, tag, loc.function);
     auto sync_op = std::make_shared<SyncOpResetEvent>(std::move(event), exec_scope, loc);
     cb_context.AddSyncOp(tag, std::move(sync_op));
 }
@@ -2449,97 +2351,6 @@ void SyncValidator::PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, 
     RecordCmdResetEvent(cb_context, std::move(event_state), exec_scope, record_obj.location);
 }
 
-bool SyncValidator::ValidateCmdWaitEvents(const SyncEnvironment& env, const AccessContext& access_context,
-                                          const std::vector<std::shared_ptr<const vvl::Event>>& events,
-                                          const vvl::span<const BarrierSet>& barrier_sets, const ResourceUsageTag base_tag,
-                                          const Location& loc) const {
-    bool skip = false;
-
-    // This is only interesting at record and not replay (Execute/Submit) time
-    if (base_tag == ResourceUsageRecord::kMaxIndex) {
-        for (size_t barrier_set_index = 0; barrier_set_index < barrier_sets.size(); barrier_set_index++) {
-            const auto& barrier_set = barrier_sets[barrier_set_index];
-            if (barrier_set.single_exec_scope) {
-                if (barrier_set.src_exec_scope.stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
-                    const std::string vuid =
-                        std::string("SYNC-") + vvl::String(loc.function) + std::string("-hostevent-unsupported");
-                    env.validator.LogInfo(vuid, env.handle, loc,
-                                          "srcStageMask includes %s, unsupported by synchronization validation.",
-                                          string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT));
-                } else {
-                    const auto& barriers = barrier_set.memory_barriers;
-                    for (size_t barrier_index = 0; barrier_index < barriers.size(); barrier_index++) {
-                        const auto& barrier = barriers[barrier_index];
-                        if (barrier.src_exec_scope.stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
-                            const std::string vuid =
-                                std::string("SYNC-") + vvl::String(loc.function) + std::string("-hostevent-unsupported");
-
-                            env.validator.LogInfo(vuid, env.handle, loc,
-                                                  "srcStageMask %s of %s %zu, %s %zu, unsupported by synchronization validation.",
-                                                  string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT), "pDependencyInfo",
-                                                  barrier_set_index, "pMemoryBarriers", barrier_index);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // The rest is common to record time and replay time
-    size_t barrier_set_index = 0;
-    size_t barrier_set_incr = (barrier_sets.size() == 1) ? 0 : 1;
-    for (const auto& event : events) {
-        const auto* sync_event = env.events_context.Get(event);
-        const auto& barrier_set = barrier_sets[barrier_set_index];
-        if (!sync_event || !sync_event->first_scope) {
-            barrier_set_index += barrier_set_incr;
-            continue;  // Core, Lifetimes, or Param check needs to catch invalid events.
-        }
-
-        // For replay calls, don't revalidate "same command buffer" events
-        if (sync_event->last_command_tag >= base_tag) {
-            continue;
-        }
-
-        const VkEvent event_handle = sync_event->event->VkHandle();
-
-        // TODO: Cleanup this error message
-        if (sync_event->unsynchronized_set != vvl::Func::Empty) {
-            // Issue error message that Wait is waiting on an signal subject to race condition, and is thus ignored for
-            // this event
-            const char* const vuid = "SYNC-vkCmdWaitEvents-unsynchronized-setops";
-            const char* const message = "%s Unsychronized %s calls result in race conditions w.r.t. event signalling, %s %s";
-            const char* const reason = "First synchronization scope is undefined.";
-            skip |=
-                env.validator.LogError(vuid, event_handle, loc, message, env.validator.FormatHandle(event_handle).c_str(),
-                                       vvl::String(sync_event->last_command), reason, "Wait operation is ignored for this event.");
-        }
-        if (barrier_set.image_barriers.size()) {
-            const auto& image_memory_barriers = barrier_set.image_barriers;
-            for (const auto& image_memory_barrier : image_memory_barriers) {
-                if (!image_memory_barrier.layout_transition) continue;
-                const auto* image_state = image_memory_barrier.image.get();
-                if (!image_state) continue;
-                const auto& subresource_range = image_memory_barrier.subresource_range;
-                const auto& src_access_scope = image_memory_barrier.barrier.src_access_scope;
-                const auto hazard = access_context.DetectImageBarrierHazard(
-                    *image_state, subresource_range, sync_event->scope.exec_scope, src_access_scope, env.queue_id,
-                    sync_event->FirstScope(), sync_event->first_scope_tag, AccessContext::DetectOptions::kDetectAll);
-                if (hazard.IsHazard()) {
-                    LogObjectList objlist(env.handle, image_state->Handle());
-                    const std::string resource_description = env.validator.FormatHandle(image_state->Handle());
-                    const std::string error = env.validator.error_messages_.ImageBarrierError(
-                        env, hazard, loc.function, resource_description, image_memory_barrier);
-                    skip |= env.validator.SyncError(hazard.Hazard(), image_state->Handle(), loc, error);
-                    break;
-                }
-            }
-        }
-        barrier_set_index += barrier_set_incr;
-    }
-    return skip;
-}
-
 bool SyncValidator::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                                  VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
                                                  uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
@@ -2570,7 +2381,8 @@ void SyncValidator::RecordCmdWaitEvents(CommandBufferAccessContext& cb_context,
                                         std::vector<std::shared_ptr<const vvl::Event>>&& events,
                                         std::vector<BarrierSet>&& barrier_sets, const Location& loc) const {
     const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
-    ApplyWaitEvents(cb_context.GetSyncEnvironment(), cb_context.GetCurrentAccessContext(), events, barrier_sets, tag, loc.function);
+    ApplyCmdWaitEvents(cb_context.GetSyncEnvironment(), cb_context.GetCurrentAccessContext(), events, barrier_sets, tag,
+                       loc.function);
     auto sync_op = std::make_shared<SyncOpWaitEvents>(std::move(events), std::move(barrier_sets), loc);
     cb_context.AddSyncOp(tag, std::move(sync_op));
 }

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -567,7 +567,7 @@ bool SyncValidator::ValidateCmdPipelineBarrier(const CommandBufferAccessContext&
             const SyncValidator& sync_state = cb_context.GetSyncState();
             const std::string resource_description = sync_state.FormatHandle(image_state.Handle());
             const std::string error = sync_state.error_messages_.ImageBarrierError(
-                hazard, cb_context.GetExecutionContext(), loc.function, resource_description, image_barrier);
+                cb_context.GetSyncEnvironment(), hazard, loc.function, resource_description, image_barrier);
             skip |= sync_state.SyncError(hazard.Hazard(), objlist, loc, error);
         }
     }
@@ -608,7 +608,7 @@ void SyncValidator::RecordCmdPipelineBarrier(CommandBufferAccessContext& cb_cont
             image_barrier.handle_index = tag_ex.handle_index;
         }
     }
-    ApplyBarrier(cb_context.GetExecutionContext(), cb_context.GetCurrentAccessContext(), barrier_set, tag);
+    ApplyBarrier(cb_context.GetSyncEnvironment(), cb_context.GetCurrentAccessContext(), barrier_set, tag);
     auto sync_op = std::make_shared<SyncOpPipelineBarrier>(std::move(barrier_set));
     cb_context.AddSyncOp(tag, std::move(sync_op));
 }
@@ -2208,13 +2208,11 @@ void SyncValidator::PostCallRecordResetEvent(VkDevice device, VkEvent event, con
     }
 }
 
-bool SyncValidator::ValidateCmdSetEvent(const ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+bool SyncValidator::ValidateCmdSetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
                                         const SyncExecScope& src_exec_scope, ResourceUsageTag base_tag, const Location& loc) const {
     bool skip = false;
 
-    const SyncValidator& sync_state = exec_context.validator;
-
-    const auto* sync_event = exec_context.events_context.Get(event);
+    const auto* sync_event = env.events_context.Get(event);
     if (!sync_event) {
         return skip;
     }
@@ -2224,20 +2222,20 @@ bool SyncValidator::ValidateCmdSetEvent(const ExecutionContext& exec_context, co
     if (!sync_event->HasBarrier(src_exec_scope.stage_mask, src_exec_scope.exec_scope)) {
         const std::string vuid_prefix = std::string("SYNC-") + vvl::String(loc.function);
         if (IsValueIn(sync_event->last_command, {Func::vkCmdResetEvent, Func::vkCmdResetEvent2, Func::vkCmdResetEvent2KHR})) {
-            skip |= sync_state.LogError(vuid_prefix + "-reset-race", event->Handle(), loc,
-                                        "%s is set after %s without an intervening execution dependency. This is a race condition "
-                                        "and may result in data hazards.",
-                                        sync_state.FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
+            skip |= LogError(vuid_prefix + "-reset-race", event->Handle(), loc,
+                             "%s is set after %s without an intervening execution dependency. This is a race condition "
+                             "and may result in data hazards.",
+                             FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
         } else if (IsValueIn(sync_event->last_command, {Func::vkCmdSetEvent, Func::vkCmdSetEvent2, Func::vkCmdSetEvent2KHR})) {
-            skip |= sync_state.LogError(vuid_prefix + "-set-race", event->Handle(), loc,
-                                        "%s is set after a previous %s without an intervening execution dependency. This is a race "
-                                        "condition and may result in data hazards.",
-                                        sync_state.FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
+            skip |= LogError(vuid_prefix + "-set-race", event->Handle(), loc,
+                             "%s is set after a previous %s without an intervening execution dependency. This is a race "
+                             "condition and may result in data hazards.",
+                             FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
         } else if (IsValueIn(sync_event->last_command,
                              {Func::vkCmdWaitEvents, Func::vkCmdWaitEvents2, Func::vkCmdWaitEvents2KHR})) {
-            skip |= sync_state.LogError(vuid_prefix + "-wait", event->Handle(), loc,
-                                        "%s is set after %s without intervening vkCmdResetEvent, may result in data hazard.",
-                                        sync_state.FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
+            skip |= LogError(vuid_prefix + "-wait", event->Handle(), loc,
+                             "%s is set after %s without intervening vkCmdResetEvent, may result in data hazard.",
+                             FormatHandle(event->Handle()).c_str(), vvl::String(sync_event->last_command));
         }
     }
     return skip;
@@ -2249,15 +2247,15 @@ bool SyncValidator::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, Vk
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
     auto event_state = Get<vvl::Event>(event);
     const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(cb_state->GetQueueFlags(), stageMask);
-    return ValidateCmdSetEvent(cb_context.GetExecutionContext(), event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex,
+    return ValidateCmdSetEvent(cb_context.GetSyncEnvironment(), event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex,
                                error_obj.location);
 }
 
-void SyncValidator::ApplySetEvent(ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+void SyncValidator::ApplySetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
                                   const SyncExecScope& src_exec_scope,
                                   const std::shared_ptr<const AccessContext>& src_access_context, ResourceUsageTag tag,
                                   vvl::Func command) const {
-    SyncEventState* sync_event = exec_context.events_context.GetFromShared(event);
+    SyncEventState* sync_event = env.events_context.GetFromShared(event);
     if (!sync_event) {
         return;
     }
@@ -2295,7 +2293,7 @@ void SyncValidator::RecordCmdSetEvent(CommandBufferAccessContext& cb_context, st
     auto src_access_context = std::make_shared<AccessContext>(*this);
     src_access_context->InitFrom(cb_context.GetCbAccessContext());
 
-    ApplySetEvent(cb_context.GetExecutionContext(), event, src_exec_scope, src_access_context, tag, loc.function);
+    ApplySetEvent(cb_context.GetSyncEnvironment(), event, src_exec_scope, src_access_context, tag, loc.function);
 
     auto sync_op = std::make_shared<SyncOpSetEvent>(std::move(event), src_exec_scope, std::move(src_access_context), loc);
     cb_context.AddSyncOp(tag, std::move(sync_op));
@@ -2331,7 +2329,7 @@ bool SyncValidator::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, V
     auto event_state = Get<vvl::Event>(event);
 
     const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, sync_utils::GetExecScopes(*pDependencyInfo).src);
-    return ValidateCmdSetEvent(cb_context.GetExecutionContext(), event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex,
+    return ValidateCmdSetEvent(cb_context.GetSyncEnvironment(), event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex,
                                error_obj.location);
 }
 
@@ -2355,11 +2353,11 @@ void SyncValidator::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, Vk
     RecordCmdSetEvent(cb_context, std::move(event_state), src_exec_scope, record_obj.location);
 }
 
-bool SyncValidator::ValidateCmdResetEvent(const ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+bool SyncValidator::ValidateCmdResetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
                                           const SyncExecScope& exec_scope, const ResourceUsageTag base_tag,
                                           const Location& loc) const {
     bool skip = false;
-    const auto* sync_event = exec_context.events_context.Get(event);
+    const auto* sync_event = env.events_context.Get(event);
     if (!sync_event) {
         return skip;
     }
@@ -2382,13 +2380,13 @@ bool SyncValidator::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, 
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
     auto event_state = Get<vvl::Event>(event);
     const SyncExecScope exec_scope = SyncExecScope::MakeSrc(cb_state->GetQueueFlags(), stageMask);
-    return ValidateCmdResetEvent(cb_context.GetExecutionContext(), event_state, exec_scope, ResourceUsageRecord::kMaxIndex,
+    return ValidateCmdResetEvent(cb_context.GetSyncEnvironment(), event_state, exec_scope, ResourceUsageRecord::kMaxIndex,
                                  error_obj.location);
 }
 
-void SyncValidator::ApplyResetEvent(ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+void SyncValidator::ApplyResetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
                                     ResourceUsageTag tag, vvl::Func command) const {
-    SyncEventState* sync_event = exec_context.events_context.GetFromShared(event);
+    SyncEventState* sync_event = env.events_context.GetFromShared(event);
     if (!sync_event) {
         return;
     }
@@ -2402,7 +2400,7 @@ void SyncValidator::ApplyResetEvent(ExecutionContext& exec_context, const std::s
 void SyncValidator::RecordCmdResetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
                                         const SyncExecScope& exec_scope, const Location& loc) const {
     const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
-    ApplyResetEvent(cb_context.GetExecutionContext(), event, tag, loc.function);
+    ApplyResetEvent(cb_context.GetSyncEnvironment(), event, tag, loc.function);
     auto sync_op = std::make_shared<SyncOpResetEvent>(std::move(event), exec_scope, loc);
     cb_context.AddSyncOp(tag, std::move(sync_op));
 }
@@ -2425,7 +2423,7 @@ bool SyncValidator::PreCallValidateCmdResetEvent2(VkCommandBuffer commandBuffer,
     const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
     auto event_state = Get<vvl::Event>(event);
     const SyncExecScope exec_scope = SyncExecScope::MakeSrc(cb_state->GetQueueFlags(), stageMask);
-    return ValidateCmdResetEvent(cb_context.GetExecutionContext(), event_state, exec_scope, ResourceUsageRecord::kMaxIndex,
+    return ValidateCmdResetEvent(cb_context.GetSyncEnvironment(), event_state, exec_scope, ResourceUsageRecord::kMaxIndex,
                                  error_obj.location);
 }
 
@@ -2451,12 +2449,11 @@ void SyncValidator::PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, 
     RecordCmdResetEvent(cb_context, std::move(event_state), exec_scope, record_obj.location);
 }
 
-bool SyncValidator::ValidateCmdWaitEvents(const ExecutionContext& exec_context, const AccessContext& access_context,
+bool SyncValidator::ValidateCmdWaitEvents(const SyncEnvironment& env, const AccessContext& access_context,
                                           const std::vector<std::shared_ptr<const vvl::Event>>& events,
                                           const vvl::span<const BarrierSet>& barrier_sets, const ResourceUsageTag base_tag,
                                           const Location& loc) const {
     bool skip = false;
-    const auto& sync_state = exec_context.validator;
 
     // This is only interesting at record and not replay (Execute/Submit) time
     if (base_tag == ResourceUsageRecord::kMaxIndex) {
@@ -2466,9 +2463,9 @@ bool SyncValidator::ValidateCmdWaitEvents(const ExecutionContext& exec_context, 
                 if (barrier_set.src_exec_scope.stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
                     const std::string vuid =
                         std::string("SYNC-") + vvl::String(loc.function) + std::string("-hostevent-unsupported");
-                    sync_state.LogInfo(vuid, exec_context.handle, loc,
-                                       "srcStageMask includes %s, unsupported by synchronization validation.",
-                                       string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT));
+                    env.validator.LogInfo(vuid, env.handle, loc,
+                                          "srcStageMask includes %s, unsupported by synchronization validation.",
+                                          string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT));
                 } else {
                     const auto& barriers = barrier_set.memory_barriers;
                     for (size_t barrier_index = 0; barrier_index < barriers.size(); barrier_index++) {
@@ -2477,10 +2474,10 @@ bool SyncValidator::ValidateCmdWaitEvents(const ExecutionContext& exec_context, 
                             const std::string vuid =
                                 std::string("SYNC-") + vvl::String(loc.function) + std::string("-hostevent-unsupported");
 
-                            sync_state.LogInfo(vuid, exec_context.handle, loc,
-                                               "srcStageMask %s of %s %zu, %s %zu, unsupported by synchronization validation.",
-                                               string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT), "pDependencyInfo",
-                                               barrier_set_index, "pMemoryBarriers", barrier_index);
+                            env.validator.LogInfo(vuid, env.handle, loc,
+                                                  "srcStageMask %s of %s %zu, %s %zu, unsupported by synchronization validation.",
+                                                  string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT), "pDependencyInfo",
+                                                  barrier_set_index, "pMemoryBarriers", barrier_index);
                         }
                     }
                 }
@@ -2492,7 +2489,7 @@ bool SyncValidator::ValidateCmdWaitEvents(const ExecutionContext& exec_context, 
     size_t barrier_set_index = 0;
     size_t barrier_set_incr = (barrier_sets.size() == 1) ? 0 : 1;
     for (const auto& event : events) {
-        const auto* sync_event = exec_context.events_context.Get(event);
+        const auto* sync_event = env.events_context.Get(event);
         const auto& barrier_set = barrier_sets[barrier_set_index];
         if (!sync_event || !sync_event->first_scope) {
             barrier_set_index += barrier_set_incr;
@@ -2513,8 +2510,9 @@ bool SyncValidator::ValidateCmdWaitEvents(const ExecutionContext& exec_context, 
             const char* const vuid = "SYNC-vkCmdWaitEvents-unsynchronized-setops";
             const char* const message = "%s Unsychronized %s calls result in race conditions w.r.t. event signalling, %s %s";
             const char* const reason = "First synchronization scope is undefined.";
-            skip |= sync_state.LogError(vuid, event_handle, loc, message, sync_state.FormatHandle(event_handle).c_str(),
-                                        vvl::String(sync_event->last_command), reason, "Wait operation is ignored for this event.");
+            skip |=
+                env.validator.LogError(vuid, event_handle, loc, message, env.validator.FormatHandle(event_handle).c_str(),
+                                       vvl::String(sync_event->last_command), reason, "Wait operation is ignored for this event.");
         }
         if (barrier_set.image_barriers.size()) {
             const auto& image_memory_barriers = barrier_set.image_barriers;
@@ -2525,14 +2523,14 @@ bool SyncValidator::ValidateCmdWaitEvents(const ExecutionContext& exec_context, 
                 const auto& subresource_range = image_memory_barrier.subresource_range;
                 const auto& src_access_scope = image_memory_barrier.barrier.src_access_scope;
                 const auto hazard = access_context.DetectImageBarrierHazard(
-                    *image_state, subresource_range, sync_event->scope.exec_scope, src_access_scope, exec_context.queue_id,
+                    *image_state, subresource_range, sync_event->scope.exec_scope, src_access_scope, env.queue_id,
                     sync_event->FirstScope(), sync_event->first_scope_tag, AccessContext::DetectOptions::kDetectAll);
                 if (hazard.IsHazard()) {
-                    LogObjectList objlist(exec_context.handle, image_state->Handle());
-                    const std::string resource_description = sync_state.FormatHandle(image_state->Handle());
-                    const std::string error = sync_state.error_messages_.ImageBarrierError(
-                        hazard, exec_context, loc.function, resource_description, image_memory_barrier);
-                    skip |= sync_state.SyncError(hazard.Hazard(), image_state->Handle(), loc, error);
+                    LogObjectList objlist(env.handle, image_state->Handle());
+                    const std::string resource_description = env.validator.FormatHandle(image_state->Handle());
+                    const std::string error = env.validator.error_messages_.ImageBarrierError(
+                        env, hazard, loc.function, resource_description, image_memory_barrier);
+                    skip |= env.validator.SyncError(hazard.Hazard(), image_state->Handle(), loc, error);
                     break;
                 }
             }
@@ -2564,7 +2562,7 @@ bool SyncValidator::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, 
         events[i] = Get<vvl::Event>(pEvents[i]);
     }
 
-    return ValidateCmdWaitEvents(cb_context.GetExecutionContext(), cb_context.GetCurrentAccessContext(), events,
+    return ValidateCmdWaitEvents(cb_context.GetSyncEnvironment(), cb_context.GetCurrentAccessContext(), events,
                                  vvl::make_span(&barrier_set, 1), ResourceUsageRecord::kMaxIndex, error_obj.location);
 }
 
@@ -2572,8 +2570,7 @@ void SyncValidator::RecordCmdWaitEvents(CommandBufferAccessContext& cb_context,
                                         std::vector<std::shared_ptr<const vvl::Event>>&& events,
                                         std::vector<BarrierSet>&& barrier_sets, const Location& loc) const {
     const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
-    ApplyWaitEvents(cb_context.GetExecutionContext(), cb_context.GetCurrentAccessContext(), events, barrier_sets, tag,
-                    loc.function);
+    ApplyWaitEvents(cb_context.GetSyncEnvironment(), cb_context.GetCurrentAccessContext(), events, barrier_sets, tag, loc.function);
     auto sync_op = std::make_shared<SyncOpWaitEvents>(std::move(events), std::move(barrier_sets), loc);
     cb_context.AddSyncOp(tag, std::move(sync_op));
 }
@@ -2632,7 +2629,7 @@ bool SyncValidator::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer,
     for (uint32_t i = 0; i < eventCount; i++) {
         barrier_sets[i] = BarrierSet(*this, queue_flags, pDependencyInfos[i]);
     }
-    return ValidateCmdWaitEvents(cb_context.GetExecutionContext(), cb_context.GetCurrentAccessContext(), events, barrier_sets,
+    return ValidateCmdWaitEvents(cb_context.GetSyncEnvironment(), cb_context.GetCurrentAccessContext(), events, barrier_sets,
                                  ResourceUsageRecord::kMaxIndex, error_obj.location);
 }
 

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -444,76 +444,57 @@ class SyncValidator : public vvl::DeviceProxy {
                                           const ErrorObject &error_obj) const override;
 
     void PostCallRecordResetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) override;
-
-
-    bool ValidateCmdSetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
-                             const SyncExecScope& src_exec_scope, ResourceUsageTag base_tag, const Location& loc) const;
     bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                     const ErrorObject& error_obj) const override;
-
-    void ApplySetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
-                       const SyncExecScope& src_exec_scope, const std::shared_ptr<const AccessContext>& src_access_context,
-                       ResourceUsageTag tag, vvl::Func command) const;
     void RecordCmdSetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
                            const SyncExecScope& src_exec_scope, const Location& loc) const;
     void PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
-                                   const RecordObject &record_obj) override;
-    bool PreCallValidateCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfoKHR *pDependencyInfo,
-                                        const ErrorObject &error_obj) const override;
-    bool PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo *pDependencyInfo,
-                                     const ErrorObject &error_obj) const override;
-    void PostCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfoKHR *pDependencyInfo,
-                                       const RecordObject &record_obj) override;
-    void PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo *pDependencyInfo,
-                                    const RecordObject &record_obj) override;
-
-    bool ValidateCmdResetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
-                               const SyncExecScope& exec_scope, ResourceUsageTag base_tag, const Location& loc) const;
+                                   const RecordObject& record_obj) override;
+    bool PreCallValidateCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfoKHR* pDependencyInfo,
+                                        const ErrorObject& error_obj) const override;
+    bool PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo,
+                                     const ErrorObject& error_obj) const override;
+    void PostCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfoKHR* pDependencyInfo,
+                                       const RecordObject& record_obj) override;
+    void PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo,
+                                    const RecordObject& record_obj) override;
     bool PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                       const ErrorObject& error_obj) const override;
-
-    void ApplyResetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event, ResourceUsageTag tag,
-                         vvl::Func command) const;
     void RecordCmdResetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
                              const SyncExecScope& exec_scope, const Location& loc) const;
     void PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
-                                     const RecordObject &record_obj) override;
+                                     const RecordObject& record_obj) override;
     bool PreCallValidateCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2KHR stageMask,
-                                          const ErrorObject &error_obj) const override;
+                                          const ErrorObject& error_obj) const override;
     bool PreCallValidateCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
-                                       const ErrorObject &error_obj) const override;
+                                       const ErrorObject& error_obj) const override;
     void PostCallRecordCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2KHR stageMask,
-                                         const RecordObject &record_obj) override;
+                                         const RecordObject& record_obj) override;
     void PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
-                                      const RecordObject &record_obj) override;
-
-    bool ValidateCmdWaitEvents(const SyncEnvironment& env, const AccessContext& access_context,
-                               const std::vector<std::shared_ptr<const vvl::Event>>& events,
-                               const vvl::span<const BarrierSet>& barrier_sets, const ResourceUsageTag base_tag,
-                               const Location& loc) const;
+                                      const RecordObject& record_obj) override;
     bool PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                       VkPipelineStageFlags sourceStageMask, VkPipelineStageFlags dstStageMask,
-                                      uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
-                                      uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
-                                      uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers,
-                                      const ErrorObject &error_obj) const override;
-
+                                      uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                      uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                      uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers,
+                                      const ErrorObject& error_obj) const override;
     void RecordCmdWaitEvents(CommandBufferAccessContext& cb_context, std::vector<std::shared_ptr<const vvl::Event>>&& events,
                              std::vector<BarrierSet>&& barrier_sets, const Location& loc) const;
-    void PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
+    void PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                      VkPipelineStageFlags sourceStageMask, VkPipelineStageFlags dstStageMask,
-                                     uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
-                                     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
-                                     uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers,
-                                     const RecordObject &record_obj) override;
-    bool PreCallValidateCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                          const VkDependencyInfoKHR *pDependencyInfos, const ErrorObject &error_obj) const override;
-    void PostCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                         const VkDependencyInfoKHR *pDependencyInfos, const RecordObject &record_obj) override;
-    bool PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                       const VkDependencyInfo *pDependencyInfos, const ErrorObject &error_obj) const override;
-    void PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                      const VkDependencyInfo *pDependencyInfos, const RecordObject &record_obj) override;
+                                     uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                     uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers,
+                                     const RecordObject& record_obj) override;
+    bool PreCallValidateCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                          const VkDependencyInfoKHR* pDependencyInfos, const ErrorObject& error_obj) const override;
+    void PostCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                         const VkDependencyInfoKHR* pDependencyInfos, const RecordObject& record_obj) override;
+    bool PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                       const VkDependencyInfo* pDependencyInfos, const ErrorObject& error_obj) const override;
+    void PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                      const VkDependencyInfo* pDependencyInfos, const RecordObject& record_obj) override;
+
     bool PreCallValidateCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2KHR stage, VkBuffer dstBuffer,
                                                  VkDeviceSize dstOffset, uint32_t marker,
                                                  const ErrorObject &error_obj) const override;

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -446,12 +446,12 @@ class SyncValidator : public vvl::DeviceProxy {
     void PostCallRecordResetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) override;
 
 
-    bool ValidateCmdSetEvent(const ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+    bool ValidateCmdSetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
                              const SyncExecScope& src_exec_scope, ResourceUsageTag base_tag, const Location& loc) const;
     bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                     const ErrorObject& error_obj) const override;
 
-    void ApplySetEvent(ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+    void ApplySetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
                        const SyncExecScope& src_exec_scope, const std::shared_ptr<const AccessContext>& src_access_context,
                        ResourceUsageTag tag, vvl::Func command) const;
     void RecordCmdSetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
@@ -467,12 +467,12 @@ class SyncValidator : public vvl::DeviceProxy {
     void PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo *pDependencyInfo,
                                     const RecordObject &record_obj) override;
 
-    bool ValidateCmdResetEvent(const ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event,
+    bool ValidateCmdResetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event,
                                const SyncExecScope& exec_scope, ResourceUsageTag base_tag, const Location& loc) const;
     bool PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                       const ErrorObject& error_obj) const override;
 
-    void ApplyResetEvent(ExecutionContext& exec_context, const std::shared_ptr<const vvl::Event>& event, ResourceUsageTag tag,
+    void ApplyResetEvent(const SyncEnvironment& env, const std::shared_ptr<const vvl::Event>& event, ResourceUsageTag tag,
                          vvl::Func command) const;
     void RecordCmdResetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
                              const SyncExecScope& exec_scope, const Location& loc) const;
@@ -487,7 +487,7 @@ class SyncValidator : public vvl::DeviceProxy {
     void PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                       const RecordObject &record_obj) override;
 
-    bool ValidateCmdWaitEvents(const ExecutionContext& exec_context, const AccessContext& access_context,
+    bool ValidateCmdWaitEvents(const SyncEnvironment& env, const AccessContext& access_context,
                                const std::vector<std::shared_ptr<const vvl::Event>>& events,
                                const vvl::span<const BarrierSet>& barrier_sets, const ResourceUsageTag base_tag,
                                const Location& loc) const;


### PR DESCRIPTION
a) Rename ExecutionContext -> SyncEnvironment to avoid similarity with various contexts (`QueueBatchContext`, `CommandBufferAccessContext`).

"Execution" part of `ExecutionContext` (previously `CommandExecutionContext`) was always a bit confusing. To some degree it made sense when `QueueBatchContext` and `CommandBufferAccessContext` implemented `CommandExecutionContext`, but now these types do not share common interface.

b) Move shared event code (between `SyncValidator` and `SyncOps`) to `sync_event.h/cpp`.