### PR TITLE
sync: Rename CommandBufferAccessContext

### DIFF
--- a/docs/syncval_design.md
+++ b/docs/syncval_design.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 -->
-<!-- Copyright 2015-2025 LunarG, Inc. -->
+<!-- Copyright 2015-2026 LunarG, Inc. -->
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
@@ -543,7 +543,7 @@ Implements:
 *   Subpass dependency graph traversal for state lookup and resolution operations (including support  for RenderPass specific and Hazard detection operations)
 *   Range map operations to split (and potentially combine) ResourceAccessState records, to ensure state changes only impact the correct portion of the address space.
 
-#### CommandBufferAccessContext
+#### CommandBufferContext
 
 container for all access contexts for a specific command buffer, and state reflecting the current context.
 
@@ -578,7 +578,7 @@ RenderPass specific hazard check and state update operations
 
 Contains the access and event context information for a given queue submission batch.  This includes a full copy of all accesses from earlier queue batches.  "Earlier" includes the previous batches in submission order on the same queue and batches corresponding to Semaphore wait operations.  To minimize memory footprint, only two groups of contexts are retained. The first contains the access and  event context for a given queue as of its most recent submission operation. The second group are the QueueBatchContext corresponding to the state of a queue with a signaled semaphore or fence operation which has not yet been awaited.  Batches that have neither unresolved semaphore or fence operations associated, nor are the most recently submitted, may have QueueBatchContext with lifespans of only the submit entry point call.
 
-Accesses within a QueueBatchContext are tagged with "global" (at device scope) ResourceUsageTag id's, which are atomically allocated when the batch context is created. These tags are unique and monotonically increasing across all queues for a given VkDevice. While CommandBufferAccessContext contains the access usage records for all commands and synchronization operations, the QueueBatchContext tagging information references a global usage record store.  *Note: Clean up of the global usage record store will require traversing the access contexts of the queue batch contexts to find and eliminate unreferenced usage records.  This will need to be assessed as to priority relative to other apparent memory leaks in the maintenance of unresolved/unknown signal and event states.*
+Accesses within a QueueBatchContext are tagged with "global" (at device scope) ResourceUsageTag id's, which are atomically allocated when the batch context is created. These tags are unique and monotonically increasing across all queues for a given VkDevice. While CommandBufferContext contains the access usage records for all commands and synchronization operations, the QueueBatchContext tagging information references a global usage record store.  *Note: Clean up of the global usage record store will require traversing the access contexts of the queue batch contexts to find and eliminate unreferenced usage records.  This will need to be assessed as to priority relative to other apparent memory leaks in the maintenance of unresolved/unknown signal and event states.*
 
 
 ### Range Based Operations

--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -295,9 +295,9 @@ void AccessContext::ResolveAllSubpassDependencies() {
 void AccessContext::ResolveChildContexts(vvl::span<AccessContext> subpass_contexts) {
     assert(!finalized_);
 
-    for (AccessContext& context : subpass_contexts) {
-        ApplySubpassBarrierAction barrier_action(context.GetDstExternalSubpassBarrier());
-        context.ResolveAccessRange(kFullRange, barrier_action, *this);
+    for (AccessContext& access_context : subpass_contexts) {
+        ApplySubpassBarrierAction barrier_action(access_context.GetDstExternalSubpassBarrier());
+        access_context.ResolveAccessRange(kFullRange, barrier_action, *this);
     }
 }
 
@@ -607,8 +607,8 @@ void AccessContext::ImportAsyncContexts(const AccessContext& from) {
     async_.insert(async_.end(), from.async_.begin(), from.async_.end());
 }
 
-void AccessContext::AddAsyncContext(const AccessContext& context, ResourceUsageTag tag, QueueId queue_id) {
-    async_.emplace_back(context, tag, queue_id);
+void AccessContext::AddAsyncContext(const AccessContext& access_context, ResourceUsageTag tag, QueueId queue_id) {
+    async_.emplace_back(access_context, tag, queue_id);
 }
 
 void SortedFirstAccesses::Init(const AccessMap& finalized_access_map) {

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -265,8 +265,7 @@ SyncEnvironment::SyncEnvironment(const SyncValidator& validator, VkQueueFlags qu
       events_context(events_context),
       usage_info_provider(usage_info_provider) {}
 
-CommandBufferAccessContext::CommandBufferAccessContext(const SyncValidator& sync_validator, VkQueueFlags queue_flags,
-                                                       VulkanTypedHandle handle)
+CommandBufferContext::CommandBufferContext(const SyncValidator& sync_validator, VkQueueFlags queue_flags, VulkanTypedHandle handle)
     : sync_state_(sync_validator),
       error_messages_(sync_validator.error_messages_),
       access_log_(std::make_shared<AccessLog>()),
@@ -281,15 +280,15 @@ CommandBufferAccessContext::CommandBufferAccessContext(const SyncValidator& sync
       current_renderpass_context_(),
       sync_ops_() {}
 
-CommandBufferAccessContext::CommandBufferAccessContext(SyncValidator& sync_validator, vvl::CommandBuffer* cb_state)
-    : CommandBufferAccessContext(sync_validator, cb_state->GetQueueFlags(), cb_state->Handle()) {
+CommandBufferContext::CommandBufferContext(SyncValidator& sync_validator, vvl::CommandBuffer* cb_state)
+    : CommandBufferContext(sync_validator, cb_state->GetQueueFlags(), cb_state->Handle()) {
     cb_state_ = cb_state;
     sync_state_.stats.AddCommandBufferContext();
 }
 
 // NOTE: Make sure the proxy doesn't outlive from, as the proxy is pointing directly to access contexts owned by from.
-CommandBufferAccessContext::CommandBufferAccessContext(const CommandBufferAccessContext& from, AsProxyContext dummy)
-    : CommandBufferAccessContext(from.sync_state_, from.cb_state_->GetQueueFlags(), from.cb_state_->Handle()) {
+CommandBufferContext::CommandBufferContext(const CommandBufferContext& from, AsProxyContext dummy)
+    : CommandBufferContext(from.sync_state_, from.cb_state_->GetQueueFlags(), from.cb_state_->Handle()) {
     // Copy only the needed fields out of from for a temporary, proxy command buffer context
     cb_state_ = from.cb_state_;
     access_log_ = std::make_shared<AccessLog>(*from.access_log_);  // potentially large, but no choice given tagging lookup.
@@ -312,12 +311,12 @@ CommandBufferAccessContext::CommandBufferAccessContext(const CommandBufferAccess
     sync_state_.stats.AddCommandBufferContext();
 }
 
-CommandBufferAccessContext::~CommandBufferAccessContext() {
+CommandBufferContext::~CommandBufferContext() {
     sync_state_.stats.RemoveCommandBufferContext();
     sync_state_.stats.RemoveHandleRecord((uint32_t)handles_.size());
 }
 
-void CommandBufferAccessContext::Reset() {
+void CommandBufferContext::Reset() {
     access_log_ = std::make_shared<AccessLog>();
     cbs_referenced_ = std::make_shared<CommandBufferSet>();
     if (cb_state_) {
@@ -339,7 +338,7 @@ void CommandBufferAccessContext::Reset() {
     dynamic_rendering_info_.reset();
 }
 
-bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject& error_obj, BeginRenderingCmdState& cmd_state) const {
+bool CommandBufferContext::ValidateBeginRendering(const ErrorObject& error_obj, BeginRenderingCmdState& cmd_state) const {
     bool skip = false;
     const DynamicRenderingInfo& info = cmd_state.GetRenderingInfo();
 
@@ -380,7 +379,7 @@ bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject& error
     return skip;
 }
 
-void CommandBufferAccessContext::RecordBeginRendering(BeginRenderingCmdState& cmd_state, const Location& loc) {
+void CommandBufferContext::RecordBeginRendering(BeginRenderingCmdState& cmd_state, const Location& loc) {
     const auto tag = NextCommandTag(loc.function);
 
     const DynamicRenderingInfo& info = cmd_state.GetRenderingInfo();
@@ -400,7 +399,7 @@ void CommandBufferAccessContext::RecordBeginRendering(BeginRenderingCmdState& cm
     dynamic_rendering_info_ = std::move(cmd_state.info);
 }
 
-bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject& error_obj) const {
+bool CommandBufferContext::ValidateEndRendering(const ErrorObject& error_obj) const {
     bool skip = false;
 
     // Only validate resolve and store if not suspending (as specified by BeginRendering)
@@ -487,7 +486,7 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject& error_o
     return skip;
 }
 
-void CommandBufferAccessContext::RecordEndRendering(const RecordObject& record_obj) {
+void CommandBufferContext::RecordEndRendering(const RecordObject& record_obj) {
     if (!dynamic_rendering_info_) {
         return;
     }
@@ -525,8 +524,7 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject& record_o
     dynamic_rendering_info_.reset();
 }
 
-bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint,
-                                                                   const Location& loc) const {
+bool CommandBufferContext::ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, const Location& loc) const {
     bool skip = false;
     if (!sync_state_.syncval_settings.shader_accesses_heuristic) {
         return skip;
@@ -694,8 +692,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
 }
 
 // TODO: Record structure repeats Validate. Unify this code, it was the source of bugs few times already.
-void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint,
-                                                                 const ResourceUsageTag tag) {
+void CommandBufferContext::RecordDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, const ResourceUsageTag tag) {
     if (!sync_state_.syncval_settings.shader_accesses_heuristic) {
         return;
     }
@@ -825,7 +822,7 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
     }
 }
 
-bool CommandBufferAccessContext::ValidateDrawVertex(uint32_t vertexCount, uint32_t firstVertex, const Location& loc) const {
+bool CommandBufferContext::ValidateDrawVertex(uint32_t vertexCount, uint32_t firstVertex, const Location& loc) const {
     bool skip = false;
     const auto* pipe = cb_state_->GetLastBoundGraphics().pipeline_state;
     if (!pipe) {
@@ -862,7 +859,7 @@ bool CommandBufferAccessContext::ValidateDrawVertex(uint32_t vertexCount, uint32
     return skip;
 }
 
-void CommandBufferAccessContext::RecordDrawVertex(uint32_t vertexCount, uint32_t firstVertex, const ResourceUsageTag tag) {
+void CommandBufferContext::RecordDrawVertex(uint32_t vertexCount, uint32_t firstVertex, const ResourceUsageTag tag) {
     const auto* pipe = cb_state_->GetLastBoundGraphics().pipeline_state;
     if (!pipe) {
         return;
@@ -891,7 +888,7 @@ void CommandBufferAccessContext::RecordDrawVertex(uint32_t vertexCount, uint32_t
     }
 }
 
-bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t index_count, uint32_t firstIndex, const Location& loc) const {
+bool CommandBufferContext::ValidateDrawVertexIndex(uint32_t index_count, uint32_t firstIndex, const Location& loc) const {
     bool skip = false;
     const auto& index_binding = cb_state_->index_buffer_binding;
     // TODO - Handle https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/issues/45
@@ -922,7 +919,7 @@ bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t index_count, u
     return skip;
 }
 
-void CommandBufferAccessContext::RecordDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, const ResourceUsageTag tag) {
+void CommandBufferContext::RecordDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, const ResourceUsageTag tag) {
     const auto& index_binding = cb_state_->index_buffer_binding;
     // TODO - Handle https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/issues/45
     const auto index_buf_state = sync_state_.Get<vvl::Buffer>(index_binding.Buffer());
@@ -943,7 +940,7 @@ void CommandBufferAccessContext::RecordDrawVertexIndex(uint32_t indexCount, uint
     // RecordDrawVertex(?, ?, tag);
 }
 
-bool CommandBufferAccessContext::ValidateDrawAttachment(const Location& loc) const {
+bool CommandBufferContext::ValidateDrawAttachment(const Location& loc) const {
     bool skip = false;
     if (current_renderpass_context_) {
         skip |= current_renderpass_context_->ValidateDrawSubpassAttachment(*this, loc.function);
@@ -953,7 +950,7 @@ bool CommandBufferAccessContext::ValidateDrawAttachment(const Location& loc) con
     return skip;
 }
 
-bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Location& location) const {
+bool CommandBufferContext::ValidateDrawDynamicRenderingAttachment(const Location& location) const {
     bool skip = false;
     const auto& last_bound_state = cb_state_->GetLastBoundGraphics();
     const auto* pipe = last_bound_state.pipeline_state;
@@ -1014,7 +1011,7 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
     return skip;
 }
 
-void CommandBufferAccessContext::RecordDrawAttachment(const ResourceUsageTag tag) {
+void CommandBufferContext::RecordDrawAttachment(const ResourceUsageTag tag) {
     if (current_renderpass_context_) {
         current_renderpass_context_->RecordDrawSubpassAttachment(*cb_state_, tag);
     } else if (dynamic_rendering_info_) {
@@ -1022,7 +1019,7 @@ void CommandBufferAccessContext::RecordDrawAttachment(const ResourceUsageTag tag
     }
 }
 
-void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUsageTag tag) {
+void CommandBufferContext::RecordDrawDynamicRenderingAttachment(ResourceUsageTag tag) {
     const auto& last_bound_state = cb_state_->GetLastBoundGraphics();
     const auto* pipe = last_bound_state.pipeline_state;
     if (!pipe || pipe->RasterizationDisabled()) {
@@ -1066,8 +1063,8 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
     }
 }
 
-VkImageAspectFlags CommandBufferAccessContext::GetAttachmentAspectsToClear(VkImageAspectFlags clear_aspect_mask,
-                                                                           const vvl::ImageView& attachment_view) const {
+VkImageAspectFlags CommandBufferContext::GetAttachmentAspectsToClear(VkImageAspectFlags clear_aspect_mask,
+                                                                     const vvl::ImageView& attachment_view) const {
     // Check if clear request is valid.
     const bool clear_color = (clear_aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT) != 0;
     const bool clear_depth = (clear_aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0;
@@ -1137,7 +1134,7 @@ static std::optional<VkImageSubresourceRange> RestrictSubresourceRangeToClearLay
     return result;
 }
 
-std::optional<CommandBufferAccessContext::ClearAttachmentInfo> CommandBufferAccessContext::GetClearAttachmentInfo(
+std::optional<CommandBufferContext::ClearAttachmentInfo> CommandBufferContext::GetClearAttachmentInfo(
     const VkClearAttachment& clear_attachment, uint32_t clear_first_layer, uint32_t clear_layer_count) const {
     const vvl::ImageView* attachment_view = nullptr;
     if (current_renderpass_context_) {
@@ -1163,8 +1160,8 @@ std::optional<CommandBufferAccessContext::ClearAttachmentInfo> CommandBufferAcce
     return ClearAttachmentInfo{*attachment_view, *subresource_range};
 }
 
-bool CommandBufferAccessContext::ValidateClearAttachment(const Location& loc, const VkClearAttachment& clear_attachment,
-                                                         uint32_t clear_rect_index, const VkClearRect& clear_rect) const {
+bool CommandBufferContext::ValidateClearAttachment(const Location& loc, const VkClearAttachment& clear_attachment,
+                                                   uint32_t clear_rect_index, const VkClearRect& clear_rect) const {
     bool skip = false;
 
     const auto optional_info = GetClearAttachmentInfo(clear_attachment, clear_rect.baseArrayLayer, clear_rect.layerCount);
@@ -1279,8 +1276,8 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location& loc, co
     return skip;
 }
 
-void CommandBufferAccessContext::RecordClearAttachment(ResourceUsageTag tag, const VkClearAttachment& clear_attachment,
-                                                       const VkClearRect& rect) {
+void CommandBufferContext::RecordClearAttachment(ResourceUsageTag tag, const VkClearAttachment& clear_attachment,
+                                                 const VkClearRect& rect) {
     const auto optional_info = GetClearAttachmentInfo(clear_attachment, rect.baseArrayLayer, rect.layerCount);
     if (!optional_info) {
         return;
@@ -1321,9 +1318,9 @@ void CommandBufferAccessContext::RecordClearAttachment(ResourceUsageTag tag, con
     }
 }
 
-QueueId CommandBufferAccessContext::GetQueueId() const { return kQueueIdInvalid; }
+QueueId CommandBufferContext::GetQueueId() const { return kQueueIdInvalid; }
 
-ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(
+ResourceUsageTag CommandBufferContext::RecordBeginRenderPass(
     vvl::Func command, const vvl::RenderPass& rp_state, const VkRect2D& render_area,
     const std::vector<std::shared_ptr<const vvl::ImageView>>& attachment_views) {
     // Create an access context the current renderpass.
@@ -1338,7 +1335,7 @@ ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(
     return barrier_tag;
 }
 
-ResourceUsageTag CommandBufferAccessContext::RecordNextSubpass(vvl::Func command) {
+ResourceUsageTag CommandBufferContext::RecordNextSubpass(vvl::Func command) {
     // At this point current subpass value has not updated yet to the index of "next subpass"
     const uint32_t previous_subpass = current_renderpass_context_->GetCurrentSubpass();
     const uint32_t this_subpass = previous_subpass + 1;
@@ -1354,7 +1351,7 @@ ResourceUsageTag CommandBufferAccessContext::RecordNextSubpass(vvl::Func command
     return transition_tag;
 }
 
-ResourceUsageTag CommandBufferAccessContext::RecordEndRenderPass(vvl::Func command) {
+ResourceUsageTag CommandBufferContext::RecordEndRenderPass(vvl::Func command) {
     const uint32_t current_subpass = current_renderpass_context_->GetCurrentSubpass();
 
     auto store_tag = NextCommandTag(command, SubCommandType::kStoreOp, current_subpass);
@@ -1369,9 +1366,9 @@ ResourceUsageTag CommandBufferAccessContext::RecordEndRenderPass(vvl::Func comma
     return barrier_tag;
 }
 
-void CommandBufferAccessContext::RecordDestroyEvent(vvl::Event* event_state) { events_context_.Destroy(event_state); }
+void CommandBufferContext::RecordDestroyEvent(vvl::Event* event_state) { events_context_.Destroy(event_state); }
 
-void CommandBufferAccessContext::RecordExecutedCommandBuffer(const CommandBufferAccessContext& recorded_cb_context) {
+void CommandBufferContext::RecordExecutedCommandBuffer(const CommandBufferContext& recorded_cb_context) {
     const AccessContext& recorded_context = recorded_cb_context.GetCbAccessContext();
 
     // Just run through the barriers ignoring the usage from the recorded context, as Resolve will overwrite outdated state
@@ -1386,12 +1383,12 @@ void CommandBufferAccessContext::RecordExecutedCommandBuffer(const CommandBuffer
     ResolveExecutedCommandBuffer(recorded_context, base_tag);
 }
 
-void CommandBufferAccessContext::ResolveExecutedCommandBuffer(const AccessContext& recorded_context, ResourceUsageTag offset) {
+void CommandBufferContext::ResolveExecutedCommandBuffer(const AccessContext& recorded_context, ResourceUsageTag offset) {
     auto tag_offset = [offset](AccessState* access) { access->OffsetTag(offset); };
     current_context_->ResolveFromContext(tag_offset, recorded_context);
 }
 
-void CommandBufferAccessContext::ImportRecordedAccessLog(const CommandBufferAccessContext& recorded_context) {
+void CommandBufferContext::ImportRecordedAccessLog(const CommandBufferContext& recorded_context) {
     cbs_referenced_->emplace_back(recorded_context.GetCBStateShared());
     access_log_->insert(access_log_->end(), recorded_context.access_log_->cbegin(), recorded_context.access_log_->cend());
 
@@ -1410,7 +1407,7 @@ void CommandBufferAccessContext::ImportRecordedAccessLog(const CommandBufferAcce
     }
 }
 
-ResourceUsageTag CommandBufferAccessContext::NextCommandTag(vvl::Func command, SubCommandType subcommand, uint32_t subpass) {
+ResourceUsageTag CommandBufferContext::NextCommandTag(vvl::Func command, SubCommandType subcommand, uint32_t subpass) {
     command_number_++;
     current_command_tag_ = access_log_->size();
 
@@ -1423,7 +1420,7 @@ ResourceUsageTag CommandBufferAccessContext::NextCommandTag(vvl::Func command, S
     return current_command_tag_;
 }
 
-ResourceUsageTag CommandBufferAccessContext::NextSubCommandTag(vvl::Func command, SubCommandType subcommand, uint32_t subpass) {
+ResourceUsageTag CommandBufferContext::NextSubCommandTag(vvl::Func command, SubCommandType subcommand, uint32_t subpass) {
     const ResourceUsageTag tag = access_log_->size();
     ResourceUsageRecord& record = access_log_->emplace_back(command, command_number_, subcommand, cb_state_, reset_count_, subpass);
 
@@ -1438,19 +1435,19 @@ ResourceUsageTag CommandBufferAccessContext::NextSubCommandTag(vvl::Func command
     return tag;
 }
 
-uint32_t CommandBufferAccessContext::AddHandle(const VulkanTypedHandle& typed_handle, uint32_t index) {
+uint32_t CommandBufferContext::AddHandle(const VulkanTypedHandle& typed_handle, uint32_t index) {
     const uint32_t handle_index = static_cast<uint32_t>(handles_.size());
     handles_.emplace_back(HandleRecord(typed_handle, index));
     sync_state_.stats.AddHandleRecord();
     return handle_index;
 }
 
-ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandle(ResourceUsageTag tag, const VulkanTypedHandle& typed_handle) {
+ResourceUsageTagEx CommandBufferContext::AddCommandHandle(ResourceUsageTag tag, const VulkanTypedHandle& typed_handle) {
     return AddCommandHandleIndexed(tag, typed_handle, vvl::kNoIndex32);
 }
 
-ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandleIndexed(ResourceUsageTag tag, const VulkanTypedHandle& typed_handle,
-                                                                       uint32_t index) {
+ResourceUsageTagEx CommandBufferContext::AddCommandHandleIndexed(ResourceUsageTag tag, const VulkanTypedHandle& typed_handle,
+                                                                 uint32_t index) {
     assert(tag < access_log_->size());
     const uint32_t handle_index = AddHandle(typed_handle, index);
     // TODO: the following range check is not needed. Test and remove.
@@ -1468,8 +1465,7 @@ ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandleIndexed(ResourceU
     return {tag, handle_index};
 }
 
-void CommandBufferAccessContext::AddSubcommandHandleIndexed(ResourceUsageTag tag, const VulkanTypedHandle& typed_handle,
-                                                            uint32_t index) {
+void CommandBufferContext::AddSubcommandHandleIndexed(ResourceUsageTag tag, const VulkanTypedHandle& typed_handle, uint32_t index) {
     assert(tag < access_log_->size());
     const uint32_t handle_index = AddHandle(typed_handle, index);
     // TODO: the following range check is not needed. Test and remove.
@@ -1488,19 +1484,19 @@ void CommandBufferAccessContext::AddSubcommandHandleIndexed(ResourceUsageTag tag
     }
 }
 
-std::string CommandBufferAccessContext::GetDebugRegionName(const ResourceUsageRecord& record) const {
+std::string CommandBufferContext::GetDebugRegionName(const ResourceUsageRecord& record) const {
     const bool use_proxy = !proxy_label_commands_.empty();
     const auto& label_commands = use_proxy ? proxy_label_commands_ : cb_state_->GetLabelCommands();
     return vvl::CommandBuffer::GetDebugRegionName(label_commands, record.label_command_index);
 }
 
-void CommandBufferAccessContext::AddSyncOp(ResourceUsageTag tag, std::shared_ptr<SyncOpBase>&& sync_op) {
+void CommandBufferContext::AddSyncOp(ResourceUsageTag tag, std::shared_ptr<SyncOpBase>&& sync_op) {
     // As renderpass operations can have side effects on the command buffer access context,
     // update the sync operation to record these if any.
     sync_ops_.emplace_back(tag, std::move(sync_op));
 }
 
-AttachmentAccess CommandBufferAccessContext::GetAttachmentAccess(SyncOrdering ordering, AttachmentAccessType type) const {
+AttachmentAccess CommandBufferContext::GetAttachmentAccess(SyncOrdering ordering, AttachmentAccessType type) const {
     AttachmentAccess attachment_access;
     attachment_access.type = type;
     attachment_access.ordering = ordering;
@@ -1509,7 +1505,7 @@ AttachmentAccess CommandBufferAccessContext::GetAttachmentAccess(SyncOrdering or
     return attachment_access;
 }
 
-uint32_t CommandBufferAccessContext::GetViewMask() const {
+uint32_t CommandBufferContext::GetViewMask() const {
     if (dynamic_rendering_info_) {
         return dynamic_rendering_info_->info.viewMask;
     } else if (current_renderpass_context_) {
@@ -1532,7 +1528,7 @@ uint32_t CommandBufferAccessContext::GetViewMask() const {
 // VK_SYNCVAL_DEBUG_COMMAND_NUMBER: the command number
 // VK_SYNCVAL_DEBUG_RESET_COUNT: (optional, default value is 1) command buffer reset count
 // VK_SYNCVAL_DEBUG_CMDBUF_PATTERN: (optional, empty string by default) pattern to match command buffer debug name
-void CommandBufferAccessContext::CheckCommandTagDebugCheckpoint() {
+void CommandBufferContext::CheckCommandTagDebugCheckpoint() {
     auto get_cmdbuf_name = [](const DebugReport& debug_report, uint64_t cmdbuf_handle) {
         std::unique_lock<std::mutex> lock(debug_report.debug_output_mutex);
         std::string object_name = debug_report.GetUtilsObjectNameNoLock(cmdbuf_handle);
@@ -1557,7 +1553,7 @@ void CommandBufferAccessContext::CheckCommandTagDebugCheckpoint() {
 
 void UpdateAccessMapStats(const AccessMap& access_map, AccessContextStats& stats);
 
-void CommandBufferAccessContext::UpdateStats(AccessStats& access_stats) const {
+void CommandBufferContext::UpdateStats(AccessStats& access_stats) const {
 #if VVL_ENABLE_SYNCVAL_STATS != 0
     UpdateAccessMapStats(cb_access_context_.GetAccessMap(), access_stats.cb_access_stats);
 
@@ -1570,29 +1566,29 @@ void CommandBufferAccessContext::UpdateStats(AccessStats& access_stats) const {
 }
 
 CommandBufferSubState::CommandBufferSubState(SyncValidator& dev, vvl::CommandBuffer& cb)
-    : vvl::CommandBufferSubState(cb), access_context(dev, &cb) {
-    access_context.SetSelfReference();
+    : vvl::CommandBufferSubState(cb), cb_context(dev, &cb) {
+    cb_context.SetSelfReference();
 }
 
 void CommandBufferSubState::End() {
-    access_context.GetCbAccessContext().Finalize();
+    cb_context.GetCbAccessContext().Finalize();
 
     // For threads that are dedicated to recording command buffers but do not submit themselves,
     // the end of recording is a logical point to update memory stats
-    access_context.GetSyncState().stats.UpdateMemoryStats();
+    cb_context.GetSyncState().stats.UpdateMemoryStats();
 }
 
 void CommandBufferSubState::Destroy() {
-    access_context.Destroy();  // must be first to clean up self references correctly.
+    cb_context.Destroy();  // must be first to clean up self references correctly.
 }
 
-void CommandBufferSubState::Reset(const Location& loc) { access_context.Reset(); }
+void CommandBufferSubState::Reset(const Location& loc) { cb_context.Reset(); }
 
 void CommandBufferSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) {
     for (auto& obj : invalid_nodes) {
         switch (obj->Type()) {
             case kVulkanObjectTypeEvent:
-                access_context.RecordDestroyEvent(static_cast<vvl::Event*>(obj.get()));
+                cb_context.RecordDestroyEvent(static_cast<vvl::Event*>(obj.get()));
                 break;
             default:
                 break;
@@ -1602,11 +1598,11 @@ void CommandBufferSubState::NotifyInvalidate(const vvl::StateObject::NodeList& i
 
 void CommandBufferSubState::RecordCopyBuffer(vvl::Buffer& src_buffer_state, vvl::Buffer& dst_buffer_state, uint32_t region_count,
                                              const VkBufferCopy* regions, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_buffer_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_buffer_state.Handle());
 
     for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         const AccessRange src_range = MakeRange(src_buffer_state, copy_region.srcOffset, copy_region.size);
@@ -1619,11 +1615,11 @@ void CommandBufferSubState::RecordCopyBuffer(vvl::Buffer& src_buffer_state, vvl:
 
 void CommandBufferSubState::RecordCopyBuffer2(vvl::Buffer& src_buffer_state, vvl::Buffer& dst_buffer_state, uint32_t region_count,
                                               const VkBufferCopy2* regions, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_buffer_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_buffer_state.Handle());
 
     for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         const AccessRange src_range = MakeRange(src_buffer_state, copy_region.srcOffset, copy_region.size);
@@ -1637,11 +1633,11 @@ void CommandBufferSubState::RecordCopyBuffer2(vvl::Buffer& src_buffer_state, vvl
 void CommandBufferSubState::RecordCopyImage(vvl::Image& src_image_state, vvl::Image& dst_image_state,
                                             VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
                                             const VkImageCopy* regions, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_image_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_image_state.Handle());
 
     for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(context, src_image_state, SYNC_COPY_TRANSFER_READ, RangeFromLayers(copy_region.srcSubresource),
@@ -1654,11 +1650,11 @@ void CommandBufferSubState::RecordCopyImage(vvl::Image& src_image_state, vvl::Im
 void CommandBufferSubState::RecordCopyImage2(vvl::Image& src_image_state, vvl::Image& dst_image_state,
                                              VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
                                              const VkImageCopy2* regions, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_image_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_image_state.Handle());
 
     for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(context, src_image_state, SYNC_COPY_TRANSFER_READ, RangeFromLayers(copy_region.srcSubresource),
@@ -1670,11 +1666,11 @@ void CommandBufferSubState::RecordCopyImage2(vvl::Image& src_image_state, vvl::I
 
 void CommandBufferSubState::RecordCopyBufferToImage(vvl::Buffer& src_buffer_state, vvl::Image& dst_image_state, VkImageLayout,
                                                     uint32_t region_count, const VkBufferImageCopy* regions, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_buffer_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_image_state.Handle());
 
     for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         AccessRange src_range = MakeRange(copy_region.bufferOffset, dst_image_state.GetBufferSizeFromCopyImage(copy_region));
@@ -1688,11 +1684,11 @@ void CommandBufferSubState::RecordCopyBufferToImage(vvl::Buffer& src_buffer_stat
 void CommandBufferSubState::RecordCopyBufferToImage2(vvl::Buffer& src_buffer_state, vvl::Image& dst_image_state, VkImageLayout,
                                                      uint32_t region_count, const VkBufferImageCopy2* regions,
                                                      const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_buffer_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_image_state.Handle());
 
     for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         AccessRange src_range = MakeRange(copy_region.bufferOffset, dst_image_state.GetBufferSizeFromCopyImage(copy_region));
@@ -1706,11 +1702,11 @@ void CommandBufferSubState::RecordCopyBufferToImage2(vvl::Buffer& src_buffer_sta
 void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image& src_image_state, vvl::Buffer& dst_buffer_state,
                                                     VkImageLayout src_image_layout, uint32_t region_count,
                                                     const VkBufferImageCopy* regions, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_image_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_buffer_state.Handle());
 
     for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(context, src_image_state, SYNC_COPY_TRANSFER_READ, RangeFromLayers(copy_region.imageSubresource),
@@ -1724,11 +1720,11 @@ void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image& src_image_state,
 void CommandBufferSubState::RecordCopyImageToBuffer2(vvl::Image& src_image_state, vvl::Buffer& dst_buffer_state,
                                                      VkImageLayout src_image_layout, uint32_t region_count,
                                                      const VkBufferImageCopy2* regions, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_image_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_buffer_state.Handle());
 
     for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(context, src_image_state, SYNC_COPY_TRANSFER_READ, RangeFromLayers(copy_region.imageSubresource),
@@ -1742,11 +1738,11 @@ void CommandBufferSubState::RecordCopyImageToBuffer2(vvl::Image& src_image_state
 void CommandBufferSubState::RecordBlitImage(vvl::Image& src_image_state, vvl::Image& dst_image_state,
                                             VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
                                             const VkImageBlit* regions, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_image_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_image_state.Handle());
 
     for (const auto& blit_region : vvl::make_span(regions, region_count)) {
         VkOffset3D offset = {std::min(blit_region.srcOffsets[0].x, blit_region.srcOffsets[1].x),
@@ -1772,11 +1768,11 @@ void CommandBufferSubState::RecordBlitImage(vvl::Image& src_image_state, vvl::Im
 void CommandBufferSubState::RecordBlitImage2(vvl::Image& src_image_state, vvl::Image& dst_image_state,
                                              VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
                                              const VkImageBlit2* regions, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_image_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_image_state.Handle());
 
     for (const auto& blit_region : vvl::make_span(regions, region_count)) {
         VkOffset3D offset = {std::min(blit_region.srcOffsets[0].x, blit_region.srcOffsets[1].x),
@@ -1801,11 +1797,11 @@ void CommandBufferSubState::RecordBlitImage2(vvl::Image& src_image_state, vvl::I
 
 void CommandBufferSubState::RecordResolveImage(vvl::Image& src_image_state, vvl::Image& dst_image_state, uint32_t region_count,
                                                const VkImageResolve* regions, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_image_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_image_state.Handle());
 
     for (const auto& resolve_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(context, src_image_state, SYNC_RESOLVE_TRANSFER_READ,
@@ -1819,11 +1815,11 @@ void CommandBufferSubState::RecordResolveImage(vvl::Image& src_image_state, vvl:
 
 void CommandBufferSubState::RecordResolveImage2(vvl::Image& src_image_state, vvl::Image& dst_image_state, uint32_t region_count,
                                                 const VkImageResolve2* regions, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
-    auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
+    auto src_tag_ex = cb_context.AddCommandHandle(tag, src_image_state.Handle());
+    auto dst_tag_ex = cb_context.AddCommandHandle(tag, dst_image_state.Handle());
 
     for (const auto& resolve_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(context, src_image_state, SYNC_RESOLVE_TRANSFER_READ,
@@ -1838,10 +1834,10 @@ void CommandBufferSubState::RecordResolveImage2(vvl::Image& src_image_state, vvl
 void CommandBufferSubState::RecordClearColorImage(vvl::Image& image_state, VkImageLayout, const VkClearColorValue*,
                                                   uint32_t range_count, const VkImageSubresourceRange* ranges,
                                                   const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    access_context.AddCommandHandle(tag, image_state.Handle());
+    cb_context.AddCommandHandle(tag, image_state.Handle());
 
     for (uint32_t index = 0; index < range_count; index++) {
         const auto& range = ranges[index];
@@ -1852,10 +1848,10 @@ void CommandBufferSubState::RecordClearColorImage(vvl::Image& image_state, VkIma
 void CommandBufferSubState::RecordClearDepthStencilImage(vvl::Image& image_state, VkImageLayout, const VkClearDepthStencilValue*,
                                                          uint32_t range_count, const VkImageSubresourceRange* ranges,
                                                          const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
-    access_context.AddCommandHandle(tag, image_state.Handle());
+    cb_context.AddCommandHandle(tag, image_state.Handle());
 
     for (uint32_t index = 0; index < range_count; index++) {
         const auto& range = ranges[index];
@@ -1865,48 +1861,48 @@ void CommandBufferSubState::RecordClearDepthStencilImage(vvl::Image& image_state
 
 void CommandBufferSubState::RecordClearAttachments(uint32_t attachment_count, const VkClearAttachment* pAttachments,
                                                    uint32_t rect_count, const VkClearRect* pRects, const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
+    const auto tag = cb_context.NextCommandTag(loc.function);
 
     for (const auto& attachment : vvl::make_span(pAttachments, attachment_count)) {
         for (const auto& rect : vvl::make_span(pRects, rect_count)) {
-            access_context.RecordClearAttachment(tag, attachment, rect);
+            cb_context.RecordClearAttachment(tag, attachment, rect);
         }
     }
 }
 
 void CommandBufferSubState::RecordFillBuffer(vvl::Buffer& buffer_state, VkDeviceSize offset, VkDeviceSize size,
                                              const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
     const AccessRange range = MakeRange(buffer_state, offset, size);
-    const ResourceUsageTagEx tag_ex = access_context.AddCommandHandle(tag, buffer_state.Handle());
+    const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, buffer_state.Handle());
     context.UpdateAccessState(buffer_state, SYNC_CLEAR_TRANSFER_WRITE, range, tag_ex);
 }
 
 void CommandBufferSubState::RecordUpdateBuffer(vvl::Buffer& buffer_state, VkDeviceSize offset, VkDeviceSize size,
                                                const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
     // VK_WHOLE_SIZE not allowed
     const AccessRange range = MakeRange(offset, size);
-    const ResourceUsageTagEx tag_ex = access_context.AddCommandHandle(tag, buffer_state.Handle());
+    const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, buffer_state.Handle());
     context.UpdateAccessState(buffer_state, SYNC_CLEAR_TRANSFER_WRITE, range, tag_ex);
 }
 
 void CommandBufferSubState::RecordDecodeVideo(vvl::VideoSession& vs_state, const VkVideoDecodeInfoKHR& decode_info,
                                               const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
     if (auto src_buffer = base.dev_data.Get<vvl::Buffer>(decode_info.srcBuffer)) {
         const AccessRange src_range = MakeRange(*src_buffer, decode_info.srcBufferOffset, decode_info.srcBufferRange);
-        const ResourceUsageTagEx src_tag_ex = access_context.AddCommandHandle(tag, src_buffer->Handle());
+        const ResourceUsageTagEx src_tag_ex = cb_context.AddCommandHandle(tag, src_buffer->Handle());
         context.UpdateAccessState(*src_buffer, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ, src_range, src_tag_ex);
     }
 
-    const vvl::DeviceState* device_state = access_context.GetSyncState().device_state;
+    const vvl::DeviceState* device_state = cb_context.GetSyncState().device_state;
     auto dst_resource = vvl::VideoPictureResource(*device_state, decode_info.dstPictureResource);
     if (dst_resource) {
         UpdateVideoAccessState(context, vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE, tag);
@@ -1931,16 +1927,16 @@ void CommandBufferSubState::RecordDecodeVideo(vvl::VideoSession& vs_state, const
 
 void CommandBufferSubState::RecordEncodeVideo(vvl::VideoSession& vs_state, const VkVideoEncodeInfoKHR& encode_info,
                                               const Location& loc) {
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
     if (auto src_buffer = base.dev_data.Get<vvl::Buffer>(encode_info.dstBuffer)) {
         const AccessRange src_range = MakeRange(*src_buffer, encode_info.dstBufferOffset, encode_info.dstBufferRange);
-        const ResourceUsageTagEx src_tag_ex = access_context.AddCommandHandle(tag, src_buffer->Handle());
+        const ResourceUsageTagEx src_tag_ex = cb_context.AddCommandHandle(tag, src_buffer->Handle());
         context.UpdateAccessState(*src_buffer, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE, src_range, src_tag_ex);
     }
 
-    const vvl::DeviceState* device_state = access_context.GetSyncState().device_state;
+    const vvl::DeviceState* device_state = cb_context.GetSyncState().device_state;
     auto src_resource = vvl::VideoPictureResource(*device_state, encode_info.srcPictureResource);
     if (src_resource) {
         UpdateVideoAccessState(context, vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ, tag);
@@ -1983,13 +1979,13 @@ void CommandBufferSubState::RecordCopyQueryPoolResults(vvl::QueryPool& pool_stat
     if (query_count == 0) {
         return;
     }
-    const auto tag = access_context.NextCommandTag(loc.function);
-    AccessContext& context = access_context.GetCbAccessContext();
+    const auto tag = cb_context.NextCommandTag(loc.function);
+    AccessContext& context = cb_context.GetCbAccessContext();
 
     const uint32_t query_size = (flags & VK_QUERY_RESULT_64_BIT) ? 8 : 4;
     const VkDeviceSize range_size = (query_count - 1) * stride + query_size;
     const AccessRange range = MakeRange(dst_offset, range_size);
-    const ResourceUsageTagEx tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
+    const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, dst_buffer_state.Handle());
     context.UpdateAccessState(dst_buffer_state, SYNC_COPY_TRANSFER_WRITE, range, tag_ex);
 
     // TODO:Track VkQueryPool
@@ -2001,7 +1997,7 @@ void CommandBufferSubState::RecordBeginRenderPass(const VkRenderPassBeginInfo& r
         return;  // [core validation check]: only primary command buffer can begin render pass
     }
 
-    const SyncValidator& validator = access_context.GetSyncState();
+    const SyncValidator& validator = cb_context.GetSyncState();
     auto rp_state = validator.Get<vvl::RenderPass>(render_pass_begin.renderPass);
     if (!rp_state) {
         return;
@@ -2014,10 +2010,10 @@ void CommandBufferSubState::RecordBeginRenderPass(const VkRenderPassBeginInfo& r
     }
 
     const ResourceUsageTag begin_tag =
-        access_context.RecordBeginRenderPass(loc.function, *rp_state, render_pass_begin.renderArea, attachments);
-    const RenderPassAccessContext* rp_context = access_context.GetCurrentRenderPassContext();
+        cb_context.RecordBeginRenderPass(loc.function, *rp_state, render_pass_begin.renderArea, attachments);
+    const RenderPassAccessContext* rp_context = cb_context.GetCurrentRenderPassContext();
     auto sync_op = std::make_shared<SyncOpBeginRenderPass>(std::move(rp_state), std::move(attachments), rp_context, loc);
-    access_context.AddSyncOp(begin_tag, std::move(sync_op));
+    cb_context.AddSyncOp(begin_tag, std::move(sync_op));
 }
 
 void CommandBufferSubState::RecordNextSubpass(const VkSubpassBeginInfo& subpass_begin_info,
@@ -2025,36 +2021,36 @@ void CommandBufferSubState::RecordNextSubpass(const VkSubpassBeginInfo& subpass_
     if (!base.IsPrimary()) {
         return;  // [core validation check]: only primary command buffer can start next subpass
     }
-    if (!access_context.GetCurrentRenderPassContext()) {
+    if (!cb_context.GetCurrentRenderPassContext()) {
         return;  // [core validation check]: begin render pass was not called
     }
-    const ResourceUsageTag tag = access_context.RecordNextSubpass(loc.function);
+    const ResourceUsageTag tag = cb_context.RecordNextSubpass(loc.function);
     auto sync_op = std::make_shared<SyncOpNextSubpass>(loc.function);
-    access_context.AddSyncOp(tag, std::move(sync_op));
+    cb_context.AddSyncOp(tag, std::move(sync_op));
 }
 
 void CommandBufferSubState::RecordEndRenderPass(const VkSubpassEndInfo* subpass_end_info, const Location& loc) {
     if (!base.IsPrimary()) {
         return;  // [core validation check]: only primary command buffer can end render pass
     }
-    if (!access_context.GetCurrentRenderPassContext()) {
+    if (!cb_context.GetCurrentRenderPassContext()) {
         return;  // [core validation check]: begin render pass was not called
     }
-    const ResourceUsageTag tag = access_context.RecordEndRenderPass(loc.function);
+    const ResourceUsageTag tag = cb_context.RecordEndRenderPass(loc.function);
     auto sync_op = std::make_shared<SyncOpEndRenderPass>(loc.function);
-    access_context.AddSyncOp(tag, std::move(sync_op));
+    cb_context.AddSyncOp(tag, std::move(sync_op));
 }
 
 void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_command_buffer, uint32_t cmd_index,
                                                  const Location& loc) {
     if (cmd_index == 0) {
-        ResourceUsageTag cb_tag = access_context.NextCommandTag(loc.function, SubCommandType::kIndex);
-        access_context.AddCommandHandleIndexed(cb_tag, secondary_command_buffer.Handle(), cmd_index);
+        ResourceUsageTag cb_tag = cb_context.NextCommandTag(loc.function, SubCommandType::kIndex);
+        cb_context.AddCommandHandleIndexed(cb_tag, secondary_command_buffer.Handle(), cmd_index);
     } else {
-        ResourceUsageTag cb_tag = access_context.NextSubCommandTag(loc.function, SubCommandType::kIndex);
-        access_context.AddSubcommandHandleIndexed(cb_tag, secondary_command_buffer.Handle(), cmd_index);
+        ResourceUsageTag cb_tag = cb_context.NextSubCommandTag(loc.function, SubCommandType::kIndex);
+        cb_context.AddSubcommandHandleIndexed(cb_tag, secondary_command_buffer.Handle(), cmd_index);
     }
-    access_context.RecordExecutedCommandBuffer(GetAccessContext(secondary_command_buffer));
+    cb_context.RecordExecutedCommandBuffer(GetCommandBufferContext(secondary_command_buffer));
 }
 
 }  // namespace syncval

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -169,7 +169,7 @@ struct SyncEnvironment {
     const ResourceUsageInfoProvider& usage_info_provider;
 };
 
-class CommandBufferAccessContext final : public ResourceUsageInfoProvider, public DebugNameProvider {
+class CommandBufferContext final : public ResourceUsageInfoProvider, public DebugNameProvider {
   public:
     struct SyncOpEntry {
         ResourceUsageTag tag;
@@ -178,13 +178,11 @@ class CommandBufferAccessContext final : public ResourceUsageInfoProvider, publi
         SyncOpEntry() = default;
         SyncOpEntry(const SyncOpEntry &other) = default;
     };
-
-    CommandBufferAccessContext(SyncValidator &sync_validator, vvl::CommandBuffer *cb_state);
-
     struct AsProxyContext {};
-    CommandBufferAccessContext(const CommandBufferAccessContext &real_context, AsProxyContext dummy);
 
-    ~CommandBufferAccessContext();
+    CommandBufferContext(SyncValidator& sync_validator, vvl::CommandBuffer* cb_state);
+    CommandBufferContext(const CommandBufferContext& real_context, AsProxyContext dummy);
+    ~CommandBufferContext();
 
     // NOTE: because this class is encapsulated in syncval::CommandBuffer, it isn't safe
     // to use shared_from_this from the constructor.
@@ -243,7 +241,7 @@ class CommandBufferAccessContext final : public ResourceUsageInfoProvider, publi
     ResourceUsageTag RecordEndRenderPass(vvl::Func command);
     void RecordDestroyEvent(vvl::Event *event_state);
 
-    void RecordExecutedCommandBuffer(const CommandBufferAccessContext &recorded_context);
+    void RecordExecutedCommandBuffer(const CommandBufferContext& recorded_context);
     void ResolveExecutedCommandBuffer(const AccessContext &recorded_context, ResourceUsageTag offset);
 
     size_t GetTagCount() const { return access_log_->size(); }
@@ -268,7 +266,7 @@ class CommandBufferAccessContext final : public ResourceUsageInfoProvider, publi
 
     std::shared_ptr<AccessLog> GetAccessLogShared() const { return access_log_; }
     std::shared_ptr<CommandBufferSet> GetCBReferencesShared() const { return cbs_referenced_; }
-    void ImportRecordedAccessLog(const CommandBufferAccessContext &cb_context);
+    void ImportRecordedAccessLog(const CommandBufferContext& cb_context);
     const std::vector<SyncOpEntry> &GetSyncOps() const { return sync_ops_; };
 
     // DebugNameProvider
@@ -279,7 +277,7 @@ class CommandBufferAccessContext final : public ResourceUsageInfoProvider, publi
     void UpdateStats(AccessStats &access_stats) const;
 
   private:
-    CommandBufferAccessContext(const SyncValidator& sync_validator, VkQueueFlags queue_flags, VulkanTypedHandle handle);
+    CommandBufferContext(const SyncValidator& sync_validator, VkQueueFlags queue_flags, VulkanTypedHandle handle);
 
     uint32_t AddHandle(const VulkanTypedHandle &typed_handle, uint32_t index);
     AttachmentAccess GetAttachmentAccess(SyncOrdering ordering, AttachmentAccessType type = AttachmentAccessType::Access) const;
@@ -302,7 +300,7 @@ class CommandBufferAccessContext final : public ResourceUsageInfoProvider, publi
     const SyncValidator& sync_state_;
     const ErrorMessages& error_messages_;
 
-    // Note: since every CommandBufferAccessContext is encapsulated in its CommandBuffer object,
+    // Note: since every CommandBufferContext is encapsulated in its CommandBuffer object,
     // a reference count is not needed here.
     vvl::CommandBuffer *cb_state_ = nullptr;
 
@@ -348,7 +346,7 @@ class CommandBufferAccessContext final : public ResourceUsageInfoProvider, publi
 
 class CommandBufferSubState : public vvl::CommandBufferSubState {
   public:
-    CommandBufferAccessContext access_context;
+    CommandBufferContext cb_context;
 
     CommandBufferSubState(SyncValidator &dev, vvl::CommandBuffer &cb);
 
@@ -412,19 +410,18 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordExecuteCommand(vvl::CommandBuffer &secondary_command_buffer, uint32_t cmd_index, const Location &loc) override;
 };
 
-static inline CommandBufferSubState &SubState(vvl::CommandBuffer &cb) {
-    return *static_cast<CommandBufferSubState *>(cb.SubState(LayerObjectTypeSyncValidation));
+static inline CommandBufferSubState& SubState(vvl::CommandBuffer& cb) {
+    return *static_cast<CommandBufferSubState*>(cb.SubState(LayerObjectTypeSyncValidation));
 }
-static inline const CommandBufferSubState &SubState(const vvl::CommandBuffer &cb) {
-    return *static_cast<const CommandBufferSubState *>(cb.SubState(LayerObjectTypeSyncValidation));
+static inline const CommandBufferSubState& SubState(const vvl::CommandBuffer& cb) {
+    return *static_cast<const CommandBufferSubState*>(cb.SubState(LayerObjectTypeSyncValidation));
 }
 
-static inline CommandBufferAccessContext& GetAccessContext(vvl::CommandBuffer& cb) {
-    return static_cast<CommandBufferSubState*>(cb.SubState(LayerObjectTypeSyncValidation))->access_context;
+static inline CommandBufferContext& GetCommandBufferContext(vvl::CommandBuffer& cb) {
+    return static_cast<CommandBufferSubState*>(cb.SubState(LayerObjectTypeSyncValidation))->cb_context;
 }
-static inline const CommandBufferAccessContext& GetAccessContext(const vvl::CommandBuffer& cb) {
-    return static_cast<const CommandBufferSubState*>(cb.SubState(LayerObjectTypeSyncValidation))->access_context;
+static inline const CommandBufferContext& GetCommandBufferContext(const vvl::CommandBuffer& cb) {
+    return static_cast<const CommandBufferSubState*>(cb.SubState(LayerObjectTypeSyncValidation))->cb_context;
 }
 
 }  // namespace syncval
-

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -45,7 +45,7 @@ std::string ErrorMessages::Error(const SyncEnvironment& env, const HazardResult&
     return message;
 }
 
-std::string ErrorMessages::BufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+std::string ErrorMessages::BufferError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                        const std::string& resource_description, const AccessRange range,
                                        AdditionalMessageInfo additional_info) const {
     std::ostringstream ss;
@@ -58,7 +58,7 @@ std::string ErrorMessages::BufferError(const HazardResult& hazard, const Command
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "BufferError", additional_info);
 }
 
-std::string ErrorMessages::BufferCopyError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::BufferCopyError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                            const vvl::Func command, const std::string& resource_description, uint32_t region_index,
                                            AccessRange range) const {
     AdditionalMessageInfo additional_info;
@@ -74,7 +74,7 @@ std::string ErrorMessages::BufferCopyError(const HazardResult& hazard, const Com
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "BufferCopyError", additional_info);
 }
 
-std::string ErrorMessages::AccelerationStructureError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::AccelerationStructureError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                       const vvl::Func command, const std::string& resource_description,
                                                       const AccessRange range, VkAccelerationStructureKHR as,
                                                       const Location& as_location) const {
@@ -97,7 +97,7 @@ std::string ErrorMessages::AccelerationStructureError(const HazardResult& hazard
                  additional_info);
 }
 
-std::string ErrorMessages::ImageCopyResolveBlitError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::ImageCopyResolveBlitError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                      vvl::Func command, const std::string& resource_description,
                                                      uint32_t region_index, const VkOffset3D& offset, const VkExtent3D& extent,
                                                      const VkImageSubresourceLayers& subresource) const {
@@ -128,9 +128,8 @@ std::string ErrorMessages::ImageCopyResolveBlitError(const HazardResult& hazard,
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, message_type, additional_info);
 }
 
-std::string ErrorMessages::ImageClearError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                           vvl::Func command, const std::string& resource_description,
-                                           uint32_t subresource_range_index,
+std::string ErrorMessages::ImageClearError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
+                                           const std::string& resource_description, uint32_t subresource_range_index,
                                            const VkImageSubresourceRange& subresource_range) const {
     std::ostringstream ss;
     ss << "\nImage clear subresource range " << subresource_range_index << ": {\n";
@@ -166,7 +165,7 @@ static void PrepareCommonDescriptorMessage(Logger& logger, const vvl::Pipeline& 
     ss << ", " << logger.FormatHandle(pipeline);
 }
 
-std::string ErrorMessages::BufferDescriptorError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::BufferDescriptorError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                  vvl::Func command, const std::string& resource_description,
                                                  const vvl::Pipeline& pipeline, uint32_t set_number,
                                                  const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
@@ -182,7 +181,7 @@ std::string ErrorMessages::BufferDescriptorError(const HazardResult& hazard, con
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "BufferDescriptorError", additional_info);
 }
 
-std::string ErrorMessages::ImageDescriptorError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::ImageDescriptorError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                 vvl::Func command, const std::string& resource_description,
                                                 const vvl::Pipeline& pipeline, uint32_t set_number,
                                                 const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
@@ -200,10 +199,9 @@ std::string ErrorMessages::ImageDescriptorError(const HazardResult& hazard, cons
 }
 
 std::string ErrorMessages::AccelerationStructureDescriptorError(
-    const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
-    const std::string& resource_description, const vvl::Pipeline& pipeline, uint32_t set_number,
-    const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type, uint32_t descriptor_binding,
-    uint32_t descriptor_array_element, VkShaderStageFlagBits shader_stage) const {
+    const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command, const std::string& resource_description,
+    const vvl::Pipeline& pipeline, uint32_t set_number, const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
+    uint32_t descriptor_binding, uint32_t descriptor_array_element, VkShaderStageFlagBits shader_stage) const {
     AdditionalMessageInfo additional_info;
     additional_info.access_action = "traces rays against";
 
@@ -217,7 +215,7 @@ std::string ErrorMessages::AccelerationStructureDescriptorError(
                  additional_info);
 }
 
-std::string ErrorMessages::ClearAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::ClearAttachmentError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                 vvl::Func command, const std::string& resource_description,
                                                 VkImageAspectFlags clear_aspects, uint32_t clear_rect_index,
                                                 const VkClearRect& clear_rect) const {
@@ -237,7 +235,7 @@ std::string ErrorMessages::ClearAttachmentError(const HazardResult& hazard, cons
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "ClearAttachmentError", additional_info);
 }
 
-std::string ErrorMessages::RenderPassAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::RenderPassAttachmentError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                      vvl::Func command, const std::string& resource_description) const {
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassAttachmentError");
 }
@@ -268,7 +266,7 @@ static void CheckForLoadOpDontCareInsight(VkAttachmentLoadOp load_op, bool is_co
     }
 }
 
-std::string ErrorMessages::BeginRenderingError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::BeginRenderingError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                vvl::Func command, const std::string& resource_description,
                                                VkAttachmentLoadOp load_op) const {
     AdditionalMessageInfo additional_info;
@@ -278,7 +276,7 @@ std::string ErrorMessages::BeginRenderingError(const HazardResult& hazard, const
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "BeginRenderingError", additional_info);
 }
 
-std::string ErrorMessages::EndRenderingResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::EndRenderingResolveError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                     vvl::Func command, const std::string& resource_description,
                                                     VkResolveModeFlagBits resolve_mode, bool resolve_write) const {
     AdditionalMessageInfo additional_info;
@@ -289,7 +287,7 @@ std::string ErrorMessages::EndRenderingResolveError(const HazardResult& hazard, 
                  additional_info);
 }
 
-std::string ErrorMessages::EndRenderingStoreError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::EndRenderingStoreError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                   vvl::Func command, const std::string& resource_description,
                                                   VkAttachmentStoreOp store_op) const {
     AdditionalMessageInfo additional_info;
@@ -298,7 +296,7 @@ std::string ErrorMessages::EndRenderingStoreError(const HazardResult& hazard, co
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "EndRenderingStoreError", additional_info);
 }
 
-std::string ErrorMessages::RenderPassLoadOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::RenderPassLoadOpError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                  vvl::Func command, const std::string& resource_description, uint32_t subpass,
                                                  uint32_t attachment, VkAttachmentLoadOp load_op, bool is_color) const {
     AdditionalMessageInfo additional_info;
@@ -310,7 +308,7 @@ std::string ErrorMessages::RenderPassLoadOpError(const HazardResult& hazard, con
 }
 
 std::string ErrorMessages::RenderPassLoadOpVsLayoutTransitionError(const HazardResult& hazard,
-                                                                   const CommandBufferAccessContext& cb_context, vvl::Func command,
+                                                                   const CommandBufferContext& cb_context, vvl::Func command,
                                                                    const std::string& resource_description,
                                                                    VkAttachmentLoadOp load_op, bool is_color) const {
     AdditionalMessageInfo additional_info;
@@ -323,12 +321,12 @@ std::string ErrorMessages::RenderPassLoadOpVsLayoutTransitionError(const HazardR
                  additional_info);
 }
 
-std::string ErrorMessages::RenderPassResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::RenderPassResolveError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                   vvl::Func command, const std::string& resource_description) const {
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassResolveError");
 }
 
-std::string ErrorMessages::RenderPassStoreOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::RenderPassStoreOpError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                   vvl::Func command, const std::string& resource_description,
                                                   VkAttachmentStoreOp store_op) const {
     AdditionalMessageInfo additional_info;
@@ -337,7 +335,7 @@ std::string ErrorMessages::RenderPassStoreOpError(const HazardResult& hazard, co
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassStoreOpError", additional_info);
 }
 
-std::string ErrorMessages::RenderPassLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+std::string ErrorMessages::RenderPassLayoutTransitionError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                            vvl::Func command, const std::string& resource_description,
                                                            VkImageLayout old_layout, VkImageLayout new_layout) const {
     const char* old_layout_str = string_VkImageLayout(old_layout);
@@ -352,7 +350,7 @@ std::string ErrorMessages::RenderPassLayoutTransitionError(const HazardResult& h
 }
 
 std::string ErrorMessages::RenderPassLayoutTransitionVsResolveError(const HazardResult& hazard,
-                                                                    const CommandBufferAccessContext& cb_context, vvl::Func command,
+                                                                    const CommandBufferContext& cb_context, vvl::Func command,
                                                                     const std::string& resource_description,
                                                                     VkImageLayout old_layout, VkImageLayout new_layout,
                                                                     uint32_t resolve_subpass) const {
@@ -371,10 +369,9 @@ std::string ErrorMessages::RenderPassLayoutTransitionVsResolveError(const Hazard
                  additional_info);
 }
 
-std::string ErrorMessages::RenderPassFinalLayoutTransitionError(const HazardResult& hazard,
-                                                                const CommandBufferAccessContext& cb_context, vvl::Func command,
-                                                                const std::string& resource_description, VkImageLayout old_layout,
-                                                                VkImageLayout new_layout) const {
+std::string ErrorMessages::RenderPassFinalLayoutTransitionError(const HazardResult& hazard, const CommandBufferContext& cb_context,
+                                                                vvl::Func command, const std::string& resource_description,
+                                                                VkImageLayout old_layout, VkImageLayout new_layout) const {
     const char* old_layout_str = string_VkImageLayout(old_layout);
     const char* new_layout_str = string_VkImageLayout(new_layout);
 
@@ -388,12 +385,9 @@ std::string ErrorMessages::RenderPassFinalLayoutTransitionError(const HazardResu
                  additional_info);
 }
 
-std::string ErrorMessages::RenderPassFinalLayoutTransitionVsStoreOrResolveError(const HazardResult& hazard,
-                                                                                const CommandBufferAccessContext& cb_context,
-                                                                                vvl::Func command,
-                                                                                const std::string& resource_description,
-                                                                                VkImageLayout old_layout, VkImageLayout new_layout,
-                                                                                uint32_t store_resolve_subpass) const {
+std::string ErrorMessages::RenderPassFinalLayoutTransitionVsStoreOrResolveError(
+    const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command, const std::string& resource_description,
+    VkImageLayout old_layout, VkImageLayout new_layout, uint32_t store_resolve_subpass) const {
     const char* old_layout_str = string_VkImageLayout(old_layout);
     const char* new_layout_str = string_VkImageLayout(new_layout);
 
@@ -428,7 +422,7 @@ std::string ErrorMessages::ImageBarrierError(const SyncEnvironment& env, const H
 }
 
 std::string ErrorMessages::FirstUseError(const SyncEnvironment& env, const HazardResult& hazard,
-                                         const CommandBufferAccessContext& recorded_context, uint32_t command_buffer_index) const {
+                                         const CommandBufferContext& recorded_context, uint32_t command_buffer_index) const {
     const ResourceUsageInfo prior_usage_info = env.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
     const ResourceUsageInfo recorded_usage_info = recorded_context.GetResourceUsageInfo(hazard.RecordedAccess()->TagEx());
 
@@ -485,7 +479,7 @@ std::string ErrorMessages::PresentError(const HazardResult& hazard, const QueueB
     return Error(batch_context.GetSyncEnvironment(), hazard, command, resource_description, "PresentError", additional_info);
 }
 
-std::string ErrorMessages::VideoError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+std::string ErrorMessages::VideoError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                       const std::string& resource_description) const {
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "VideoError");
 }

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -31,7 +31,7 @@ class Pipeline;
 
 namespace syncval {
 
-class CommandBufferAccessContext;
+class CommandBufferContext;
 class HazardResult;
 class QueueBatchContext;
 class SyncValidator;
@@ -46,98 +46,97 @@ class ErrorMessages {
                       const std::string& resource_description, const char* message_type,
                       const AdditionalMessageInfo& additional_info = {}) const;
 
-    std::string BufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string BufferError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                             const std::string& resource_description, const AccessRange range,
                             AdditionalMessageInfo additional_info = {}) const;
 
-    std::string BufferCopyError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, const vvl::Func command,
+    std::string BufferCopyError(const HazardResult& hazard, const CommandBufferContext& cb_context, const vvl::Func command,
                                 const std::string& resouce_description, uint32_t region_index, AccessRange range) const;
 
-    std::string AccelerationStructureError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+    std::string AccelerationStructureError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                            const vvl::Func command, const std::string& resource_description,
                                            const AccessRange range, VkAccelerationStructureKHR as,
                                            const Location& as_location) const;
 
-    std::string ImageCopyResolveBlitError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                          vvl::Func command, const std::string& resource_description, uint32_t region_index,
-                                          const VkOffset3D& offset, const VkExtent3D& extent,
-                                          const VkImageSubresourceLayers& subresource) const;
+    std::string ImageCopyResolveBlitError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
+                                          const std::string& resource_description, uint32_t region_index, const VkOffset3D& offset,
+                                          const VkExtent3D& extent, const VkImageSubresourceLayers& subresource) const;
 
-    std::string ImageClearError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string ImageClearError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                 const std::string& resource_description, uint32_t subresource_range_index,
                                 const VkImageSubresourceRange& subresource_range) const;
 
-    std::string BufferDescriptorError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string BufferDescriptorError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                       const std::string& resource_description, const vvl::Pipeline& pipeline, uint32_t set_number,
                                       const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
                                       uint32_t descriptor_binding, uint32_t descriptor_array_element,
                                       VkShaderStageFlagBits shader_stage) const;
 
-    std::string ImageDescriptorError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string ImageDescriptorError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                      const std::string& resource_description, const vvl::Pipeline& pipeline, uint32_t set_number,
                                      const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
                                      uint32_t descriptor_binding, uint32_t descriptor_array_element,
                                      VkShaderStageFlagBits shader_stage, VkImageLayout image_layout) const;
 
-    std::string AccelerationStructureDescriptorError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+    std::string AccelerationStructureDescriptorError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                      vvl::Func command, const std::string& resource_description,
                                                      const vvl::Pipeline& pipeline, uint32_t set_number,
                                                      const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
                                                      uint32_t descriptor_binding, uint32_t descriptor_array_element,
                                                      VkShaderStageFlagBits shader_stage) const;
 
-    std::string ClearAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string ClearAttachmentError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                      const std::string& resource_description, VkImageAspectFlags clear_aspects,
                                      uint32_t clear_rect_index, const VkClearRect& clear_rect) const;
 
-    std::string RenderPassAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                          vvl::Func command, const std::string& resource_description) const;
+    std::string RenderPassAttachmentError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
+                                          const std::string& resource_description) const;
 
-    std::string BeginRenderingError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string BeginRenderingError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                     const std::string& resource_description, VkAttachmentLoadOp load_op) const;
-    std::string EndRenderingResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                         vvl::Func command, const std::string& resource_description,
-                                         VkResolveModeFlagBits resolve_mode, bool resolve_write) const;
-    std::string EndRenderingStoreError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string EndRenderingResolveError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
+                                         const std::string& resource_description, VkResolveModeFlagBits resolve_mode,
+                                         bool resolve_write) const;
+    std::string EndRenderingStoreError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                        const std::string& resource_description, VkAttachmentStoreOp store_op) const;
 
-    std::string RenderPassLoadOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string RenderPassLoadOpError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                       const std::string& resource_description, uint32_t subpass, uint32_t attachment,
                                       VkAttachmentLoadOp load_op, bool is_color) const;
-    std::string RenderPassLoadOpVsLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+    std::string RenderPassLoadOpVsLayoutTransitionError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                         vvl::Func command, const std::string& resource_description,
                                                         VkAttachmentLoadOp load_op, bool is_color) const;
-    std::string RenderPassResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string RenderPassResolveError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                        const std::string& resource_description) const;
-    std::string RenderPassStoreOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string RenderPassStoreOpError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                        const std::string& resource_description, VkAttachmentStoreOp store_op) const;
 
-    std::string RenderPassLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+    std::string RenderPassLayoutTransitionError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                 vvl::Func command, const std::string& resource_description,
                                                 VkImageLayout old_layout, VkImageLayout new_layout) const;
-    std::string RenderPassLayoutTransitionVsResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+    std::string RenderPassLayoutTransitionVsResolveError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                          vvl::Func command, const std::string& resource_description,
                                                          VkImageLayout old_layout, VkImageLayout new_layout,
                                                          uint32_t resolve_subpass) const;
-    std::string RenderPassFinalLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+    std::string RenderPassFinalLayoutTransitionError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                                      vvl::Func command, const std::string& resource_description,
                                                      VkImageLayout old_layout, VkImageLayout new_layout) const;
     std::string RenderPassFinalLayoutTransitionVsStoreOrResolveError(const HazardResult& hazard,
-                                                                     const CommandBufferAccessContext& cb_context,
-                                                                     vvl::Func command, const std::string& resource_description,
+                                                                     const CommandBufferContext& cb_context, vvl::Func command,
+                                                                     const std::string& resource_description,
                                                                      VkImageLayout old_layout, VkImageLayout new_layout,
                                                                      uint32_t store_resolve_subpass) const;
 
     std::string ImageBarrierError(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                                   const std::string& resource_description, const SyncImageBarrier& barrier) const;
 
-    std::string FirstUseError(const SyncEnvironment& env, const HazardResult& hazard,
-                              const CommandBufferAccessContext& recorded_context, uint32_t command_buffer_index) const;
+    std::string FirstUseError(const SyncEnvironment& env, const HazardResult& hazard, const CommandBufferContext& recorded_context,
+                              uint32_t command_buffer_index) const;
 
     std::string PresentError(const HazardResult& hazard, const QueueBatchContext& batch_context, vvl::Func command,
                              const std::string& resource_description, uint32_t swapchain_index) const;
 
-    std::string VideoError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string VideoError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                            const std::string& resource_description) const;
 
   private:

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -162,15 +162,15 @@ bool SyncOpEndRenderPass::ReplayValidate(ReplayState& replay, ResourceUsageTag r
 
 void SyncOpEndRenderPass::ReplayRecord(SyncEnvironment& env, AccessContext& access_context, ResourceUsageTag exec_tag) const {}
 
-ReplayState::ReplayState(CommandBufferAccessContext& proxy_primary_cb_context,
-                         const CommandBufferAccessContext& recorded_cb_context, ResourceUsageTag base_tag, const Location& cb_loc)
+ReplayState::ReplayState(CommandBufferContext& proxy_primary_cb_context, const CommandBufferContext& recorded_cb_context,
+                         ResourceUsageTag base_tag, const Location& cb_loc)
     : env(proxy_primary_cb_context.GetSyncEnvironment()),
       destination_context(proxy_primary_cb_context.GetCbAccessContext()),
       recorded_cb_context(recorded_cb_context),
       base_tag(base_tag),
       cb_loc(cb_loc) {}
 
-ReplayState::ReplayState(QueueBatchContext& batch_context, const CommandBufferAccessContext& recorded_cb_context,
+ReplayState::ReplayState(QueueBatchContext& batch_context, const CommandBufferContext& recorded_cb_context,
                          ResourceUsageTag base_tag, const Location& cb_loc)
     : env(batch_context.GetSyncEnvironment()),
       destination_context(batch_context.GetAccessContext()),

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -31,7 +31,7 @@ class RenderPass;
 
 namespace syncval {
 
-class CommandBufferAccessContext;
+class CommandBufferContext;
 struct SyncEnvironment;
 class QueueBatchContext;
 class RenderPassAccessContext;
@@ -228,9 +228,9 @@ struct RenderPassReplayState {
 };
 
 struct ReplayState {
-    ReplayState(CommandBufferAccessContext& proxy_primary_cb_context, const CommandBufferAccessContext& recorded_cb_context,
+    ReplayState(CommandBufferContext& proxy_primary_cb_context, const CommandBufferContext& recorded_cb_context,
                 ResourceUsageTag base_tag, const Location& cb_loc);
-    ReplayState(QueueBatchContext& batch_context, const CommandBufferAccessContext& recorded_cb_context, ResourceUsageTag base_tag,
+    ReplayState(QueueBatchContext& batch_context, const CommandBufferContext& recorded_cb_context, ResourceUsageTag base_tag,
                 const Location& cb_loc);
 
     bool ValidateFirstUse();
@@ -242,7 +242,7 @@ struct ReplayState {
 
     SyncEnvironment& env;
     AccessContext& destination_context;
-    const CommandBufferAccessContext& recorded_cb_context;
+    const CommandBufferContext& recorded_cb_context;
     std::optional<RenderPassReplayState> rp_replay;
     const ResourceUsageTag base_tag;
     const Location& cb_loc;

--- a/layers/sync/sync_render_pass.cpp
+++ b/layers/sync/sync_render_pass.cpp
@@ -28,12 +28,12 @@ namespace syncval {
 
 class ValidateResolveAction {
   public:
-    ValidateResolveAction(VkRenderPass render_pass, uint32_t subpass, uint32_t view_mask, const AccessContext& context,
-                          const CommandBufferAccessContext& cb_context, vvl::Func command)
+    ValidateResolveAction(VkRenderPass render_pass, uint32_t subpass, uint32_t view_mask, const AccessContext& access_context,
+                          const CommandBufferContext& cb_context, vvl::Func command)
         : render_pass_(render_pass),
           subpass_(subpass),
           view_mask_(view_mask),
-          context_(context),
+          context_(access_context),
           cb_context_(cb_context),
           command_(command),
           skip_(false) {}
@@ -66,7 +66,7 @@ class ValidateResolveAction {
     const uint32_t subpass_;
     const uint32_t view_mask_;
     const AccessContext& context_;
-    const CommandBufferAccessContext& cb_context_;
+    const CommandBufferContext& cb_context_;
     vvl::Func command_;
     bool skip_;
 };
@@ -163,9 +163,9 @@ static AccessContext* CreateStoreResolveProxyContext(const AccessContext& contex
 }
 
 // Layout transitions are handled as if the were occuring in the beginning of the next subpass
-bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAccessContext& cb_context,
-                                                        const AccessContext& access_context, const vvl::RenderPass& rp_state,
-                                                        uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
+bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferContext& cb_context, const AccessContext& access_context,
+                                                        const vvl::RenderPass& rp_state, uint32_t render_pass_instance_id,
+                                                        uint32_t subpass, uint32_t view_mask,
                                                         const AttachmentViewGenVector& attachment_views, vvl::Func command) {
     bool skip = false;
     // As validation methods are const and precede the record/update phase, for any tranistions from the immediately
@@ -229,9 +229,9 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
     return skip;
 }
 
-bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessContext& cb_context,
-                                                    const AccessContext& access_context, const vvl::RenderPass& rp_state,
-                                                    uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
+bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferContext& cb_context, const AccessContext& access_context,
+                                                    const vvl::RenderPass& rp_state, uint32_t render_pass_instance_id,
+                                                    uint32_t subpass, uint32_t view_mask,
                                                     const AttachmentViewGenVector& attachment_views, vvl::Func command) {
     bool skip = false;
 
@@ -315,7 +315,7 @@ bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessCon
 // because of the ordering guarantees w.r.t. sample access and that the resolve validation hasn't altered the state, because
 // store is part of the same Next/End operation.
 // The latter is handled in layout transistion validation directly
-bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessContext& cb_context, vvl::Func command) const {
+bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferContext& cb_context, vvl::Func command) const {
     bool skip = false;
 
     const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kRaster, AttachmentAccessType::StoreOp);
@@ -493,7 +493,7 @@ void ResolveOperation(Action& action, const vvl::RenderPass& rp_state, const Att
     }
 }
 
-bool RenderPassAccessContext::ValidateResolveOperations(const CommandBufferAccessContext& cb_context, vvl::Func command) const {
+bool RenderPassAccessContext::ValidateResolveOperations(const CommandBufferContext& cb_context, vvl::Func command) const {
     const uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
     ValidateResolveAction validate_action(rp_state_->VkHandle(), current_subpass_, view_mask, CurrentContext(), cb_context,
                                           command);
@@ -571,7 +571,7 @@ static uint32_t GetSubpassDepthStencilAttachmentIndex(const vku::safe_VkPipeline
     return (pipe_ds_ci && depth_stencil_ref) ? depth_stencil_ref->attachment : VK_ATTACHMENT_UNUSED;
 }
 
-bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferAccessContext& cb_context, vvl::Func command) const {
+bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferContext& cb_context, vvl::Func command) const {
     bool skip = false;
     const vvl::CommandBuffer& cmd_buffer = cb_context.GetCBState();
     const auto& last_bound_state = cmd_buffer.GetLastBoundGraphics();
@@ -729,7 +729,7 @@ const vvl::ImageView* RenderPassAccessContext::GetClearAttachmentView(const VkCl
     return attachment_views_[attachment_index].GetViewState();
 }
 
-bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessContext& cb_context, vvl::Func command) const {
+bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferContext& cb_context, vvl::Func command) const {
     // PHASE1 TODO: Add Validate Preserve attachments
     bool skip = false;
     skip |= ValidateResolveOperations(cb_context, command);
@@ -755,7 +755,7 @@ bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessConte
     }
     return skip;
 }
-bool RenderPassAccessContext::ValidateEndRenderPass(const CommandBufferAccessContext& cb_context, vvl::Func command) const {
+bool RenderPassAccessContext::ValidateEndRenderPass(const CommandBufferContext& cb_context, vvl::Func command) const {
     // PHASE1 TODO: Validate Preserve
     bool skip = false;
     skip |= ValidateResolveOperations(cb_context, command);
@@ -769,7 +769,7 @@ AccessContext* RenderPassAccessContext::CreateStoreResolveProxy() const {
                                           rp_state_->create_info.pSubpasses[current_subpass_].viewMask, attachment_views_);
 }
 
-bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const CommandBufferAccessContext& cb_context,
+bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const CommandBufferContext& cb_context,
                                                                     vvl::Func command) const {
     bool skip = false;
 

--- a/layers/sync/sync_render_pass.h
+++ b/layers/sync/sync_render_pass.h
@@ -33,56 +33,56 @@ class RenderPass;
 
 namespace syncval {
 
-class CommandBufferAccessContext;
+class CommandBufferContext;
 
 enum class AttachmentType { kColor, kDepth, kStencil };
 
 struct DynamicRenderingInfo {
     struct Attachment {
-        const vku::safe_VkRenderingAttachmentInfo &info;
+        const vku::safe_VkRenderingAttachmentInfo& info;
         std::shared_ptr<const vvl::ImageView> view;
         std::shared_ptr<const vvl::ImageView> resolve_view;
         ImageRangeGen view_gen;
         std::optional<ImageRangeGen> resolve_gen;
         AttachmentType type;
 
-        Attachment(const SyncValidator &state, const vku::safe_VkRenderingAttachmentInfo &info, const AttachmentType type_,
-                   const VkOffset3D &offset, const VkExtent3D &extent);
+        Attachment(const SyncValidator& state, const vku::safe_VkRenderingAttachmentInfo& info, const AttachmentType type_,
+                   const VkOffset3D& offset, const VkExtent3D& extent);
 
         ImageRangeGen GetRangeGen(uint32_t view_mask = 0) const;
 
         SyncAccessIndex GetLoadUsage() const;
         SyncAccessIndex GetStoreUsage() const;
         SyncOrdering GetOrdering() const;
-        Location GetLocation(const Location &loc, uint32_t index = 0) const;
-        bool IsWriteable(const LastBound &last_bound_state) const;
+        Location GetLocation(const Location& loc, uint32_t index = 0) const;
+        bool IsWriteable(const LastBound& last_bound_state) const;
         bool IsValid() const { return view.get(); }
     };
 
     // attachments store references to this info, so make sure this doesn't get moved around.
-    DynamicRenderingInfo(const DynamicRenderingInfo &) = delete;
-    DynamicRenderingInfo(DynamicRenderingInfo &&) = delete;
-    DynamicRenderingInfo &operator=(const DynamicRenderingInfo &) = delete;
-    DynamicRenderingInfo &operator=(DynamicRenderingInfo &&) = delete;
+    DynamicRenderingInfo(const DynamicRenderingInfo&) = delete;
+    DynamicRenderingInfo(DynamicRenderingInfo&&) = delete;
+    DynamicRenderingInfo& operator=(const DynamicRenderingInfo&) = delete;
+    DynamicRenderingInfo& operator=(DynamicRenderingInfo&&) = delete;
 
-    DynamicRenderingInfo(const SyncValidator &state, const VkRenderingInfo &rendering_info);
+    DynamicRenderingInfo(const SyncValidator& state, const VkRenderingInfo& rendering_info);
 
-    const vvl::ImageView *GetClearAttachmentView(const VkClearAttachment &clear_attachment) const;
+    const vvl::ImageView* GetClearAttachmentView(const VkClearAttachment& clear_attachment) const;
 
     vku::safe_VkRenderingInfo info;
     std::vector<Attachment> attachments;  // All attachments (with internal typing)
 };
 
 struct BeginRenderingCmdState {
-    BeginRenderingCmdState(std::shared_ptr<const vvl::CommandBuffer> &&cb_state_) : cb_state(std::move(cb_state_)) {}
-    void AddRenderingInfo(const SyncValidator &state, const VkRenderingInfo &rendering_info);
-    const DynamicRenderingInfo &GetRenderingInfo() const;
+    BeginRenderingCmdState(std::shared_ptr<const vvl::CommandBuffer>&& cb_state_) : cb_state(std::move(cb_state_)) {}
+    void AddRenderingInfo(const SyncValidator& state, const VkRenderingInfo& rendering_info);
+    const DynamicRenderingInfo& GetRenderingInfo() const;
     std::shared_ptr<const vvl::CommandBuffer> cb_state;
     std::unique_ptr<DynamicRenderingInfo> info;
 };
 
-std::unique_ptr<AccessContext[]> InitSubpassContexts(VkQueueFlags queue_flags, const vvl::RenderPass &rp_state,
-                                                     const AccessContext &external_context);
+std::unique_ptr<AccessContext[]> InitSubpassContexts(VkQueueFlags queue_flags, const vvl::RenderPass& rp_state,
+                                                     const AccessContext& external_context);
 
 using AttachmentViewGenVector = std::vector<AttachmentViewGen>;
 
@@ -96,58 +96,58 @@ class RenderPassAccessContext {
                             const std::vector<std::shared_ptr<const vvl::ImageView>>& attachment_views,
                             const AccessContext& external_context, uint32_t render_pass_instance_id);
 
-    static bool ValidateLayoutTransitions(const CommandBufferAccessContext& cb_context, const AccessContext& access_context,
+    static bool ValidateLayoutTransitions(const CommandBufferContext& cb_context, const AccessContext& access_context,
                                           const vvl::RenderPass& rp_state, uint32_t render_pass_instance_id, uint32_t subpass,
                                           uint32_t view_mask, const AttachmentViewGenVector& attachment_views, vvl::Func command);
 
-    static bool ValidateLoadOperation(const CommandBufferAccessContext& cb_context, const AccessContext& access_context,
+    static bool ValidateLoadOperation(const CommandBufferContext& cb_context, const AccessContext& access_context,
                                       const vvl::RenderPass& rp_state, uint32_t render_pass_instance_id, uint32_t subpass,
                                       uint32_t view_mask, const AttachmentViewGenVector& attachment_views, vvl::Func command);
 
-    bool ValidateStoreOperation(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
-    bool ValidateResolveOperations(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
+    bool ValidateStoreOperation(const CommandBufferContext& cb_context, vvl::Func command) const;
+    bool ValidateResolveOperations(const CommandBufferContext& cb_context, vvl::Func command) const;
 
-    static void UpdateAttachmentResolveAccess(const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
+    static void UpdateAttachmentResolveAccess(const vvl::RenderPass& rp_state, const AttachmentViewGenVector& attachment_views,
                                               uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
-                                              const ResourceUsageTag tag, AccessContext &access_context);
+                                              const ResourceUsageTag tag, AccessContext& access_context);
 
-    static void UpdateAttachmentStoreAccess(const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
+    static void UpdateAttachmentStoreAccess(const vvl::RenderPass& rp_state, const AttachmentViewGenVector& attachment_views,
                                             uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
-                                            const ResourceUsageTag tag, AccessContext &access_context);
+                                            const ResourceUsageTag tag, AccessContext& access_context);
 
-    static void RecordLayoutTransitions(const vvl::RenderPass &rp_state, uint32_t subpass,
-                                        const AttachmentViewGenVector &attachment_views, const ResourceUsageTag tag,
-                                        AccessContext &access_context);
+    static void RecordLayoutTransitions(const vvl::RenderPass& rp_state, uint32_t subpass,
+                                        const AttachmentViewGenVector& attachment_views, const ResourceUsageTag tag,
+                                        AccessContext& access_context);
 
-    bool ValidateDrawSubpassAttachment(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
-    void RecordDrawSubpassAttachment(const vvl::CommandBuffer &cmd_buffer, ResourceUsageTag tag);
+    bool ValidateDrawSubpassAttachment(const CommandBufferContext& cb_context, vvl::Func command) const;
+    void RecordDrawSubpassAttachment(const vvl::CommandBuffer& cmd_buffer, ResourceUsageTag tag);
 
-    const vvl::ImageView *GetClearAttachmentView(const VkClearAttachment &clear_attachment) const;
+    const vvl::ImageView* GetClearAttachmentView(const VkClearAttachment& clear_attachment) const;
 
-    bool ValidateNextSubpass(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
-    bool ValidateEndRenderPass(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
-    bool ValidateFinalSubpassLayoutTransitions(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
+    bool ValidateNextSubpass(const CommandBufferContext& cb_context, vvl::Func command) const;
+    bool ValidateEndRenderPass(const CommandBufferContext& cb_context, vvl::Func command) const;
+    bool ValidateFinalSubpassLayoutTransitions(const CommandBufferContext& cb_context, vvl::Func command) const;
 
     void RecordLayoutTransitions(ResourceUsageTag tag);
     void RecordLoadOperations(ResourceUsageTag tag);
     void RecordBeginRenderPass(ResourceUsageTag tag, ResourceUsageTag load_tag);
     void RecordNextSubpass(ResourceUsageTag resolve_tag, ResourceUsageTag store_tag, ResourceUsageTag transition_tag,
                            ResourceUsageTag load_tag);
-    void RecordEndRenderPass(AccessContext *external_context, ResourceUsageTag store_tag, ResourceUsageTag transition_tag);
+    void RecordEndRenderPass(AccessContext* external_context, ResourceUsageTag store_tag, ResourceUsageTag transition_tag);
 
     uint32_t GetCurrentSubpass() const { return current_subpass_; }
-    AccessContext &CurrentContext();
-    const AccessContext &CurrentContext() const;
+    AccessContext& CurrentContext();
+    const AccessContext& CurrentContext() const;
     vvl::span<const AccessContext> GetSubpassContexts() const;
     vvl::span<AccessContext> GetSubpassContexts();
-    const vvl::RenderPass *GetRenderPassState() const { return rp_state_; }
-    AccessContext *CreateStoreResolveProxy() const;
+    const vvl::RenderPass* GetRenderPassState() const { return rp_state_; }
+    AccessContext* CreateStoreResolveProxy() const;
 
-private:
+  private:
     AttachmentAccess GetAttachmentAccess(SyncOrdering ordering, AttachmentAccessType type = AttachmentAccessType::Access) const;
 
   private:
-    const vvl::RenderPass *rp_state_;
+    const vvl::RenderPass* rp_state_;
     const AttachmentViewGenVector attachment_views_;
     const AccessContext* external_context_;
     const std::unique_ptr<AccessContext[]> subpass_contexts_;

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -676,7 +676,7 @@ static ResourceUsageInfo GetResourceUsageInfoFromRecord(ResourceUsageTagEx tag_e
         // Associated resource
         if (tag_ex.handle_index != vvl::kNoIndex32) {
             auto& cb_context = SubState(*record.cb_state);
-            const auto& handle_records = cb_context.access_context.GetHandleRecords();
+            const auto& handle_records = cb_context.cb_context.GetHandleRecords();
 
             // Command buffer can be in inconsistent state due to unhandled core validation error (core validation is disabled).
             // In this case the goal is not to crash, no guarantees that reported information (handle index) makes sense.
@@ -695,7 +695,7 @@ static ResourceUsageInfo GetResourceUsageInfoFromRecord(ResourceUsageTagEx tag_e
     return info;
 }
 
-ResourceUsageInfo CommandBufferAccessContext::GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const {
+ResourceUsageInfo CommandBufferContext::GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const {
     const ResourceUsageRecord& record = (*access_log_)[tag_ex.tag];
     const auto debug_name_provider = (record.label_command_index == vvl::kNoIndex32) ? nullptr : this;
     return GetResourceUsageInfoFromRecord(tag_ex, record, debug_name_provider);

--- a/layers/sync/sync_stats.cpp
+++ b/layers/sync/sync_stats.cpp
@@ -122,8 +122,8 @@ void AccessStats::Update(SyncValidator& validator) {
     subpass_access_stats = {};
 
     validator.device_state->ForEachShared<vvl::CommandBuffer>([this](std::shared_ptr<vvl::CommandBuffer> cb) {
-        const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb);
-        cb_access_context.UpdateStats(*this);
+        const CommandBufferContext& cb_context = GetCommandBufferContext(*cb);
+        cb_context.UpdateStats(*this);
     });
     for (const auto& batch : validator.GetAllQueueBatchContexts()) {
         const AccessContext& access_context = batch->GetAccessContext();
@@ -219,7 +219,7 @@ std::string Stats::CreateReport() {
     ss << "-----------------------\n";
     ss << "Common stats                    count       max_count\n";
     ss << "-----------------------\n";
-    print_common_stats("CommandBufferAccessContext", command_buffer_contexts);
+    print_common_stats("CommandBufferContext", command_buffer_contexts);
     print_common_stats("QueueBatchContext", queue_batch_contexts);
     print_common_stats("Timeline signal", timeline_signals);
     print_common_stats("Unresolved batch", unresolved_batches);

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -724,27 +724,27 @@ bool QueueBatchContext::ValidateSubmit(const std::vector<CommandBufferConstPtr>&
     uint32_t tag_count = 0;
     for (const auto& cb : command_buffers) {
         if (!cb) continue;
-        tag_count += static_cast<uint32_t>(SubState(*cb).access_context.GetTagCount());
+        tag_count += static_cast<uint32_t>(SubState(*cb).cb_context.GetTagCount());
     }
     batch.base_tag = SetupBatchTags(tag_count);
 
     for (uint32_t index = 0; index < (uint32_t)command_buffers.size(); index++) {
         const auto& cb = SubState(*command_buffers[index]);
-        const CommandBufferAccessContext& access_context = cb.access_context;
+        const CommandBufferContext& cb_context = cb.cb_context;
 
         // Validate and resolve command buffers that have tagged commands
-        if (access_context.GetTagCount() > 0) {
+        if (cb_context.GetTagCount() > 0) {
             const Location submit_info_loc = submit_loc.dot(vvl::Field::pSubmits, batch_index);
             const Location cb_loc = submit_loc.function == vvl::Func::vkQueueSubmit
                                         ? submit_info_loc.dot(vvl::Field::pCommandBuffers, index)
                                         : submit_info_loc.dot(vvl::Field::pCommandBufferInfos, index);
 
-            skip |= ReplayState(*this, access_context, batch.base_tag, cb_loc).ValidateFirstUse();
+            skip |= ReplayState(*this, cb_context, batch.base_tag, cb_loc).ValidateFirstUse();
 
             // The barriers have already been applied in ValidatFirstUse
-            batch_log_.Import(batch, access_context, current_label_stack);
-            ResolveSubmittedCommandBuffer(access_context.GetCbAccessContext(), batch.base_tag);
-            batch.base_tag += access_context.GetTagCount();
+            batch_log_.Import(batch, cb_context, current_label_stack);
+            ResolveSubmittedCommandBuffer(cb_context.GetCbAccessContext(), batch.base_tag);
+            batch.base_tag += cb_context.GetTagCount();
         }
         // Apply debug label commands
         vvl::CommandBuffer::ReplayLabelCommands(cb.base.GetLabelCommands(), current_label_stack);
@@ -798,10 +798,10 @@ void QueueState::SetLastBatch(BatchContextPtr&& last) {
     }
 }
 
-void BatchAccessLog::Import(const BatchRecord& batch, const CommandBufferAccessContext& cb_access,
+void BatchAccessLog::Import(const BatchRecord& batch, const CommandBufferContext& cb_context,
                             const std::vector<std::string>& initial_label_stack) {
-    ResourceUsageRange import_range = {batch.base_tag, batch.base_tag + cb_access.GetTagCount()};
-    log_map_.insert(std::make_pair(import_range, CBSubmitLog(batch, cb_access, initial_label_stack)));
+    ResourceUsageRange import_range = {batch.base_tag, batch.base_tag + cb_context.GetTagCount()};
+    log_map_.insert(std::make_pair(import_range, CBSubmitLog(batch, cb_context, initial_label_stack)));
 }
 
 void BatchAccessLog::Import(const BatchAccessLog& other) {
@@ -898,7 +898,7 @@ BatchAccessLog::CBSubmitLog::CBSubmitLog(const BatchRecord& batch, std::shared_p
                                          std::shared_ptr<const AccessLog> log)
     : batch_(batch), cbs_(cbs), log_(log) {}
 
-BatchAccessLog::CBSubmitLog::CBSubmitLog(const BatchRecord& batch, const CommandBufferAccessContext& cb,
+BatchAccessLog::CBSubmitLog::CBSubmitLog(const BatchRecord& batch, const CommandBufferContext& cb,
                                          const std::vector<std::string>& initial_label_stack)
     : batch_(batch), cbs_(cb.GetCBReferencesShared()), log_(cb.GetAccessLogShared()), initial_label_stack_(initial_label_stack) {}
 

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -206,8 +206,7 @@ class BatchAccessLog {
         CBSubmitLog &operator=(const CBSubmitLog &other) = default;
         CBSubmitLog &operator=(CBSubmitLog &&other) = default;
         CBSubmitLog(const BatchRecord& batch, std::shared_ptr<const CommandBufferSet> cbs, std::shared_ptr<const AccessLog> log);
-        CBSubmitLog(const BatchRecord& batch, const CommandBufferAccessContext& cb,
-                    const std::vector<std::string>& initial_label_stack);
+        CBSubmitLog(const BatchRecord& batch, const CommandBufferContext& cb, const std::vector<std::string>& initial_label_stack);
         size_t Size() const { return log_->size(); }
         AccessRecord GetAccessRecord(ResourceUsageTag tag) const;
 
@@ -222,9 +221,9 @@ class BatchAccessLog {
         std::vector<std::string> initial_label_stack_;
     };
 
-    void Import(const BatchRecord &batch, const CommandBufferAccessContext &cb_access,
-                const std::vector<std::string> &initial_label_stack);
-    void Import(const BatchAccessLog &other);
+    void Import(const BatchRecord& batch, const CommandBufferContext& cb_context,
+                const std::vector<std::string>& initial_label_stack);
+    void Import(const BatchAccessLog& other);
     void Insert(const BatchRecord& batch, const ResourceUsageRange& range, std::shared_ptr<const AccessLog> log);
 
     void Trim(const ResourceUsageTagSet &used);

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -376,8 +376,8 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     // If we have no previous accesses, we have no hazards
     auto src_buffer = Get<vvl::Buffer>(srcBuffer);
@@ -386,7 +386,7 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
     for (const auto [region_index, copy_region] : vvl::enumerate(pRegions, regionCount)) {
         if (src_buffer) {
             const AccessRange src_range = MakeRange(*src_buffer, copy_region.srcOffset, copy_region.size);
-            auto hazard = context.DetectHazard(*src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
+            auto hazard = access_context.DetectHazard(*src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcBuffer);
                 const std::string error = error_messages_.BufferCopyError(hazard, cb_context, error_obj.location.function,
@@ -396,7 +396,7 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
         }
         if (dst_buffer) {
             const AccessRange dst_range = MakeRange(*dst_buffer, copy_region.dstOffset, copy_region.size);
-            auto hazard = context.DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
+            auto hazard = access_context.DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstBuffer);
                 const std::string error = error_messages_.BufferCopyError(hazard, cb_context, error_obj.location.function,
@@ -415,8 +415,8 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     // If we have no previous accesses, we have no hazards
     auto src_buffer = Get<vvl::Buffer>(pCopyBufferInfo->srcBuffer);
@@ -425,7 +425,7 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
     for (const auto [region_index, copy_region] : vvl::enumerate(pCopyBufferInfo->pRegions, pCopyBufferInfo->regionCount)) {
         if (src_buffer) {
             const AccessRange src_range = MakeRange(*src_buffer, copy_region.srcOffset, copy_region.size);
-            auto hazard = context.DetectHazard(*src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
+            auto hazard = access_context.DetectHazard(*src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
             if (hazard.IsHazard()) {
                 // TODO -- add tag information to log msg when useful.
                 // TODO: there are no tests for this error
@@ -438,7 +438,7 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
         }
         if (dst_buffer && !skip) {
             const AccessRange dst_range = MakeRange(*dst_buffer, copy_region.dstOffset, copy_region.size);
-            auto hazard = context.DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
+            auto hazard = access_context.DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
             if (hazard.IsHazard()) {
                 // TODO: there are no tests for this error
                 const LogObjectList objlist(commandBuffer, pCopyBufferInfo->dstBuffer);
@@ -463,32 +463,32 @@ bool SyncValidator::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, V
                                                 const VkImageCopy* pRegions, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     auto src_image = Get<vvl::Image>(srcImage);
     auto dst_image = Get<vvl::Image>(dstImage);
     for (const auto [region_index, copy_region] : vvl::enumerate(pRegions, regionCount)) {
         if (src_image) {
-            auto hazard = context.DetectHazard(*src_image, RangeFromLayers(copy_region.srcSubresource), copy_region.srcOffset,
-                                               copy_region.extent, SYNC_COPY_TRANSFER_READ);
+            auto hazard = access_context.DetectHazard(*src_image, RangeFromLayers(copy_region.srcSubresource),
+                                                      copy_region.srcOffset, copy_region.extent, SYNC_COPY_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
-                    hazard, cb_access_context, error_obj.location.function, FormatHandle(srcImage), region_index,
-                    copy_region.srcOffset, copy_region.extent, copy_region.srcSubresource);
+                    hazard, cb_context, error_obj.location.function, FormatHandle(srcImage), region_index, copy_region.srcOffset,
+                    copy_region.extent, copy_region.srcSubresource);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
 
         if (dst_image) {
-            auto hazard = context.DetectHazard(*dst_image, RangeFromLayers(copy_region.dstSubresource), copy_region.dstOffset,
-                                               copy_region.extent, SYNC_COPY_TRANSFER_WRITE);
+            auto hazard = access_context.DetectHazard(*dst_image, RangeFromLayers(copy_region.dstSubresource),
+                                                      copy_region.dstOffset, copy_region.extent, SYNC_COPY_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
-                    hazard, cb_access_context, error_obj.location.function, FormatHandle(dstImage), region_index,
-                    copy_region.dstOffset, copy_region.extent, copy_region.dstSubresource);
+                    hazard, cb_context, error_obj.location.function, FormatHandle(dstImage), region_index, copy_region.dstOffset,
+                    copy_region.extent, copy_region.dstSubresource);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -496,7 +496,6 @@ bool SyncValidator::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, V
             break;
         }
     }
-
     return skip;
 }
 
@@ -504,20 +503,20 @@ bool SyncValidator::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, 
                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     auto src_image = Get<vvl::Image>(pCopyImageInfo->srcImage);
     auto dst_image = Get<vvl::Image>(pCopyImageInfo->dstImage);
 
     for (const auto [region_index, copy_region] : vvl::enumerate(pCopyImageInfo->pRegions, pCopyImageInfo->regionCount)) {
         if (src_image) {
-            auto hazard = context.DetectHazard(*src_image, RangeFromLayers(copy_region.srcSubresource), copy_region.srcOffset,
-                                               copy_region.extent, SYNC_COPY_TRANSFER_READ);
+            auto hazard = access_context.DetectHazard(*src_image, RangeFromLayers(copy_region.srcSubresource),
+                                                      copy_region.srcOffset, copy_region.extent, SYNC_COPY_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pCopyImageInfo->srcImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
-                    hazard, cb_access_context, error_obj.location.function, FormatHandle(pCopyImageInfo->srcImage), region_index,
+                    hazard, cb_context, error_obj.location.function, FormatHandle(pCopyImageInfo->srcImage), region_index,
                     copy_region.srcOffset, copy_region.extent, copy_region.srcSubresource);
                 // TODO: this error not covered by the test
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
@@ -525,19 +524,18 @@ bool SyncValidator::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, 
         }
 
         if (dst_image) {
-            auto hazard = context.DetectHazard(*dst_image, RangeFromLayers(copy_region.dstSubresource), copy_region.dstOffset,
-                                               copy_region.extent, SYNC_COPY_TRANSFER_WRITE);
+            auto hazard = access_context.DetectHazard(*dst_image, RangeFromLayers(copy_region.dstSubresource),
+                                                      copy_region.dstOffset, copy_region.extent, SYNC_COPY_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pCopyImageInfo->dstImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
-                    hazard, cb_access_context, error_obj.location.function, FormatHandle(pCopyImageInfo->dstImage), region_index,
+                    hazard, cb_context, error_obj.location.function, FormatHandle(pCopyImageInfo->dstImage), region_index,
                     copy_region.dstOffset, copy_region.extent, copy_region.dstSubresource);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
             if (skip) break;
         }
     }
-
     return skip;
 }
 
@@ -546,7 +544,7 @@ bool SyncValidator::PreCallValidateCmdCopyImage2KHR(VkCommandBuffer commandBuffe
     return PreCallValidateCmdCopyImage2(commandBuffer, pCopyImageInfo, error_obj);
 }
 
-bool SyncValidator::ValidateCmdPipelineBarrier(const CommandBufferAccessContext& cb_context, const BarrierSet& barrier_set,
+bool SyncValidator::ValidateCmdPipelineBarrier(const CommandBufferContext& cb_context, const BarrierSet& barrier_set,
                                                const Location& loc) const {
     bool skip = false;
     const AccessContext& context = cb_context.GetCurrentAccessContext();
@@ -582,7 +580,7 @@ bool SyncValidator::PreCallValidateCmdPipelineBarrier(
     bool skip = false;
 
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     const SyncExecScope src_exec_scope(SyncExecScope::MakeSrc(queue_flags, srcStageMask));
@@ -590,13 +588,13 @@ bool SyncValidator::PreCallValidateCmdPipelineBarrier(
     const BarrierSet barrier_set(*this, src_exec_scope, dst_exec_scope, memoryBarrierCount, pMemoryBarriers,
                                  bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
 
-    skip |= ValidateCmdPipelineBarrier(cb_access_context, barrier_set, error_obj.location);
+    skip |= ValidateCmdPipelineBarrier(cb_context, barrier_set, error_obj.location);
     stats.OnBarrierCommand(memoryBarrierCount, bufferMemoryBarrierCount, imageMemoryBarrierCount,
                            barrier_set.execution_dependency_barrier_count);
     return skip;
 }
 
-void SyncValidator::RecordCmdPipelineBarrier(CommandBufferAccessContext& cb_context, BarrierSet&& barrier_set,
+void SyncValidator::RecordCmdPipelineBarrier(CommandBufferContext& cb_context, BarrierSet&& barrier_set,
                                              const Location& loc) const {
     const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
     for (const SyncBufferBarrier& buffer_barrier : barrier_set.buffer_barriers) {
@@ -620,7 +618,7 @@ void SyncValidator::PostCallRecordCmdPipelineBarrier(
     const VkImageMemoryBarrier* pImageMemoryBarriers, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
     const SyncExecScope src_exec_scope(SyncExecScope::MakeSrc(queue_flags, srcStageMask));
     const SyncExecScope dst_exec_scope(SyncExecScope::MakeDst(queue_flags, dstStageMask));
@@ -645,10 +643,10 @@ bool SyncValidator::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBu
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const BarrierSet barrier_set(*this, queue_flags, *pDependencyInfo);
 
-    skip |= ValidateCmdPipelineBarrier(cb_access_context, barrier_set, error_obj.location);
+    skip |= ValidateCmdPipelineBarrier(cb_context, barrier_set, error_obj.location);
     stats.OnBarrierCommand(pDependencyInfo->memoryBarrierCount, pDependencyInfo->bufferMemoryBarrierCount,
                            pDependencyInfo->imageMemoryBarrierCount, barrier_set.execution_dependency_barrier_count);
     return skip;
@@ -665,7 +663,7 @@ void SyncValidator::PostCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuf
         return;
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
     BarrierSet barrier_set(*this, queue_flags, *pDependencyInfo);
     RecordCmdPipelineBarrier(cb_context, std::move(barrier_set), record_obj.location);
@@ -754,7 +752,7 @@ bool SyncValidator::ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const
     }
 
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     const uint32_t subpass_zero = 0;
@@ -814,7 +812,7 @@ bool SyncValidator::ValidateCmdNextSubpass(VkCommandBuffer commandBuffer, const 
                                            const VkSubpassEndInfo* pSubpassEndInfo, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const RenderPassAccessContext* renderpass_context = cb_context.GetCurrentRenderPassContext();
     if (!renderpass_context) {
         return skip;
@@ -845,7 +843,7 @@ bool SyncValidator::PreCallValidateCmdNextSubpass2(VkCommandBuffer commandBuffer
 bool SyncValidator::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const RenderPassAccessContext* renderpass_context = cb_context.GetCurrentRenderPassContext();
     if (!renderpass_context) {
         return skip;
@@ -883,7 +881,7 @@ bool SyncValidator::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuff
     cmd_state->AddRenderingInfo(*this, *pRenderingInfo);
 
     // We need to set skip, because the TlsGuard destructor is looking at the skip value for RAII cleanup.
-    skip |= GetAccessContext(*cmd_state->cb_state).ValidateBeginRendering(error_obj, *cmd_state);
+    skip |= GetCommandBufferContext(*cmd_state->cb_state).ValidateBeginRendering(error_obj, *cmd_state);
     return skip;
 }
 
@@ -899,7 +897,7 @@ void SyncValidator::PostCallRecordCmdBeginRendering(VkCommandBuffer commandBuffe
     assert(cmd_state && cmd_state->cb_state && (cmd_state->cb_state->VkHandle() == commandBuffer));
     // Note: for fine grain locking need to to something other than cast.
     auto cb_state = std::const_pointer_cast<vvl::CommandBuffer>(cmd_state->cb_state);
-    GetAccessContext(*cb_state).RecordBeginRendering(*cmd_state, record_obj.location);
+    GetCommandBufferContext(*cb_state).RecordBeginRendering(*cmd_state, record_obj.location);
 }
 
 bool SyncValidator::PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
@@ -909,7 +907,7 @@ bool SyncValidator::PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuf
 bool SyncValidator::PreCallValidateCmdEndRendering(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    skip |= GetAccessContext(*cb_state).ValidateEndRendering(error_obj);
+    skip |= GetCommandBufferContext(*cb_state).ValidateEndRendering(error_obj);
     return skip;
 }
 
@@ -919,7 +917,7 @@ void SyncValidator::PreCallRecordCmdEndRenderingKHR(VkCommandBuffer commandBuffe
 
 void SyncValidator::PreCallRecordCmdEndRendering(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    GetAccessContext(*cb_state).RecordEndRendering(record_obj);
+    GetCommandBufferContext(*cb_state).RecordEndRendering(record_obj);
 }
 
 template <typename RegionType>
@@ -928,8 +926,8 @@ bool SyncValidator::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, 
                                                  const Location& loc) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     auto src_buffer = Get<vvl::Buffer>(srcBuffer);
     auto dst_image = Get<vvl::Image>(dstImage);
@@ -939,22 +937,22 @@ bool SyncValidator::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, 
         if (dst_image) {
             if (src_buffer) {
                 AccessRange src_range = MakeRange(copy_region.bufferOffset, dst_image->GetBufferSizeFromCopyImage(copy_region));
-                hazard = context.DetectHazard(*src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
+                hazard = access_context.DetectHazard(*src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
                 if (hazard.IsHazard()) {
                     // PHASE1 TODO -- add tag information to log msg when useful.
                     const LogObjectList objlist(commandBuffer, srcBuffer);
-                    const std::string error = error_messages_.BufferCopyError(hazard, cb_access_context, loc.function,
+                    const std::string error = error_messages_.BufferCopyError(hazard, cb_context, loc.function,
                                                                               FormatHandle(srcBuffer), region_index, src_range);
                     skip |= SyncError(hazard.Hazard(), objlist, loc, error);
                 }
             }
 
-            hazard = context.DetectHazard(*dst_image, RangeFromLayers(copy_region.imageSubresource), copy_region.imageOffset,
-                                          copy_region.imageExtent, SYNC_COPY_TRANSFER_WRITE);
+            hazard = access_context.DetectHazard(*dst_image, RangeFromLayers(copy_region.imageSubresource), copy_region.imageOffset,
+                                                 copy_region.imageExtent, SYNC_COPY_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
-                    hazard, cb_access_context, loc.function, FormatHandle(dstImage), region_index, copy_region.imageOffset,
+                    hazard, cb_context, loc.function, FormatHandle(dstImage), region_index, copy_region.imageOffset,
                     copy_region.imageExtent, copy_region.imageSubresource);
                 skip |= SyncError(hazard.Hazard(), objlist, loc, error);
             }
@@ -992,29 +990,29 @@ bool SyncValidator::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, 
                                                  const Location& loc) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     auto src_image = Get<vvl::Image>(srcImage);
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
     const VkDeviceMemory dst_memory = (dst_buffer && !dst_buffer->sparse) ? dst_buffer->MemoryState()->VkHandle() : VK_NULL_HANDLE;
     for (const auto [region_index, copy_region] : vvl::enumerate(pRegions, regionCount)) {
         if (src_image) {
-            auto hazard = context.DetectHazard(*src_image, RangeFromLayers(copy_region.imageSubresource), copy_region.imageOffset,
-                                               copy_region.imageExtent, SYNC_COPY_TRANSFER_READ);
+            auto hazard = access_context.DetectHazard(*src_image, RangeFromLayers(copy_region.imageSubresource),
+                                                      copy_region.imageOffset, copy_region.imageExtent, SYNC_COPY_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
-                    hazard, cb_access_context, loc.function, FormatHandle(srcImage), region_index, copy_region.imageOffset,
+                    hazard, cb_context, loc.function, FormatHandle(srcImage), region_index, copy_region.imageOffset,
                     copy_region.imageExtent, copy_region.imageSubresource);
                 skip |= SyncError(hazard.Hazard(), objlist, loc, error);
             }
             if (dst_memory != VK_NULL_HANDLE) {
                 AccessRange dst_range = MakeRange(copy_region.bufferOffset, src_image->GetBufferSizeFromCopyImage(copy_region));
-                hazard = context.DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
+                hazard = access_context.DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, dstBuffer);
-                    const std::string error = error_messages_.BufferCopyError(hazard, cb_access_context, loc.function,
+                    const std::string error = error_messages_.BufferCopyError(hazard, cb_context, loc.function,
                                                                               FormatHandle(dstBuffer), region_index, dst_range);
                     skip |= SyncError(hazard.Hazard(), objlist, loc, error);
                 }
@@ -1052,8 +1050,8 @@ bool SyncValidator::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage 
                                          const RegionType* pRegions, VkFilter filter, const Location& loc) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     auto src_image = Get<vvl::Image>(srcImage);
     auto dst_image = Get<vvl::Image>(dstImage);
@@ -1066,12 +1064,12 @@ bool SyncValidator::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage 
             VkExtent3D extent = {static_cast<uint32_t>(abs(blit_region.srcOffsets[1].x - blit_region.srcOffsets[0].x)),
                                  static_cast<uint32_t>(abs(blit_region.srcOffsets[1].y - blit_region.srcOffsets[0].y)),
                                  static_cast<uint32_t>(abs(blit_region.srcOffsets[1].z - blit_region.srcOffsets[0].z))};
-            auto hazard = context.DetectHazard(*src_image, RangeFromLayers(blit_region.srcSubresource), offset, extent,
-                                               SYNC_BLIT_TRANSFER_READ);
+            auto hazard = access_context.DetectHazard(*src_image, RangeFromLayers(blit_region.srcSubresource), offset, extent,
+                                                      SYNC_BLIT_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
                 const std::string error =
-                    error_messages_.ImageCopyResolveBlitError(hazard, cb_access_context, loc.function, FormatHandle(srcImage),
+                    error_messages_.ImageCopyResolveBlitError(hazard, cb_context, loc.function, FormatHandle(srcImage),
                                                               region_index, offset, extent, blit_region.srcSubresource);
                 skip |= SyncError(hazard.Hazard(), objlist, loc, error);
             }
@@ -1084,19 +1082,18 @@ bool SyncValidator::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage 
             VkExtent3D extent = {static_cast<uint32_t>(abs(blit_region.dstOffsets[1].x - blit_region.dstOffsets[0].x)),
                                  static_cast<uint32_t>(abs(blit_region.dstOffsets[1].y - blit_region.dstOffsets[0].y)),
                                  static_cast<uint32_t>(abs(blit_region.dstOffsets[1].z - blit_region.dstOffsets[0].z))};
-            auto hazard = context.DetectHazard(*dst_image, RangeFromLayers(blit_region.dstSubresource), offset, extent,
-                                               SYNC_BLIT_TRANSFER_WRITE);
+            auto hazard = access_context.DetectHazard(*dst_image, RangeFromLayers(blit_region.dstSubresource), offset, extent,
+                                                      SYNC_BLIT_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
                 const std::string error =
-                    error_messages_.ImageCopyResolveBlitError(hazard, cb_access_context, loc.function, FormatHandle(dstImage),
+                    error_messages_.ImageCopyResolveBlitError(hazard, cb_context, loc.function, FormatHandle(dstImage),
                                                               region_index, offset, extent, blit_region.dstSubresource);
                 skip |= SyncError(hazard.Hazard(), objlist, loc, error);
             }
             if (skip) break;
         }
     }
-
     return skip;
 }
 
@@ -1119,7 +1116,7 @@ bool SyncValidator::PreCallValidateCmdBlitImage2(VkCommandBuffer commandBuffer, 
                                 pBlitImageInfo->filter, error_obj.location.dot(Field::pBlitImageInfo));
 }
 
-bool SyncValidator::ValidateIndirectBuffer(const CommandBufferAccessContext& cb_context, const AccessContext& context,
+bool SyncValidator::ValidateIndirectBuffer(const CommandBufferContext& cb_context, const AccessContext& access_context,
                                            const VkDeviceSize struct_size, const VkBuffer buffer, const VkDeviceSize offset,
                                            const uint32_t drawCount, const uint32_t stride, const Location& loc) const {
     bool skip = false;
@@ -1130,7 +1127,7 @@ bool SyncValidator::ValidateIndirectBuffer(const CommandBufferAccessContext& cb_
     if (drawCount == 1 || stride == size) {
         if (drawCount > 1) size *= drawCount;
         const AccessRange range = MakeRange(offset, size);
-        auto hazard = context.DetectHazard(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
+        auto hazard = access_context.DetectHazard(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
         if (hazard.IsHazard()) {
             const LogObjectList objlist(cb_context.GetCBState().Handle(), buf_state->Handle());
             const std::string resource_description = "indirect " + FormatHandle(buffer);
@@ -1140,7 +1137,7 @@ bool SyncValidator::ValidateIndirectBuffer(const CommandBufferAccessContext& cb_
     } else {
         for (uint32_t i = 0; i < drawCount; ++i) {
             const AccessRange range = MakeRange(offset + i * stride, size);
-            auto hazard = context.DetectHazard(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
+            auto hazard = access_context.DetectHazard(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(cb_context.GetCBState().Handle(), buf_state->Handle());
                 const std::string resource_description = "indirect " + FormatHandle(buffer);
@@ -1153,33 +1150,34 @@ bool SyncValidator::ValidateIndirectBuffer(const CommandBufferAccessContext& cb_
     return skip;
 }
 
-void SyncValidator::RecordIndirectBuffer(CommandBufferAccessContext& cb_context, const ResourceUsageTag tag,
+void SyncValidator::RecordIndirectBuffer(CommandBufferContext& cb_context, const ResourceUsageTag tag,
                                          const VkDeviceSize struct_size, const VkBuffer buffer, const VkDeviceSize offset,
                                          const uint32_t drawCount, uint32_t stride) {
     auto buf_state = Get<vvl::Buffer>(buffer);
     auto tag_ex = buf_state ? cb_context.AddCommandHandle(tag, buf_state->Handle()) : ResourceUsageTagEx{tag};
 
     VkDeviceSize size = struct_size;
-    AccessContext& context = cb_context.GetCurrentAccessContext();
+    AccessContext& access_context = cb_context.GetCurrentAccessContext();
     if (drawCount == 1 || stride == size) {
         if (drawCount > 1) size *= drawCount;
         const AccessRange range = MakeRange(offset, size);
-        context.UpdateAccessState(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range, tag_ex);
+        access_context.UpdateAccessState(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range, tag_ex);
     } else {
         for (uint32_t i = 0; i < drawCount; ++i) {
             const AccessRange range = MakeRange(offset + i * stride, size);
-            context.UpdateAccessState(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range, tag_ex);
+            access_context.UpdateAccessState(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range, tag_ex);
         }
     }
 }
 
-bool SyncValidator::ValidateCountBuffer(const CommandBufferAccessContext& cb_context, const AccessContext& context, VkBuffer buffer,
-                                        VkDeviceSize offset, const Location& loc, const char* count_buffer_label) const {
+bool SyncValidator::ValidateCountBuffer(const CommandBufferContext& cb_context, const AccessContext& access_context,
+                                        VkBuffer buffer, VkDeviceSize offset, const Location& loc,
+                                        const char* count_buffer_label) const {
     bool skip = false;
 
     auto count_buf_state = Get<vvl::Buffer>(buffer);
     const AccessRange range = MakeRange(offset, 4);
-    auto hazard = context.DetectHazard(*count_buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
+    auto hazard = access_context.DetectHazard(*count_buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
     if (hazard.IsHazard()) {
         const LogObjectList objlist(cb_context.GetCBState().Handle(), count_buf_state->Handle());
         const std::string resource_description = std::string(count_buffer_label) + " " + FormatHandle(buffer);
@@ -1189,41 +1187,40 @@ bool SyncValidator::ValidateCountBuffer(const CommandBufferAccessContext& cb_con
     return skip;
 }
 
-void SyncValidator::RecordCountBuffer(CommandBufferAccessContext& cb_context, const ResourceUsageTag tag, VkBuffer buffer,
+void SyncValidator::RecordCountBuffer(CommandBufferContext& cb_context, const ResourceUsageTag tag, VkBuffer buffer,
                                       VkDeviceSize offset) {
     auto count_buf_state = Get<vvl::Buffer>(buffer);
     const AccessRange range = MakeRange(offset, 4);
     const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, count_buf_state->Handle());
-    AccessContext& context = cb_context.GetCurrentAccessContext();
-    context.UpdateAccessState(*count_buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range, tag_ex);
+    AccessContext& access_context = cb_context.GetCurrentAccessContext();
+    access_context.UpdateAccessState(*count_buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range, tag_ex);
 }
 
 bool SyncValidator::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
                                                const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    skip |= GetAccessContext(*cb_state).ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
+    skip |= GetCommandBufferContext(*cb_state).ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
     return skip;
 }
 
 void SyncValidator::PostCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
                                               const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
-
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, tag);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, tag);
 }
 
 bool SyncValidator::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                        const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCurrentAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
-    skip |= ValidateIndirectBuffer(cb_context, context, sizeof(VkDispatchIndirectCommand), buffer, offset, 1,
+    skip |= ValidateIndirectBuffer(cb_context, access_context, sizeof(VkDispatchIndirectCommand), buffer, offset, 1,
                                    sizeof(VkDispatchIndirectCommand), error_obj.location);
     return skip;
 }
@@ -1231,12 +1228,11 @@ bool SyncValidator::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBu
 void SyncValidator::PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                       const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, tag);
-    RecordIndirectBuffer(cb_access_context, tag, sizeof(VkDispatchIndirectCommand), buffer, offset, 1,
-                         sizeof(VkDispatchIndirectCommand));
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, tag);
+    RecordIndirectBuffer(cb_context, tag, sizeof(VkDispatchIndirectCommand), buffer, offset, 1, sizeof(VkDispatchIndirectCommand));
 }
 
 bool SyncValidator::PreCallValidateCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
@@ -1244,7 +1240,7 @@ bool SyncValidator::PreCallValidateCmdDispatchBase(VkCommandBuffer commandBuffer
                                                    uint32_t groupCountZ, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    skip |= GetAccessContext(*cb_state).ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
+    skip |= GetCommandBufferContext(*cb_state).ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
     return skip;
 }
 
@@ -1259,9 +1255,9 @@ void SyncValidator::PostCallRecordCmdDispatchBase(VkCommandBuffer commandBuffer,
                                                   uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
                                                   uint32_t groupCountZ, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, tag);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, tag);
 }
 
 void SyncValidator::PostCallRecordCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
@@ -1275,23 +1271,23 @@ bool SyncValidator::PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32
                                            uint32_t firstVertex, uint32_t firstInstance, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
-    skip |= cb_access_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
-    skip |= cb_access_context.ValidateDrawVertex(vertexCount, firstVertex, error_obj.location);
-    skip |= cb_access_context.ValidateDrawAttachment(error_obj.location);
+    skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= cb_context.ValidateDrawVertex(vertexCount, firstVertex, error_obj.location);
+    skip |= cb_context.ValidateDrawAttachment(error_obj.location);
     return skip;
 }
 
 void SyncValidator::PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
                                           uint32_t firstVertex, uint32_t firstInstance, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
-    cb_access_context.RecordDrawVertex(vertexCount, firstVertex, tag);
-    cb_access_context.RecordDrawAttachment(tag);
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
+    cb_context.RecordDrawVertex(vertexCount, firstVertex, tag);
+    cb_context.RecordDrawAttachment(tag);
 }
 
 bool SyncValidator::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
@@ -1299,11 +1295,11 @@ bool SyncValidator::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer,
                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
-    skip |= cb_access_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
-    skip |= cb_access_context.ValidateDrawVertexIndex(indexCount, firstIndex, error_obj.location);
-    skip |= cb_access_context.ValidateDrawAttachment(error_obj.location);
+    skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= cb_context.ValidateDrawVertexIndex(indexCount, firstIndex, error_obj.location);
+    skip |= cb_context.ValidateDrawAttachment(error_obj.location);
     return skip;
 }
 
@@ -1311,12 +1307,12 @@ void SyncValidator::PostCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, 
                                                  uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
                                                  const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
-    cb_access_context.RecordDrawVertexIndex(indexCount, firstIndex, tag);
-    cb_access_context.RecordDrawAttachment(tag);
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
+    cb_context.RecordDrawVertexIndex(indexCount, firstIndex, tag);
+    cb_context.RecordDrawAttachment(tag);
 }
 
 bool SyncValidator::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -1325,16 +1321,16 @@ bool SyncValidator::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer
     if (drawCount == 0) return skip;
 
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
-    skip |= cb_access_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
-    skip |= cb_access_context.ValidateDrawAttachment(error_obj.location);
-    skip |= ValidateIndirectBuffer(cb_access_context, context, sizeof(VkDrawIndirectCommand), buffer, offset, drawCount, stride,
+    skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= cb_context.ValidateDrawAttachment(error_obj.location);
+    skip |= ValidateIndirectBuffer(cb_context, access_context, sizeof(VkDrawIndirectCommand), buffer, offset, drawCount, stride,
                                    error_obj.location);
     // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
-    // skip |= cb_access_context->ValidateDrawVertex(?, ?, error_obj.location);
+    // skip |= cb_context->ValidateDrawVertex(?, ?, error_obj.location);
     return skip;
 }
 
@@ -1344,15 +1340,15 @@ void SyncValidator::PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer,
         return;
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
-    cb_access_context.RecordDrawAttachment(tag);
-    RecordIndirectBuffer(cb_access_context, tag, sizeof(VkDrawIndirectCommand), buffer, offset, drawCount, stride);
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
+    cb_context.RecordDrawAttachment(tag);
+    RecordIndirectBuffer(cb_context, tag, sizeof(VkDrawIndirectCommand), buffer, offset, drawCount, stride);
 
     // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
-    // cb_access_context->RecordDrawVertex(?, ?, tag);
+    // cb_context->RecordDrawVertex(?, ?, tag);
 }
 
 bool SyncValidator::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -1360,32 +1356,32 @@ bool SyncValidator::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer comman
     bool skip = false;
     if (drawCount == 0) return skip;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
-    skip |= cb_access_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
-    skip |= cb_access_context.ValidateDrawAttachment(error_obj.location);
-    skip |= ValidateIndirectBuffer(cb_access_context, context, sizeof(VkDrawIndexedIndirectCommand), buffer, offset, drawCount,
+    skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= cb_context.ValidateDrawAttachment(error_obj.location);
+    skip |= ValidateIndirectBuffer(cb_context, access_context, sizeof(VkDrawIndexedIndirectCommand), buffer, offset, drawCount,
                                    stride, error_obj.location);
 
     // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
-    // skip |= cb_access_context->ValidateDrawVertexIndex(?, ?, error_obj.location);
+    // skip |= cb_context->ValidateDrawVertexIndex(?, ?, error_obj.location);
     return skip;
 }
 
 void SyncValidator::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                          uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
-    cb_access_context.RecordDrawAttachment(tag);
-    RecordIndirectBuffer(cb_access_context, tag, sizeof(VkDrawIndexedIndirectCommand), buffer, offset, drawCount, stride);
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
+    cb_context.RecordDrawAttachment(tag);
+    RecordIndirectBuffer(cb_context, tag, sizeof(VkDrawIndexedIndirectCommand), buffer, offset, drawCount, stride);
 
     // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
-    // cb_access_context->RecordDrawVertexIndex(?, ?, tag);
+    // cb_context->RecordDrawVertexIndex(?, ?, tag);
 }
 
 bool SyncValidator::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -1393,18 +1389,18 @@ bool SyncValidator::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandB
                                                         uint32_t stride, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
-    skip |= cb_access_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
-    skip |= cb_access_context.ValidateDrawAttachment(error_obj.location);
-    skip |= ValidateIndirectBuffer(cb_access_context, context, sizeof(VkDrawIndirectCommand), buffer, offset, maxDrawCount, stride,
+    skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= cb_context.ValidateDrawAttachment(error_obj.location);
+    skip |= ValidateIndirectBuffer(cb_context, access_context, sizeof(VkDrawIndirectCommand), buffer, offset, maxDrawCount, stride,
                                    error_obj.location);
-    skip |= ValidateCountBuffer(cb_access_context, context, countBuffer, countBufferOffset, error_obj.location);
+    skip |= ValidateCountBuffer(cb_context, access_context, countBuffer, countBufferOffset, error_obj.location);
 
     // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
-    // skip |= cb_access_context->ValidateDrawVertex(?, ?, error_obj.location);
+    // skip |= cb_context->ValidateDrawVertex(?, ?, error_obj.location);
     return skip;
 }
 
@@ -1412,16 +1408,16 @@ void SyncValidator::RecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, Vk
                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                uint32_t stride, Func command) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(command);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(command);
 
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
-    cb_access_context.RecordDrawAttachment(tag);
-    RecordIndirectBuffer(cb_access_context, tag, sizeof(VkDrawIndirectCommand), buffer, offset, 1, stride);
-    RecordCountBuffer(cb_access_context, tag, countBuffer, countBufferOffset);
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
+    cb_context.RecordDrawAttachment(tag);
+    RecordIndirectBuffer(cb_context, tag, sizeof(VkDrawIndirectCommand), buffer, offset, 1, stride);
+    RecordCountBuffer(cb_context, tag, countBuffer, countBufferOffset);
 
     // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
-    // cb_access_context->RecordDrawVertex(?, ?, tag);
+    // cb_context->RecordDrawVertex(?, ?, tag);
 }
 
 void SyncValidator::PostCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -1466,17 +1462,17 @@ bool SyncValidator::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer c
                                                                const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
-    skip |= cb_access_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
-    skip |= cb_access_context.ValidateDrawAttachment(error_obj.location);
-    skip |= ValidateIndirectBuffer(cb_access_context, context, sizeof(VkDrawIndexedIndirectCommand), buffer, offset, maxDrawCount,
+    skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= cb_context.ValidateDrawAttachment(error_obj.location);
+    skip |= ValidateIndirectBuffer(cb_context, access_context, sizeof(VkDrawIndexedIndirectCommand), buffer, offset, maxDrawCount,
                                    stride, error_obj.location);
-    skip |= ValidateCountBuffer(cb_access_context, context, countBuffer, countBufferOffset, error_obj.location);
+    skip |= ValidateCountBuffer(cb_context, access_context, countBuffer, countBufferOffset, error_obj.location);
 
     // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
-    // skip |= cb_access_context->ValidateDrawVertexIndex(?, ?, error_obj.location);
+    // skip |= cb_context->ValidateDrawVertexIndex(?, ?, error_obj.location);
     return skip;
 }
 
@@ -1484,16 +1480,16 @@ void SyncValidator::RecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuf
                                                       VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                       uint32_t stride, Func command) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(command);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(command);
 
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
-    cb_access_context.RecordDrawAttachment(tag);
-    RecordIndirectBuffer(cb_access_context, tag, sizeof(VkDrawIndexedIndirectCommand), buffer, offset, 1, stride);
-    RecordCountBuffer(cb_access_context, tag, countBuffer, countBufferOffset);
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
+    cb_context.RecordDrawAttachment(tag);
+    RecordIndirectBuffer(cb_context, tag, sizeof(VkDrawIndexedIndirectCommand), buffer, offset, 1, stride);
+    RecordCountBuffer(cb_context, tag, countBuffer, countBufferOffset);
 
     // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
-    // cb_access_context->RecordDrawVertexIndex(?, ?, tag);
+    // cb_context->RecordDrawVertexIndex(?, ?, tag);
 }
 
 void SyncValidator::PostCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -1540,21 +1536,21 @@ bool SyncValidator::PreCallValidateCmdDrawMeshTasksEXT(VkCommandBuffer commandBu
                                                        uint32_t groupCountZ, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
-    skip |= cb_access_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
-    skip |= cb_access_context.ValidateDrawAttachment(error_obj.location);
+    skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= cb_context.ValidateDrawAttachment(error_obj.location);
     return skip;
 }
 
 void SyncValidator::PostCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                                       uint32_t groupCountZ, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
-    cb_access_context.RecordDrawAttachment(tag);
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
+    cb_context.RecordDrawAttachment(tag);
 }
 
 bool SyncValidator::PreCallValidateCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -1565,12 +1561,12 @@ bool SyncValidator::PreCallValidateCmdDrawMeshTasksIndirectEXT(VkCommandBuffer c
         return skip;
     }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
-    skip |= cb_access_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
-    skip |= cb_access_context.ValidateDrawAttachment(error_obj.location);
-    skip |= ValidateIndirectBuffer(cb_access_context, context, sizeof(VkDrawMeshTasksIndirectCommandEXT), buffer, offset, drawCount,
+    skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= cb_context.ValidateDrawAttachment(error_obj.location);
+    skip |= ValidateIndirectBuffer(cb_context, access_context, sizeof(VkDrawMeshTasksIndirectCommandEXT), buffer, offset, drawCount,
                                    stride, error_obj.location);
     return skip;
 }
@@ -1581,12 +1577,12 @@ void SyncValidator::PostCallRecordCmdDrawMeshTasksIndirectEXT(VkCommandBuffer co
         return;
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
-    cb_access_context.RecordDrawAttachment(tag);
-    RecordIndirectBuffer(cb_access_context, tag, sizeof(VkDrawMeshTasksIndirectCommandEXT), buffer, offset, drawCount, stride);
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
+    cb_context.RecordDrawAttachment(tag);
+    RecordIndirectBuffer(cb_context, tag, sizeof(VkDrawMeshTasksIndirectCommandEXT), buffer, offset, drawCount, stride);
 }
 
 bool SyncValidator::PreCallValidateCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer,
@@ -1596,12 +1592,12 @@ bool SyncValidator::PreCallValidateCmdDrawMeshTasksIndirectCountEXT(VkCommandBuf
     bool skip = false;
 
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
-    skip |= cb_access_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
-    skip |= cb_access_context.ValidateDrawAttachment(error_obj.location);
-    skip |= ValidateCountBuffer(cb_access_context, context, countBuffer, countBufferOffset, error_obj.location);
+    skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= cb_context.ValidateDrawAttachment(error_obj.location);
+    skip |= ValidateCountBuffer(cb_context, access_context, countBuffer, countBufferOffset, error_obj.location);
     return skip;
 }
 
@@ -1610,12 +1606,12 @@ void SyncValidator::PostCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuff
                                                                    VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                                    uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
-    cb_access_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
-    cb_access_context.RecordDrawAttachment(tag);
-    RecordCountBuffer(cb_access_context, tag, countBuffer, countBufferOffset);
+    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
+    cb_context.RecordDrawAttachment(tag);
+    RecordCountBuffer(cb_context, tag, countBuffer, countBufferOffset);
 }
 
 bool SyncValidator::PreCallValidateCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
@@ -1627,7 +1623,7 @@ bool SyncValidator::PreCallValidateCmdDrawMultiIndexedEXT(VkCommandBuffer comman
         return skip;
     }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     skip |= cb_context.ValidateDrawAttachment(error_obj.location);
@@ -1647,7 +1643,7 @@ void SyncValidator::PostCallRecordCmdDrawMultiIndexedEXT(VkCommandBuffer command
         return;
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
     cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
@@ -1667,7 +1663,7 @@ bool SyncValidator::PreCallValidateCmdDrawMultiEXT(VkCommandBuffer commandBuffer
         return skip;
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     skip |= cb_context.ValidateDrawAttachment(error_obj.location);
@@ -1686,7 +1682,7 @@ void SyncValidator::PostCallRecordCmdDrawMultiEXT(VkCommandBuffer commandBuffer,
         return;
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
     cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
@@ -1704,7 +1700,7 @@ bool SyncValidator::PreCallValidateCmdDrawIndirectByteCountEXT(VkCommandBuffer c
                                                                uint32_t vertexStride, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
@@ -1719,7 +1715,7 @@ void SyncValidator::PostCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer co
                                                               VkDeviceSize counterBufferOffset, uint32_t counterOffset,
                                                               uint32_t vertexStride, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
     cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
@@ -1732,15 +1728,15 @@ bool SyncValidator::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuf
                                                       const VkImageSubresourceRange* pRanges, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     if (auto image_state = Get<vvl::Image>(image)) {
         for (const auto [range_index, range] : vvl::enumerate(pRanges, rangeCount)) {
-            auto hazard = context.DetectHazard(*image_state, range, SYNC_CLEAR_TRANSFER_WRITE);
+            auto hazard = access_context.DetectHazard(*image_state, range, SYNC_CLEAR_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, image);
-                const auto error = error_messages_.ImageClearError(hazard, cb_access_context, error_obj.location.function,
+                const auto error = error_messages_.ImageClearError(hazard, cb_context, error_obj.location.function,
                                                                    FormatHandle(image), range_index, range);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
@@ -1756,15 +1752,15 @@ bool SyncValidator::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer com
                                                              const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     if (auto image_state = Get<vvl::Image>(image)) {
         for (const auto [range_index, range] : vvl::enumerate(pRanges, rangeCount)) {
-            auto hazard = context.DetectHazard(*image_state, range, SYNC_CLEAR_TRANSFER_WRITE);
+            auto hazard = access_context.DetectHazard(*image_state, range, SYNC_CLEAR_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, image);
-                const auto error = error_messages_.ImageClearError(hazard, cb_access_context, error_obj.location.function,
+                const auto error = error_messages_.ImageClearError(hazard, cb_context, error_obj.location.function,
                                                                    FormatHandle(image), range_index, range);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
@@ -1781,7 +1777,7 @@ bool SyncValidator::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
 
     for (const VkClearAttachment& attachment : vvl::make_span(pAttachments, attachmentCount)) {
         for (const auto [rect_index, rect] : vvl::enumerate(pRects, rectCount)) {
-            skip |= GetAccessContext(*cb_state).ValidateClearAttachment(error_obj.location, attachment, rect_index, rect);
+            skip |= GetCommandBufferContext(*cb_state).ValidateClearAttachment(error_obj.location, attachment, rect_index, rect);
         }
     }
     return skip;
@@ -1793,8 +1789,8 @@ bool SyncValidator::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer comma
                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
 
@@ -1802,16 +1798,15 @@ bool SyncValidator::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer comma
         const uint32_t query_size = (flags & VK_QUERY_RESULT_64_BIT) ? 8 : 4;
         const VkDeviceSize range_size = (queryCount - 1) * stride + query_size;
         const AccessRange range = MakeRange(dstOffset, range_size);
-        auto hazard = context.DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, range);
+        auto hazard = access_context.DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, range);
         if (hazard.IsHazard()) {
             const LogObjectList objlist(commandBuffer, queryPool, dstBuffer);
             const std::string resource_description = "dstBuffer " + FormatHandle(dstBuffer);
             const auto error =
-                error_messages_.BufferError(hazard, cb_access_context, error_obj.location.function, resource_description, range);
+                error_messages_.BufferError(hazard, cb_context, error_obj.location.function, resource_description, range);
             skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
         }
     }
-
     // TODO:Track VkQueryPool
     return skip;
 }
@@ -1820,20 +1815,19 @@ bool SyncValidator::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, 
                                                  VkDeviceSize size, uint32_t data, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
 
     if (dst_buffer) {
         const AccessRange range = MakeRange(*dst_buffer, dstOffset, size);
-        auto hazard = context.DetectHazard(*dst_buffer, SYNC_CLEAR_TRANSFER_WRITE, range);
+        auto hazard = access_context.DetectHazard(*dst_buffer, SYNC_CLEAR_TRANSFER_WRITE, range);
         if (hazard.IsHazard()) {
             const LogObjectList objlist(commandBuffer, dstBuffer);
             const std::string resource_description = "dstBuffer " + FormatHandle(dstBuffer);
             const auto error =
-                error_messages_.BufferError(hazard, cb_access_context, error_obj.location.function, resource_description, range);
+                error_messages_.BufferError(hazard, cb_context, error_obj.location.function, resource_description, range);
             skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
         }
     }
@@ -1845,39 +1839,38 @@ bool SyncValidator::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer
                                                    const VkImageResolve* pRegions, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     auto src_image = Get<vvl::Image>(srcImage);
     auto dst_image = Get<vvl::Image>(dstImage);
 
     for (const auto [region_index, resolve_region] : vvl::enumerate(pRegions, regionCount)) {
         if (src_image) {
-            auto hazard = context.DetectHazard(*src_image, RangeFromLayers(resolve_region.srcSubresource), resolve_region.srcOffset,
-                                               resolve_region.extent, SYNC_RESOLVE_TRANSFER_READ);
+            auto hazard = access_context.DetectHazard(*src_image, RangeFromLayers(resolve_region.srcSubresource),
+                                                      resolve_region.srcOffset, resolve_region.extent, SYNC_RESOLVE_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
-                    hazard, cb_access_context, error_obj.location.function, FormatHandle(srcImage), region_index,
-                    resolve_region.srcOffset, resolve_region.extent, resolve_region.srcSubresource);
+                    hazard, cb_context, error_obj.location.function, FormatHandle(srcImage), region_index, resolve_region.srcOffset,
+                    resolve_region.extent, resolve_region.srcSubresource);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
 
         if (dst_image) {
-            auto hazard = context.DetectHazard(*dst_image, RangeFromLayers(resolve_region.dstSubresource), resolve_region.dstOffset,
-                                               resolve_region.extent, SYNC_RESOLVE_TRANSFER_WRITE);
+            auto hazard = access_context.DetectHazard(*dst_image, RangeFromLayers(resolve_region.dstSubresource),
+                                                      resolve_region.dstOffset, resolve_region.extent, SYNC_RESOLVE_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
-                    hazard, cb_access_context, error_obj.location.function, FormatHandle(dstImage), region_index,
-                    resolve_region.dstOffset, resolve_region.extent, resolve_region.dstSubresource);
+                    hazard, cb_context, error_obj.location.function, FormatHandle(dstImage), region_index, resolve_region.dstOffset,
+                    resolve_region.extent, resolve_region.dstSubresource);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
             if (skip) break;
         }
     }
-
     return skip;
 }
 
@@ -1885,8 +1878,8 @@ bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
                                                     const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     const Location image_info_loc = error_obj.location.dot(Field::pResolveImageInfo);
     auto src_image = Get<vvl::Image>(pResolveImageInfo->srcImage);
@@ -1895,12 +1888,12 @@ bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
     for (const auto [region_index, resolve_region] : vvl::enumerate(pResolveImageInfo->pRegions, pResolveImageInfo->regionCount)) {
         const Location region_loc = image_info_loc.dot(Field::pRegions, region_index);
         if (src_image) {
-            auto hazard = context.DetectHazard(*src_image, RangeFromLayers(resolve_region.srcSubresource), resolve_region.srcOffset,
-                                               resolve_region.extent, SYNC_RESOLVE_TRANSFER_READ);
+            auto hazard = access_context.DetectHazard(*src_image, RangeFromLayers(resolve_region.srcSubresource),
+                                                      resolve_region.srcOffset, resolve_region.extent, SYNC_RESOLVE_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pResolveImageInfo->srcImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
-                    hazard, cb_access_context, error_obj.location.function, FormatHandle(pResolveImageInfo->srcImage), region_index,
+                    hazard, cb_context, error_obj.location.function, FormatHandle(pResolveImageInfo->srcImage), region_index,
                     resolve_region.srcOffset, resolve_region.extent, resolve_region.srcSubresource);
                 // TODO: this error is not covered by the test
                 skip |= SyncError(hazard.Hazard(), objlist, region_loc, error);
@@ -1908,12 +1901,12 @@ bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
         }
 
         if (dst_image) {
-            auto hazard = context.DetectHazard(*dst_image, RangeFromLayers(resolve_region.dstSubresource), resolve_region.dstOffset,
-                                               resolve_region.extent, SYNC_RESOLVE_TRANSFER_WRITE);
+            auto hazard = access_context.DetectHazard(*dst_image, RangeFromLayers(resolve_region.dstSubresource),
+                                                      resolve_region.dstOffset, resolve_region.extent, SYNC_RESOLVE_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pResolveImageInfo->dstImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
-                    hazard, cb_access_context, error_obj.location.function, FormatHandle(pResolveImageInfo->dstImage), region_index,
+                    hazard, cb_context, error_obj.location.function, FormatHandle(pResolveImageInfo->dstImage), region_index,
                     resolve_region.dstOffset, resolve_region.extent, resolve_region.dstSubresource);
                 // TODO: this error is not covered by the test
                 skip |= SyncError(hazard.Hazard(), objlist, region_loc, error);
@@ -1921,7 +1914,6 @@ bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
             if (skip) break;
         }
     }
-
     return skip;
 }
 
@@ -1935,20 +1927,20 @@ bool SyncValidator::PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer
                                                    VkDeviceSize dataSize, const void* pData, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
 
     if (dst_buffer) {
         // VK_WHOLE_SIZE not allowed
         const AccessRange range = MakeRange(dstOffset, dataSize);
-        auto hazard = context.DetectHazard(*dst_buffer, SYNC_CLEAR_TRANSFER_WRITE, range);
+        auto hazard = access_context.DetectHazard(*dst_buffer, SYNC_CLEAR_TRANSFER_WRITE, range);
         if (hazard.IsHazard()) {
             const LogObjectList objlist(commandBuffer, dstBuffer);
             const std::string resource_description = "dstBuffer " + FormatHandle(dstBuffer);
             const auto error =
-                error_messages_.BufferError(hazard, cb_access_context, error_obj.location.function, resource_description, range);
+                error_messages_.BufferError(hazard, cb_context, error_obj.location.function, resource_description, range);
             skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
         }
     }
@@ -1960,16 +1952,16 @@ bool SyncValidator::PreCallValidateCmdWriteBufferMarkerAMD(VkCommandBuffer comma
                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
     if (auto dst_buffer = Get<vvl::Buffer>(dstBuffer)) {
         const AccessRange range = MakeRange(dstOffset, 4);
-        auto hazard = context.DetectMarkerHazard(*dst_buffer, range);
+        auto hazard = access_context.DetectMarkerHazard(*dst_buffer, range);
         if (hazard.IsHazard()) {
             const std::string resource_description = "dstBuffer " + FormatHandle(dstBuffer);
             const auto error =
-                error_messages_.BufferError(hazard, cb_access_context, error_obj.location.function, resource_description, range);
+                error_messages_.BufferError(hazard, cb_context, error_obj.location.function, resource_description, range);
             skip |= SyncError(hazard.Hazard(), dstBuffer, error_obj.location, error);
         }
     }
@@ -1980,14 +1972,14 @@ void SyncValidator::PostCallRecordCmdWriteBufferMarkerAMD(VkCommandBuffer comman
                                                           VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
                                                           const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
-    AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
+    AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
     if (auto dst_buffer = Get<vvl::Buffer>(dstBuffer)) {
         const AccessRange range = MakeRange(dstOffset, 4);
-        const ResourceUsageTagEx tag_ex = cb_access_context.AddCommandHandle(tag, dst_buffer->Handle());
-        context.UpdateAccessState(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, range, tag_ex, SyncFlag::kMarker);
+        const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, dst_buffer->Handle());
+        access_context.UpdateAccessState(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, range, tag_ex, SyncFlag::kMarker);
     }
 }
 
@@ -1995,8 +1987,8 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
                                                      const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     const auto vs_state = cb_state->bound_video_session.get();
     if (!vs_state) return skip;
@@ -2004,19 +1996,19 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
     auto src_buffer = Get<vvl::Buffer>(pDecodeInfo->srcBuffer);
     if (src_buffer) {
         const AccessRange src_range = MakeRange(*src_buffer, pDecodeInfo->srcBufferOffset, pDecodeInfo->srcBufferRange);
-        auto hazard = context.DetectHazard(*src_buffer, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ, src_range);
+        auto hazard = access_context.DetectHazard(*src_buffer, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ, src_range);
         if (hazard.IsHazard()) {
             const std::string resource_description = "bitstream buffer " + FormatHandle(pDecodeInfo->srcBuffer);
             // TODO: there are no tests for this error
-            const auto error = error_messages_.BufferError(hazard, cb_access_context, error_obj.location.function,
-                                                           resource_description, src_range);
+            const auto error =
+                error_messages_.BufferError(hazard, cb_context, error_obj.location.function, resource_description, src_range);
             skip |= SyncError(hazard.Hazard(), src_buffer->Handle(), error_obj.location, error);
         }
     }
 
     auto dst_resource = vvl::VideoPictureResource(*device_state, pDecodeInfo->dstPictureResource);
     if (dst_resource) {
-        auto hazard = context.DetectVideoHazard(*vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
+        auto hazard = access_context.DetectVideoHazard(*vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
         if (hazard.IsHazard()) {
             std::ostringstream ss;
             ss << "decode output picture ";
@@ -2025,7 +2017,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
             FormatVideoPictureResouce(*this, pDecodeInfo->dstPictureResource, ss);
             const std::string resouce_description = ss.str();
             const std::string error =
-                error_messages_.VideoError(hazard, cb_access_context, error_obj.location.function, resouce_description);
+                error_messages_.VideoError(hazard, cb_context, error_obj.location.function, resouce_description);
             skip |= SyncError(hazard.Hazard(), dst_resource.image_view_state->Handle(), error_obj.location, error);
         }
     }
@@ -2034,7 +2026,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
         const VkVideoPictureResourceInfoKHR& video_picture = *pDecodeInfo->pSetupReferenceSlot->pPictureResource;
         auto setup_resource = vvl::VideoPictureResource(*device_state, video_picture);
         if (setup_resource && (setup_resource != dst_resource)) {
-            auto hazard = context.DetectVideoHazard(*vs_state, setup_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
+            auto hazard = access_context.DetectVideoHazard(*vs_state, setup_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
                 ss << "reconstructed picture ";
@@ -2046,7 +2038,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
                 FormatVideoPictureResouce(*this, video_picture, ss);
                 const std::string resouce_description = ss.str();
                 const std::string error =
-                    error_messages_.VideoError(hazard, cb_access_context, error_obj.location.function, resouce_description);
+                    error_messages_.VideoError(hazard, cb_context, error_obj.location.function, resouce_description);
                 skip |= SyncError(hazard.Hazard(), setup_resource.image_view_state->Handle(), error_obj.location, error);
             }
         }
@@ -2057,7 +2049,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
             const VkVideoPictureResourceInfoKHR& video_picture = *pDecodeInfo->pReferenceSlots[i].pPictureResource;
             auto reference_resource = vvl::VideoPictureResource(*device_state, video_picture);
             if (reference_resource) {
-                auto hazard = context.DetectVideoHazard(*vs_state, reference_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ);
+                auto hazard = access_context.DetectVideoHazard(*vs_state, reference_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ);
                 if (hazard.IsHazard()) {
                     std::ostringstream ss;
                     ss << "reference picture " << i << " ";
@@ -2069,13 +2061,12 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
                     FormatVideoPictureResouce(*this, video_picture, ss);
                     const std::string resouce_description = ss.str();
                     const std::string error =
-                        error_messages_.VideoError(hazard, cb_access_context, error_obj.location.function, resouce_description);
+                        error_messages_.VideoError(hazard, cb_context, error_obj.location.function, resouce_description);
                     skip |= SyncError(hazard.Hazard(), reference_resource.image_view_state->Handle(), error_obj.location, error);
                 }
             }
         }
     }
-
     return skip;
 }
 
@@ -2083,8 +2074,8 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
                                                      const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     const auto vs_state = cb_state->bound_video_session.get();
     if (!vs_state) return skip;
@@ -2092,17 +2083,17 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
     auto dst_buffer = Get<vvl::Buffer>(pEncodeInfo->dstBuffer);
     if (dst_buffer) {
         const AccessRange dst_range = MakeRange(*dst_buffer, pEncodeInfo->dstBufferOffset, pEncodeInfo->dstBufferRange);
-        auto hazard = context.DetectHazard(*dst_buffer, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE, dst_range);
+        auto hazard = access_context.DetectHazard(*dst_buffer, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE, dst_range);
         if (hazard.IsHazard()) {
             const std::string resource_description = "bitstream buffer " + FormatHandle(pEncodeInfo->dstBuffer);
-            const auto error = error_messages_.BufferError(hazard, cb_access_context, error_obj.location.function,
-                                                           resource_description, dst_range);
+            const auto error =
+                error_messages_.BufferError(hazard, cb_context, error_obj.location.function, resource_description, dst_range);
             skip |= SyncError(hazard.Hazard(), dst_buffer->Handle(), error_obj.location, error);
         }
     }
 
     if (auto src_resource = vvl::VideoPictureResource(*device_state, pEncodeInfo->srcPictureResource)) {
-        auto hazard = context.DetectVideoHazard(*vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
+        auto hazard = access_context.DetectVideoHazard(*vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
         if (hazard.IsHazard()) {
             std::ostringstream ss;
             ss << "encode input picture ";
@@ -2112,7 +2103,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
             const std::string resouce_description = ss.str();
             // TODO: there are no tests for this error
             const std::string error =
-                error_messages_.VideoError(hazard, cb_access_context, error_obj.location.function, resouce_description);
+                error_messages_.VideoError(hazard, cb_context, error_obj.location.function, resouce_description);
             skip |= SyncError(hazard.Hazard(), src_resource.image_view_state->Handle(), error_obj.location, error);
         }
     }
@@ -2121,7 +2112,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
         const VkVideoPictureResourceInfoKHR& video_picture = *pEncodeInfo->pSetupReferenceSlot->pPictureResource;
         auto setup_resource = vvl::VideoPictureResource(*device_state, video_picture);
         if (setup_resource) {
-            auto hazard = context.DetectVideoHazard(*vs_state, setup_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE);
+            auto hazard = access_context.DetectVideoHazard(*vs_state, setup_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
                 ss << "reconstructed picture ";
@@ -2133,7 +2124,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
                 FormatVideoPictureResouce(*this, video_picture, ss);
                 const std::string resouce_description = ss.str();
                 const std::string error =
-                    error_messages_.VideoError(hazard, cb_access_context, error_obj.location.function, resouce_description);
+                    error_messages_.VideoError(hazard, cb_context, error_obj.location.function, resouce_description);
                 skip |= SyncError(hazard.Hazard(), setup_resource.image_view_state->Handle(), error_obj.location, error);
             }
         }
@@ -2144,7 +2135,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
             const VkVideoPictureResourceInfoKHR& video_picture = *pEncodeInfo->pReferenceSlots[i].pPictureResource;
             auto reference_resource = vvl::VideoPictureResource(*device_state, video_picture);
             if (reference_resource) {
-                auto hazard = context.DetectVideoHazard(*vs_state, reference_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
+                auto hazard = access_context.DetectVideoHazard(*vs_state, reference_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
                 if (hazard.IsHazard()) {
                     std::ostringstream ss;
                     ss << "reference picture " << i << " ";
@@ -2156,7 +2147,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
                     FormatVideoPictureResouce(*this, video_picture, ss);
                     const std::string resource_description = ss.str();
                     const std::string error =
-                        error_messages_.VideoError(hazard, cb_access_context, error_obj.location.function, resource_description);
+                        error_messages_.VideoError(hazard, cb_context, error_obj.location.function, resource_description);
                     skip |= SyncError(hazard.Hazard(), reference_resource.image_view_state->Handle(), error_obj.location, error);
                 }
             }
@@ -2171,7 +2162,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
                 VkOffset3D offset = {0, 0, 0};
                 VkExtent3D extent = {quantization_map_info->quantizationMapExtent.width,
                                      quantization_map_info->quantizationMapExtent.height, 1};
-                auto hazard = context.DetectHazard(*image_view_state, offset, extent, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
+                auto hazard = access_context.DetectHazard(*image_view_state, offset, extent, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
                 if (hazard.IsHazard()) {
                     std::ostringstream ss;
                     ss << "quantization map ";
@@ -2180,13 +2171,12 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
                     FormatVideoQuantizationMap(*this, *quantization_map_info, ss);
                     const std::string resource_description = ss.str();
                     const std::string error =
-                        error_messages_.VideoError(hazard, cb_access_context, error_obj.location.function, resource_description);
+                        error_messages_.VideoError(hazard, cb_context, error_obj.location.function, resource_description);
                     skip |= SyncError(hazard.Hazard(), image_view_state->Handle(), error_obj.location, error);
                 }
             }
         }
     }
-
     return skip;
 }
 
@@ -2211,14 +2201,14 @@ void SyncValidator::PostCallRecordResetEvent(VkDevice device, VkEvent event, con
 bool SyncValidator::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                                const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     auto event_state = Get<vvl::Event>(event);
     const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(cb_state->GetQueueFlags(), stageMask);
     return ValidateCmdSetEvent(cb_context.GetSyncEnvironment(), event_state, src_exec_scope, ResourceUsageRecord::kMaxIndex,
                                error_obj.location);
 }
 
-void SyncValidator::RecordCmdSetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
+void SyncValidator::RecordCmdSetEvent(CommandBufferContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
                                       const SyncExecScope& src_exec_scope, const Location& loc) const {
     const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
 
@@ -2238,7 +2228,7 @@ void SyncValidator::RecordCmdSetEvent(CommandBufferAccessContext& cb_context, st
 void SyncValidator::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                               const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     auto event_state = Get<vvl::Event>(event);
@@ -2259,7 +2249,7 @@ bool SyncValidator::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, V
         return skip;
     }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     auto event_state = Get<vvl::Event>(event);
@@ -2280,7 +2270,7 @@ void SyncValidator::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, Vk
         return;
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     auto event_state = Get<vvl::Event>(event);
@@ -2292,14 +2282,14 @@ void SyncValidator::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, Vk
 bool SyncValidator::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                                  const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     auto event_state = Get<vvl::Event>(event);
     const SyncExecScope exec_scope = SyncExecScope::MakeSrc(cb_state->GetQueueFlags(), stageMask);
     return ValidateCmdResetEvent(cb_context.GetSyncEnvironment(), event_state, exec_scope, ResourceUsageRecord::kMaxIndex,
                                  error_obj.location);
 }
 
-void SyncValidator::RecordCmdResetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
+void SyncValidator::RecordCmdResetEvent(CommandBufferContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
                                         const SyncExecScope& exec_scope, const Location& loc) const {
     const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
     ApplyCmdResetEvent(cb_context.GetSyncEnvironment(), event, tag, loc.function);
@@ -2310,7 +2300,7 @@ void SyncValidator::RecordCmdResetEvent(CommandBufferAccessContext& cb_context, 
 void SyncValidator::PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                                 const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     auto event_state = Get<vvl::Event>(event);
@@ -2322,7 +2312,7 @@ void SyncValidator::PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, V
 bool SyncValidator::PreCallValidateCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                                   const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     auto event_state = Get<vvl::Event>(event);
     const SyncExecScope exec_scope = SyncExecScope::MakeSrc(cb_state->GetQueueFlags(), stageMask);
     return ValidateCmdResetEvent(cb_context.GetSyncEnvironment(), event_state, exec_scope, ResourceUsageRecord::kMaxIndex,
@@ -2342,7 +2332,7 @@ void SyncValidator::PostCallRecordCmdResetEvent2KHR(VkCommandBuffer commandBuffe
 void SyncValidator::PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                                  const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     auto event_state = Get<vvl::Event>(event);
@@ -2359,7 +2349,7 @@ bool SyncValidator::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, 
                                                  uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers,
                                                  const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, srcStageMask);
@@ -2377,8 +2367,7 @@ bool SyncValidator::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, 
                                  vvl::make_span(&barrier_set, 1), ResourceUsageRecord::kMaxIndex, error_obj.location);
 }
 
-void SyncValidator::RecordCmdWaitEvents(CommandBufferAccessContext& cb_context,
-                                        std::vector<std::shared_ptr<const vvl::Event>>&& events,
+void SyncValidator::RecordCmdWaitEvents(CommandBufferContext& cb_context, std::vector<std::shared_ptr<const vvl::Event>>&& events,
                                         std::vector<BarrierSet>&& barrier_sets, const Location& loc) const {
     const ResourceUsageTag tag = cb_context.NextCommandTag(loc.function);
     ApplyCmdWaitEvents(cb_context.GetSyncEnvironment(), cb_context.GetCurrentAccessContext(), events, barrier_sets, tag,
@@ -2395,7 +2384,7 @@ void SyncValidator::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, u
                                                 uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers,
                                                 const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     std::vector<std::shared_ptr<const vvl::Event>> events(eventCount);
@@ -2430,7 +2419,7 @@ bool SyncValidator::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer,
         return skip;
     }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     std::vector<std::shared_ptr<const vvl::Event>> events(eventCount);
@@ -2451,7 +2440,7 @@ void SyncValidator::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, 
         return;
     }
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const VkQueueFlags queue_flags = cb_state->GetQueueFlags();
 
     std::vector<std::shared_ptr<const vvl::Event>> events(eventCount);
@@ -2470,16 +2459,16 @@ bool SyncValidator::PreCallValidateCmdWriteBufferMarker2AMD(VkCommandBuffer comm
                                                             const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
     if (auto dst_buffer = Get<vvl::Buffer>(dstBuffer)) {
         const AccessRange range = MakeRange(dstOffset, 4);
-        auto hazard = context.DetectMarkerHazard(*dst_buffer, range);
+        auto hazard = access_context.DetectMarkerHazard(*dst_buffer, range);
         if (hazard.IsHazard()) {
             const std::string resource_description = "dstBuffer " + FormatHandle(dstBuffer);
             const auto error =
-                error_messages_.BufferError(hazard, cb_access_context, error_obj.location.function, resource_description, range);
+                error_messages_.BufferError(hazard, cb_context, error_obj.location.function, resource_description, range);
             skip |= SyncError(hazard.Hazard(), dstBuffer, error_obj.location, error);
         }
     }
@@ -2490,14 +2479,14 @@ void SyncValidator::PostCallRecordCmdWriteBufferMarker2AMD(VkCommandBuffer comma
                                                            VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
                                                            const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_access_context = GetAccessContext(*cb_state);
-    const ResourceUsageTag tag = cb_access_context.NextCommandTag(record_obj.location.function);
-    AccessContext& context = cb_access_context.GetCurrentAccessContext();
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
+    AccessContext& access_context = cb_context.GetCurrentAccessContext();
 
     if (auto dst_buffer = Get<vvl::Buffer>(dstBuffer)) {
         const AccessRange range = MakeRange(dstOffset, 4);
-        const ResourceUsageTagEx tag_ex = cb_access_context.AddCommandHandle(tag, dst_buffer->Handle());
-        context.UpdateAccessState(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, range, tag_ex, SyncFlag::kMarker);
+        const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, dst_buffer->Handle());
+        access_context.UpdateAccessState(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, range, tag_ex, SyncFlag::kMarker);
     }
 }
 
@@ -2505,10 +2494,10 @@ bool SyncValidator::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuf
                                                       const VkCommandBuffer* pCommandBuffers, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
     // Heavyweight, but we need a proxy copy of the active command buffer access context
-    CommandBufferAccessContext proxy_cb_context(cb_context, CommandBufferAccessContext::AsProxyContext());
+    CommandBufferContext proxy_cb_context(cb_context, CommandBufferContext::AsProxyContext());
 
     auto& proxy_label_commands = proxy_cb_context.GetProxyLabelCommands();
     proxy_label_commands = cb_state->GetLabelCommands();
@@ -2523,7 +2512,7 @@ bool SyncValidator::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuf
 
         const auto recorded_cb = Get<vvl::CommandBuffer>(pCommandBuffers[cb_index]);
         if (!recorded_cb) continue;
-        const CommandBufferAccessContext& recorded_cb_context = GetAccessContext(*recorded_cb);
+        const CommandBufferContext& recorded_cb_context = GetCommandBufferContext(*recorded_cb);
 
         const ResourceUsageTag base_tag = proxy_cb_context.GetTagCount();
         const Location cb_loc = error_obj.location.dot(vvl::Field::pCommandBuffers, cb_index);
@@ -3200,8 +3189,8 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     for (const auto [i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, i);
@@ -3212,7 +3201,7 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
             const VkDeviceSize offset = info.scratchData.deviceAddress - scratch_buffer.deviceAddress;
             const AccessRange range = MakeRange(scratch_buffer, offset, scratch_size);
             auto hazard =
-                context.DetectHazard(scratch_buffer, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, range);
+                access_context.DetectHazard(scratch_buffer, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, scratch_buffer.Handle());
                 const std::string resource_description = "scratch buffer " + FormatHandle(scratch_buffer.VkHandle());
@@ -3225,8 +3214,8 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
         if (const auto src_accel = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure)) {
             if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
                 const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
-                auto hazard = context.DetectHazard(*src_as_buffer.state,
-                                                   SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_READ, range);
+                auto hazard = access_context.DetectHazard(*src_as_buffer.state,
+                                                          SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_READ, range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, src_as_buffer.state->Handle(), src_accel->Handle());
                     const std::string resource_description = FormatHandle(src_as_buffer.state->VkHandle());
@@ -3241,8 +3230,8 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
         if (const auto dst_accel = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure)) {
             if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
                 const AccessRange dst_range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
-                auto hazard = context.DetectHazard(*dst_as_buffer.state,
-                                                   SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, dst_range);
+                auto hazard = access_context.DetectHazard(
+                    *dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, dst_range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, dst_as_buffer.state->Handle(), dst_accel->Handle());
                     const std::string resource_description = FormatHandle(dst_as_buffer.state->VkHandle());
@@ -3267,10 +3256,11 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
             if (!geometry_info.has_value()) {
                 continue;
             }
-            auto validate_accel_input_geometry = [this, &context, &cb_context, &commandBuffer, &error_obj](
+            auto validate_accel_input_geometry = [this, &access_context, &cb_context, &commandBuffer, &error_obj](
                                                      const vvl::Buffer& geometry_data, const AccessRange& geometry_range,
                                                      const char* data_description) {
-                auto hazard = context.DetectHazard(geometry_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ, geometry_range);
+                auto hazard =
+                    access_context.DetectHazard(geometry_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ, geometry_range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, geometry_data.Handle());
                     std::ostringstream ss;
@@ -3309,8 +3299,8 @@ void SyncValidator::PostCallRecordCmdBuildAccelerationStructuresKHR(
     VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    AccessContext& context = cb_context.GetCbAccessContext();
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    AccessContext& access_context = cb_context.GetCbAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
@@ -3322,8 +3312,8 @@ void SyncValidator::PostCallRecordCmdBuildAccelerationStructuresKHR(
             const VkDeviceSize offset = info.scratchData.deviceAddress - scratch_buffer.deviceAddress;
             const AccessRange scratch_range = MakeRange(scratch_buffer, offset, scratch_size);
             const ResourceUsageTagEx scratch_tag_ex = cb_context.AddCommandHandle(tag, scratch_buffer.Handle());
-            context.UpdateAccessState(scratch_buffer, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, scratch_range,
-                                      scratch_tag_ex);
+            access_context.UpdateAccessState(scratch_buffer, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE,
+                                             scratch_range, scratch_tag_ex);
         }
 
         const auto src_accel = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure);
@@ -3336,8 +3326,8 @@ void SyncValidator::PostCallRecordCmdBuildAccelerationStructuresKHR(
             if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
                 const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
                 const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, src_as_buffer.state->Handle());
-                context.UpdateAccessState(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_READ,
-                                          range, tag_ex);
+                access_context.UpdateAccessState(*src_as_buffer.state,
+                                                 SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_READ, range, tag_ex);
             }
         }
         // Record destination acceleration structure access (WRITE)
@@ -3345,8 +3335,8 @@ void SyncValidator::PostCallRecordCmdBuildAccelerationStructuresKHR(
             if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
                 const AccessRange dst_range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
                 const ResourceUsageTagEx dst_tag_ex = cb_context.AddCommandHandle(tag, dst_as_buffer.state->Handle());
-                context.UpdateAccessState(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE,
-                                          dst_range, dst_tag_ex);
+                access_context.UpdateAccessState(
+                    *dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, dst_range, dst_tag_ex);
             }
         }
         // Record geometry buffer acceses (READ)
@@ -3365,29 +3355,29 @@ void SyncValidator::PostCallRecordCmdBuildAccelerationStructuresKHR(
             }
             if (geometry_info->vertex_data) {
                 const ResourceUsageTagEx vertex_tag_ex = cb_context.AddCommandHandle(tag, geometry_info->vertex_data->Handle());
-                context.UpdateAccessState(*geometry_info->vertex_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ,
-                                          geometry_info->vertex_range, vertex_tag_ex);
+                access_context.UpdateAccessState(*geometry_info->vertex_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ,
+                                                 geometry_info->vertex_range, vertex_tag_ex);
             }
             if (geometry_info->index_data) {
                 const ResourceUsageTagEx index_tag_ex = cb_context.AddCommandHandle(tag, geometry_info->index_data->Handle());
-                context.UpdateAccessState(*geometry_info->index_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ,
-                                          geometry_info->index_range, index_tag_ex);
+                access_context.UpdateAccessState(*geometry_info->index_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ,
+                                                 geometry_info->index_range, index_tag_ex);
             }
             if (geometry_info->transform_data) {
                 const ResourceUsageTagEx transform_tag_ex =
                     cb_context.AddCommandHandle(tag, geometry_info->transform_data->Handle());
-                context.UpdateAccessState(*geometry_info->transform_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ,
-                                          geometry_info->transform_range, transform_tag_ex);
+                access_context.UpdateAccessState(*geometry_info->transform_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ,
+                                                 geometry_info->transform_range, transform_tag_ex);
             }
             if (geometry_info->aabb_data) {
                 const ResourceUsageTagEx aabb_tag_ex = cb_context.AddCommandHandle(tag, geometry_info->aabb_data->Handle());
-                context.UpdateAccessState(*geometry_info->aabb_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ,
-                                          geometry_info->aabb_range, aabb_tag_ex);
+                access_context.UpdateAccessState(*geometry_info->aabb_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ,
+                                                 geometry_info->aabb_range, aabb_tag_ex);
             }
             if (geometry_info->instance_data) {
                 const ResourceUsageTagEx instance_tag_ex = cb_context.AddCommandHandle(tag, geometry_info->instance_data->Handle());
-                context.UpdateAccessState(*geometry_info->instance_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ,
-                                          geometry_info->instance_range, instance_tag_ex);
+                access_context.UpdateAccessState(*geometry_info->instance_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ,
+                                                 geometry_info->instance_range, instance_tag_ex);
             }
         }
     }
@@ -3398,16 +3388,16 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuff
                                                                    const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
     if (const auto src_accel = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
         if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
             const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
-            auto hazard =
-                context.DetectHazard(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range);
+            auto hazard = access_context.DetectHazard(*src_as_buffer.state,
+                                                      SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(cb_state->Handle(), src_as_buffer.state->Handle(), src_accel->Handle());
                 const std::string resource_description = FormatHandle(src_as_buffer.state->VkHandle());
@@ -3421,8 +3411,8 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuff
     if (const auto dst_accel = Get<vvl::AccelerationStructureKHR>(pInfo->dst)) {
         if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
             const AccessRange range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
-            auto hazard =
-                context.DetectHazard(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range);
+            auto hazard = access_context.DetectHazard(*dst_as_buffer.state,
+                                                      SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(cb_state->Handle(), dst_as_buffer.state->Handle(), dst_accel->Handle());
                 const std::string resource_description = FormatHandle(dst_as_buffer.state->VkHandle());
@@ -3440,8 +3430,8 @@ void SyncValidator::PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffe
                                                                   const VkCopyAccelerationStructureInfoKHR* pInfo,
                                                                   const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    AccessContext& context = cb_context.GetCbAccessContext();
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    AccessContext& access_context = cb_context.GetCbAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
@@ -3449,16 +3439,16 @@ void SyncValidator::PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffe
         if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
             const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
             const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, src_as_buffer.state->Handle());
-            context.UpdateAccessState(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range,
-                                      tag_ex);
+            access_context.UpdateAccessState(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ,
+                                             range, tag_ex);
         }
     }
     if (const auto dst_accel = Get<vvl::AccelerationStructureKHR>(pInfo->dst)) {
         if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
             const AccessRange range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
             const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, dst_as_buffer.state->Handle());
-            context.UpdateAccessState(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range,
-                                      tag_ex);
+            access_context.UpdateAccessState(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE,
+                                             range, tag_ex);
         }
     }
 }
@@ -3468,16 +3458,16 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkCom
                                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
     if (const auto src_accel = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
         if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
             const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
-            auto hazard =
-                context.DetectHazard(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range);
+            auto hazard = access_context.DetectHazard(*src_as_buffer.state,
+                                                      SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(cb_state->Handle(), src_as_buffer.state->Handle(), src_accel->Handle());
                 const std::string resource_description = FormatHandle(src_as_buffer.state->VkHandle());
@@ -3501,8 +3491,8 @@ void SyncValidator::PostCallRecordCmdCopyAccelerationStructureToMemoryKHR(VkComm
                                                                           const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
                                                                           const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    AccessContext& context = cb_context.GetCbAccessContext();
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    AccessContext& access_context = cb_context.GetCbAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
@@ -3510,8 +3500,8 @@ void SyncValidator::PostCallRecordCmdCopyAccelerationStructureToMemoryKHR(VkComm
         if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
             const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
             const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, src_as_buffer.state->Handle());
-            context.UpdateAccessState(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range,
-                                      tag_ex);
+            access_context.UpdateAccessState(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ,
+                                             range, tag_ex);
         }
     }
 }
@@ -3521,16 +3511,16 @@ bool SyncValidator::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkCom
                                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    const AccessContext& context = cb_context.GetCbAccessContext();
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
     if (const auto dst_accel = Get<vvl::AccelerationStructureKHR>(pInfo->dst)) {
         if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
             const AccessRange range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
-            auto hazard =
-                context.DetectHazard(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range);
+            auto hazard = access_context.DetectHazard(*dst_as_buffer.state,
+                                                      SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(cb_state->Handle(), dst_as_buffer.state->Handle(), dst_accel->Handle());
                 const std::string resource_description = FormatHandle(dst_as_buffer.state->VkHandle());
@@ -3554,8 +3544,8 @@ void SyncValidator::PostCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkComm
                                                                           const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
                                                                           const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
-    AccessContext& context = cb_context.GetCbAccessContext();
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    AccessContext& access_context = cb_context.GetCbAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
@@ -3563,13 +3553,13 @@ void SyncValidator::PostCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkComm
         if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
             const AccessRange range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
             const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, dst_as_buffer.state->Handle());
-            context.UpdateAccessState(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range,
-                                      tag_ex);
+            access_context.UpdateAccessState(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE,
+                                             range, tag_ex);
         }
     }
 }
 
-bool SyncValidator::ValidateSbtBuffer(const CommandBufferAccessContext& cb_context,
+bool SyncValidator::ValidateSbtBuffer(const CommandBufferContext& cb_context,
                                       const VkStridedDeviceAddressRegionKHR* p_sbt_address_region, const Location& loc,
                                       const char* sbt_buffer_label) const {
     bool skip = false;
@@ -3595,8 +3585,8 @@ bool SyncValidator::ValidateSbtBuffer(const CommandBufferAccessContext& cb_conte
     return skip;
 }
 
-void SyncValidator::RecordSbtBuffer(CommandBufferAccessContext& cb_context,
-                                    const VkStridedDeviceAddressRegionKHR* p_sbt_address_region, ResourceUsageTag tag) {
+void SyncValidator::RecordSbtBuffer(CommandBufferContext& cb_context, const VkStridedDeviceAddressRegionKHR* p_sbt_address_region,
+                                    ResourceUsageTag tag) {
     if (!p_sbt_address_region) {
         return;
     }
@@ -3621,7 +3611,7 @@ bool SyncValidator::PreCallValidateCmdTraceRaysKHR(VkCommandBuffer commandBuffer
                                                    const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
     skip |= ValidateSbtBuffer(cb_context, pRaygenShaderBindingTable, error_obj.location, "raygen");
@@ -3638,7 +3628,7 @@ void SyncValidator::PostCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                                   const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                                   uint32_t width, uint32_t height, uint32_t depth, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
     cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, tag);
@@ -3657,7 +3647,7 @@ bool SyncValidator::PreCallValidateCmdTraceRaysIndirectKHR(VkCommandBuffer comma
                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
@@ -3680,7 +3670,7 @@ void SyncValidator::PostCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer comman
                                                           const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                                           VkDeviceAddress indirectDeviceAddress, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
     cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, tag);
@@ -3698,7 +3688,7 @@ bool SyncValidator::PreCallValidateCmdTraceRaysIndirect2KHR(VkCommandBuffer comm
                                                             const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const AccessContext& access_context = cb_context.GetCbAccessContext();
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
@@ -3713,7 +3703,7 @@ bool SyncValidator::PreCallValidateCmdTraceRaysIndirect2KHR(VkCommandBuffer comm
 void SyncValidator::PostCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
                                                            const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferAccessContext& cb_context = GetAccessContext(*cb_state);
+    CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
     cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, tag);

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -170,7 +170,7 @@ class SyncValidator : public vvl::DeviceProxy {
     bool PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo,
                                       const ErrorObject &error_obj) const override;
 
-    bool ValidateCmdPipelineBarrier(const CommandBufferAccessContext& cb_context, const BarrierSet& barrier_set,
+    bool ValidateCmdPipelineBarrier(const CommandBufferContext& cb_context, const BarrierSet& barrier_set,
                                     const Location& loc) const;
     bool PreCallValidateCmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask,
                                            VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,
@@ -179,7 +179,7 @@ class SyncValidator : public vvl::DeviceProxy {
                                            uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers,
                                            const ErrorObject &error_obj) const override;
 
-    void RecordCmdPipelineBarrier(CommandBufferAccessContext& cb_context, BarrierSet&& barrier_set, const Location& loc) const;
+    void RecordCmdPipelineBarrier(CommandBufferContext& cb_context, BarrierSet&& barrier_set, const Location& loc) const;
     void PostCallRecordCmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask,
                                           VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,
                                           uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
@@ -265,15 +265,15 @@ class SyncValidator : public vvl::DeviceProxy {
     bool PreCallValidateCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2 *pBlitImageInfo,
                                       const ErrorObject &error_obj) const override;
 
-    bool ValidateIndirectBuffer(const CommandBufferAccessContext &cb_context, const AccessContext &context,
+    bool ValidateIndirectBuffer(const CommandBufferContext& cb_context, const AccessContext& access_context,
                                 const VkDeviceSize struct_size, const VkBuffer buffer, const VkDeviceSize offset,
-                                const uint32_t drawCount, const uint32_t stride, const Location &loc) const;
-    void RecordIndirectBuffer(CommandBufferAccessContext &cb_context, ResourceUsageTag tag, const VkDeviceSize struct_size,
+                                const uint32_t drawCount, const uint32_t stride, const Location& loc) const;
+    void RecordIndirectBuffer(CommandBufferContext& cb_context, ResourceUsageTag tag, const VkDeviceSize struct_size,
                               const VkBuffer buffer, const VkDeviceSize offset, const uint32_t drawCount, uint32_t stride);
 
-    bool ValidateCountBuffer(const CommandBufferAccessContext& cb_context, const AccessContext& context, VkBuffer buffer,
+    bool ValidateCountBuffer(const CommandBufferContext& cb_context, const AccessContext& access_context, VkBuffer buffer,
                              VkDeviceSize offset, const Location& loc, const char* count_buffer_label = "draw count") const;
-    void RecordCountBuffer(CommandBufferAccessContext& cb_context, ResourceUsageTag tag, VkBuffer buffer, VkDeviceSize offset);
+    void RecordCountBuffer(CommandBufferContext& cb_context, ResourceUsageTag tag, VkBuffer buffer, VkDeviceSize offset);
 
     bool PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
                                     const ErrorObject &error_obj) const override;
@@ -446,7 +446,7 @@ class SyncValidator : public vvl::DeviceProxy {
     void PostCallRecordResetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) override;
     bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                     const ErrorObject& error_obj) const override;
-    void RecordCmdSetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
+    void RecordCmdSetEvent(CommandBufferContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
                            const SyncExecScope& src_exec_scope, const Location& loc) const;
     void PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                    const RecordObject& record_obj) override;
@@ -460,7 +460,7 @@ class SyncValidator : public vvl::DeviceProxy {
                                     const RecordObject& record_obj) override;
     bool PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                       const ErrorObject& error_obj) const override;
-    void RecordCmdResetEvent(CommandBufferAccessContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
+    void RecordCmdResetEvent(CommandBufferContext& cb_context, std::shared_ptr<const vvl::Event>&& event,
                              const SyncExecScope& exec_scope, const Location& loc) const;
     void PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                      const RecordObject& record_obj) override;
@@ -478,7 +478,7 @@ class SyncValidator : public vvl::DeviceProxy {
                                       uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
                                       uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers,
                                       const ErrorObject& error_obj) const override;
-    void RecordCmdWaitEvents(CommandBufferAccessContext& cb_context, std::vector<std::shared_ptr<const vvl::Event>>&& events,
+    void RecordCmdWaitEvents(CommandBufferContext& cb_context, std::vector<std::shared_ptr<const vvl::Event>>&& events,
                              std::vector<BarrierSet>&& barrier_sets, const Location& loc) const;
     void PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                      VkPipelineStageFlags sourceStageMask, VkPipelineStageFlags dstStageMask,
@@ -572,10 +572,9 @@ class SyncValidator : public vvl::DeviceProxy {
                                                                const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo,
                                                                const RecordObject &record_obj) override;
 
-    bool ValidateSbtBuffer(const CommandBufferAccessContext& cb_context,
-                           const VkStridedDeviceAddressRegionKHR* p_sbt_address_region, const Location& loc,
-                           const char* sbt_buffer_label) const;
-    void RecordSbtBuffer(CommandBufferAccessContext& cb_context, const VkStridedDeviceAddressRegionKHR* p_sbt_address_region,
+    bool ValidateSbtBuffer(const CommandBufferContext& cb_context, const VkStridedDeviceAddressRegionKHR* p_sbt_address_region,
+                           const Location& loc, const char* sbt_buffer_label) const;
+    void RecordSbtBuffer(CommandBufferContext& cb_context, const VkStridedDeviceAddressRegionKHR* p_sbt_address_region,
                          ResourceUsageTag tag);
     bool PreCallValidateCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                         const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,


### PR DESCRIPTION
`CommandBufferAccessContext` -> `CommandBufferContext`.

Dont use AccessContext suffix in `CommandBufferAccessContext` because it's not subtype of `AccessContext`.

The new `CommandBufferContext` name also matches the naming of `QueueBatchContext`.

Other consistency renames.