### PR TITLE
sync: Use non-recursive resolve when sufficient

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -272,7 +272,7 @@ const SubpassBarrier& AccessContext::GetSubpassBarrier(uint32_t src_subpass) con
     }
 }
 
-void AccessContext::ResolveFromContext(const AccessContext& from) {
+void AccessContext::ResolveFromContextRecursePrev(const AccessContext& from) {
     assert(!finalized_);
     auto noop_action = [](AccessState* access) {};
     from.ResolveAccessRangeRecursePrev(kFullRange, noop_action, *this, false);
@@ -290,6 +290,15 @@ void AccessContext::ResolveFromSubpassContext(const ApplySubpassTransitionBarrie
 void AccessContext::ResolveAllSubpassDependencies() {
     assert(!finalized_);
     ResolveSubpassDependencies(kFullRange, *this, true);
+}
+
+void AccessContext::ResolveChildContexts(vvl::span<AccessContext> subpass_contexts) {
+    assert(!finalized_);
+
+    for (AccessContext& context : subpass_contexts) {
+        ApplySubpassBarrierAction barrier_action(context.GetDstExternalSubpassBarrier());
+        context.ResolveAccessRange(kFullRange, barrier_action, *this);
+    }
 }
 
 void AccessContext::ResolveSubpassDependencies(const AccessRange& range, AccessContext& resolve_context, bool infill,
@@ -590,15 +599,6 @@ void AccessContext::UpdateAttachmentAccessState(const AttachmentViewGen& view_ge
             view_mask >>= 1;
             view_index++;
         }
-    }
-}
-
-void AccessContext::ResolveChildContexts(vvl::span<AccessContext> subpass_contexts) {
-    assert(!finalized_);
-
-    for (AccessContext& context : subpass_contexts) {
-        ApplySubpassBarrierAction barrier_action(context.GetDstExternalSubpassBarrier());
-        context.ResolveAccessRange(kFullRange, barrier_action, *this);
     }
 }
 

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -252,22 +252,24 @@ class AccessContext {
         kDetectAll = (kDetectPrevious | kDetectAsync)
     };
 
-    void ResolveFromContext(const AccessContext &from);
+    template <typename ResolveOp>
+    void ResolveFromContext(ResolveOp&& resolve_op, const AccessContext& from_context);
+
+    template <typename ResolveOp>
+    void ResolveFromContext(ResolveOp&& resolve_op, const AccessContext& from_context,
+                            subresource_adapter::ImageRangeGenerator range_gen);
+
+    void ResolveFromContextRecursePrev(const AccessContext& from);
 
     // Resolves this subpass context from the subpass context defined by the layout transition dependency
-    void ResolveFromSubpassContext(const ApplySubpassTransitionBarrierAction &subpass_transition_action,
-                                   const AccessContext &from_context,
+    void ResolveFromSubpassContext(const ApplySubpassTransitionBarrierAction& subpass_transition_action,
+                                   const AccessContext& from_context,
                                    subresource_adapter::ImageRangeGenerator attachment_range_gen);
 
     // Import accesses from all subpass dependencies (including src external dependency)
     void ResolveAllSubpassDependencies();
 
-    template <typename ResolveOp>
-    void ResolveFromContext(ResolveOp &&resolve_op, const AccessContext &from_context);
-
-    template <typename ResolveOp>
-    void ResolveFromContext(ResolveOp &&resolve_op, const AccessContext &from_context,
-                            subresource_adapter::ImageRangeGenerator range_gen);
+    void ResolveChildContexts(vvl::span<AccessContext> subpass_contexts);
 
     void UpdateAccessState(const vvl::Buffer &buffer, SyncAccessIndex current_usage, const AccessRange &range,
                            ResourceUsageTagEx tag_ex, SyncFlags flags = 0);
@@ -277,8 +279,6 @@ class AccessContext {
     void UpdateAttachmentAccessState(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type,
                                      SyncAccessIndex current_usage, const AttachmentAccess &attachment_access,
                                      ResourceUsageTagEx tag_ex, uint32_t view_mask = 0);
-
-    void ResolveChildContexts(vvl::span<AccessContext> subpass_contexts);
 
     void ImportAsyncContexts(const AccessContext &from);
     void ClearAsyncContexts() { async_.clear(); }

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -302,7 +302,7 @@ CommandBufferAccessContext::CommandBufferAccessContext(const CommandBufferAccess
     const AccessContext& from_context = from.GetCurrentAccessContext();
 
     // Construct a fully resolved single access context out of from
-    cb_access_context_.ResolveFromContext(from_context);
+    cb_access_context_.ResolveFromContextRecursePrev(from_context);
     // The proxy has flatten the current render pass context (if any), but the async contexts are needed for hazard detection
     cb_access_context_.ImportAsyncContexts(from_context);
 

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -510,7 +510,8 @@ void QueueBatchContext::ResolveLastBatch(const BatchContextPtr& last_batch) {
     events_context_.DeepCopy(last_batch->events_context_);
 
     // If there are no semaphores to the previous batch, make sure a "submit order" non-barriered import is done
-    access_context_.ResolveFromContext(last_batch->access_context_);
+    auto noop_action = [](AccessState* access) {};
+    access_context_.ResolveFromContext(noop_action, last_batch->access_context_);
     ImportTags(*last_batch);
 
     last_synchronized_present.Merge(last_batch->last_synchronized_present);
@@ -611,7 +612,8 @@ void QueueBatchContext::LogAcquireOperation(const PresentedImage& presented, vvl
 
 void QueueBatchContext::SetupAccessContext(const PresentedImage& presented) {
     if (presented.batch) {
-        access_context_.ResolveFromContext(presented.batch->access_context_);
+        auto noop_action = [](AccessState* access) {};
+        access_context_.ResolveFromContext(noop_action, presented.batch->access_context_);
         ImportTags(*presented.batch);
     }
 }


### PR DESCRIPTION
For `QueueBatchContext::ResolveLastBatch` and `QueueBatchContext::SetupAccessContext` we work with batch contexts that can't have subpass contexts, so no need to use recursive versions of context resolve.