### PR TITLE
layers: Add CopyBuffer dst overlap

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -794,14 +794,14 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, cons
     const auto* dst_binding = dst_buffer_state.Binding();
 
     const bool are_buffers_sparse = src_buffer_state.sparse || dst_buffer_state.sparse;
-    const bool validate_no_memory_overlaps = !are_buffers_sparse && (regionCount > 0) && src_binding && dst_binding &&
-                                             (src_binding->memory_state == dst_binding->memory_state);
+    const bool validate_src_dst_overlaps = !are_buffers_sparse && (regionCount > 0) && src_binding && dst_binding &&
+                                           (src_binding->memory_state == dst_binding->memory_state);
 
     using MemoryRange = vvl::BindableMemoryTracker::BufferRange;
 
     std::vector<MemoryRange> src_memory_ranges;
     std::vector<MemoryRange> dst_memory_ranges;
-    if (validate_no_memory_overlaps) {
+    if (validate_src_dst_overlaps) {
         src_memory_ranges.reserve(regionCount);
         dst_memory_ranges.reserve(regionCount);
     }
@@ -850,9 +850,28 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, cons
             }
         }
 
-        // The union of the source regions, and the union of the destination regions, must not overlap in memory
-        if (validate_no_memory_overlaps) {
-            // Sort copy ranges
+        // Validate Dst vs Dst overlap
+        if (dst_binding) {
+            MemoryRange dst_buffer_memory_range(dst_binding->memory_offset + region.dstOffset,
+                                                dst_binding->memory_offset + region.dstOffset + region.size);
+            for (uint32_t j = i + 1; j < regionCount; ++j) {
+                const auto& other_region = pRegions[j];
+                MemoryRange other_region_range(dst_binding->memory_offset + other_region.dstOffset,
+                                               dst_binding->memory_offset + other_region.dstOffset + other_region.size);
+                if (dst_buffer_memory_range.intersects(other_region_range)) {
+                    const LogObjectList objlist(commandBuffer, dst_binding->memory_state->Handle(), dst_buffer_state.Handle());
+                    const char* vuid = is_2 ? "VUID-VkCopyBufferInfo2-pRegions-12482" : "VUID-vkCmdCopyBuffer-pRegions-12482";
+                    skip |= LogError(vuid, objlist, region_loc,
+                                     "destination buffer range %s overlaps with pRegions[%" PRIu32
+                                     "] destination buffer range %s\nThis will cause a write-after-write memory hazard.",
+                                     vvl::string_range(dst_buffer_memory_range).c_str(), j,
+                                     vvl::string_range(other_region_range).c_str());
+                }
+            }
+        }
+
+        // Sort copy ranges to validate src vs dst overlap
+        if (validate_src_dst_overlaps) {
             {
                 MemoryRange src_buffer_memory_range(src_binding->memory_offset + region.srcOffset,
                                                     src_binding->memory_offset + region.srcOffset + region.size);
@@ -869,7 +888,7 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, cons
         }
     }
 
-    if (validate_no_memory_overlaps) {
+    if (validate_src_dst_overlaps) {
         // Memory ranges are sorted, so looking for overlaps can be done in linear time
         auto src_ranges_it = src_memory_ranges.cbegin();
         auto dst_ranges_it = dst_memory_ranges.cbegin();

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -3106,6 +3106,32 @@ TEST_F(NegativeCopyBufferImage, CompletelyOverlappingBuffer) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeCopyBufferImage, OverlapDstBuffer) {
+    RETURN_IF_SKIP(Init());
+
+    VkBufferCopy copy_infos[3];
+    copy_infos[0].srcOffset = 0;
+    copy_infos[0].dstOffset = 0;
+    copy_infos[0].size = 8;
+    copy_infos[1].srcOffset = 8;
+    copy_infos[1].dstOffset = 16;
+    copy_infos[1].size = 8;
+    copy_infos[2].srcOffset = 16;
+    copy_infos[2].dstOffset = 8;
+    copy_infos[2].size = 16;
+
+    vkt::Buffer src_buffer(*m_device, 64, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+    vkt::Buffer dst_buffer(*m_device, 64, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    m_command_buffer.Begin();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBuffer-pRegions-12482");
+    vk::CmdCopyBuffer(m_command_buffer, src_buffer, dst_buffer, 3, copy_infos);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeCopyBufferImage, InterleavedRegions) {
     TEST_DESCRIPTION("Test copying between interleaved source and destination regions.");
     RETURN_IF_SKIP(Init());


### PR DESCRIPTION
`12482` was added recently as it was an oversight we never checked for `dst` overlap with another `dst`

this just adds it, same style as `VUID-VkCopyDeviceMemoryImageInfoKHR-pRegions-12473`