### PR TITLE
scripts: Fix syncval mimalloc v3.3.2 stats

### DIFF
--- a/docs/syncval_development.md
+++ b/docs/syncval_development.md
@@ -27,7 +27,7 @@ Build the project with `VVL_ENABLE_SYNCVAL_STATS=1` preprocessor definition to e
 
 If `VVL_ENABLE_SYNCVAL_STATS=1` environment variable is also set, statistics will be printed to console when the application exits. During development, statistics can be printed at any time by calling `Stats::CreateReport()`. The statistics tracking object is a member of the syncval validator (`SyncValidator::stats`) and can be inspected directly during development.
 
-If the *mimalloc* allocator is used, syncval statistics can also collect allocation information using the mimalloc stats system. The mimalloc dependency must be build with `MI_STAT=1` preprocessor definition. The total amount of allocated memory is tracked in `Stats::total_allocated_memory`, and all mimalloc stats are stored in `Stats::mi_stats`.
+If the *mimalloc* allocator is used, syncval statistics can also collect allocation information using the mimalloc stats system. The mimalloc dependency must be build with `MI_STAT=2` preprocessor definition. The total amount of allocated memory is tracked in `Stats::total_allocated_memory`, and all mimalloc stats are stored in `Stats::mi_stats`.
 
 The mimalloc statistics are updated at fixed points: `vkQueueSubmit`, `vkQueuePresent`, and when generating a report via `Stats::CreateReport()`. To update mimalloc stats manually at arbitrary point, call `Stats::UpdateMemoryStats`.
 

--- a/layers/sync/sync_stats.cpp
+++ b/layers/sync/sync_stats.cpp
@@ -170,10 +170,10 @@ void Stats::OnBarrierCommand(uint32_t memory_barrier_count, uint32_t buffer_barr
 
 void Stats::UpdateMemoryStats() {
 #if defined(USE_MIMALLOC_STATS)
-    mi_stats_merge();
     {
         std::unique_lock<std::mutex> lock(mi_stats_mutex);
-        mi_stats_get(sizeof(mi_stats), &mi_stats);
+        mi_stats_init(&mi_stats);
+        mi_stats_get(&mi_stats);
     }
 #endif
 }

--- a/layers/sync/sync_stats.h
+++ b/layers/sync/sync_stats.h
@@ -28,7 +28,7 @@
 #include <atomic>
 #include <mutex>
 
-// NOTE: mimalloc should be built with MI_STAT=1 to enable stats module
+// NOTE: mimalloc should be built with MI_STAT=2 to enable stats module
 #if defined(USE_MIMALLOC)
 #include <mimalloc.h>
 #if MI_MALLOC_VERSION >= 300

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -131,10 +131,10 @@ if (UPDATE_DEPS)
         list(APPEND cmake_var "--cmake_var" "VUL_MOCK_ANDROID=ON")
     endif()
 
-    # Enable mimalloc statistics level 1. This is useful for release builds.
-    # Default value for release builds is MI_STAT=0, for debug builds it is MI_STAT=2.
+    # Enable mimalloc statistics level 2. It is required for allocation counts and size-bin statistic.
+    # Default value for release builds is MI_STAT=0.
     if (VVL_ENABLE_MI_STAT)
-         list(APPEND cmake_var "--cmake_var" "MI_EXTRA_CPPDEFS=\"MI_STAT=1\"")
+         list(APPEND cmake_var "--cmake_var" "MI_EXTRA_CPPDEFS=\"MI_STAT=2\"")
     endif()
 
     if (cmake_var)


### PR DESCRIPTION
VVL updated mimalloc to 3.3.2 some time ago. This change fixes syncval stats so it works with the updated mimalloc.