### PR TITLE
sync: Update settings before refactor

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -106,6 +106,8 @@
                     "settings": [
                         { "key": "validate_core", "value": false },
                         { "key": "validate_sync", "value": true },
+                            { "key": "syncval_full_validation", "value": false },
+                            { "key": "syncval_record_time_validation", "value": true },
                             { "key": "syncval_submit_time_validation", "value": true },
                             { "key": "syncval_shader_accesses_heuristic", "value": false },
                             { "key": "syncval_message_extra_properties", "value": false },
@@ -449,8 +451,35 @@
                             "expanded": false,
                             "settings": [
                                 {
+                                    "key": "syncval_full_validation",
+                                    "label": "Full validation",
+                                    "description": "Validate accesses across all command buffers. Errors are reported during queue submission.",
+                                    "type": "BOOL",
+                                    "default": false,
+                                    "view": "HIDDEN",
+                                    "dependence": {
+                                        "mode": "ALL",
+                                        "settings": [
+                                            { "key": "validate_sync", "value": true }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "syncval_record_time_validation",
+                                    "label": "Record-time validation",
+                                    "description": "Enable early reporting during command buffer recording, at the command that caused the error. Only a subset of validation can run this early. Full validation runs during queue submission. Disabling this reduces validation overhead.",
+                                    "type": "BOOL",
+                                    "default": true,
+                                    "dependence": {
+                                        "mode": "ALL",
+                                        "settings": [
+                                            { "key": "validate_sync", "value": true }
+                                        ]
+                                    }
+                                },
+                                {
                                     "key": "syncval_submit_time_validation",
-                                    "label": "Submit time validation",
+                                    "label": "Submit-time validation (legacy)",
                                     "description": "Enable synchronization validation on the boundary between submitted command buffers. This also validates accesses from presentation operations. This option can incur a significant performance cost.",
                                     "type": "BOOL",
                                     "default": true,

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -200,10 +200,13 @@ const char* VK_LAYER_GPUAV_DEBUG_DISABLE_DONTINLINE = "gpuav_debug_disable_donti
 
 // SyncVal
 // ---
-const char* VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION = "syncval_submit_time_validation";
+const char* VK_LAYER_SYNCVAL_FULL_VALIDATION = "syncval_full_validation";
+const char* VK_LAYER_SYNCVAL_RECORD_TIME_VALIDATION = "syncval_record_time_validation";
 const char* VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC = "syncval_shader_accesses_heuristic";
 const char* VK_LAYER_SYNCVAL_LOAD_OP_AFTER_STORE_OP_VALIDATION = "syncval_load_op_after_store_op_validation";
 const char* VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES = "syncval_message_extra_properties";
+// TODO: mark as REMOVED after refactor
+const char* VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION = "syncval_submit_time_validation";
 
 // Message Formatting
 // ---
@@ -1222,9 +1225,13 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
     }
 
     SyncValSettings& syncval_settings = *settings_data->syncval_settings;
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION,
-                                syncval_settings.submit_time_validation);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_FULL_VALIDATION)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_FULL_VALIDATION, syncval_settings.full_validation);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_RECORD_TIME_VALIDATION)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_RECORD_TIME_VALIDATION,
+                                syncval_settings.record_time_validation);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC)) {
@@ -1240,6 +1247,12 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES,
                                 syncval_settings.message_extra_properties);
+    }
+
+    // TODO: add REMOVED warning similar to REMOVED_VK_LAYER_GPUAV_VALIDATE_RAY_QUERY
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION,
+                                syncval_settings.legacy_submit_time_validation);
     }
 
     GpuDumpSettings& gpu_dump_settings = *settings_data->gpu_dump_settings;

--- a/layers/layer_options_validation.h
+++ b/layers/layer_options_validation.h
@@ -106,8 +106,10 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT &la
         else if (strcmp(VK_LAYER_PRINTF_VERBOSE, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_REPORT_FLAGS, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_STRING_EXT; }
         else if (strcmp(VK_LAYER_STATELESS_PARAM, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
+        else if (strcmp(VK_LAYER_SYNCVAL_FULL_VALIDATION, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_SYNCVAL_LOAD_OP_AFTER_STORE_OP_VALIDATION, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
+        else if (strcmp(VK_LAYER_SYNCVAL_RECORD_TIME_VALIDATION, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_THREAD_SAFETY, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }

--- a/layers/sync/sync_settings.h
+++ b/layers/sync/sync_settings.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,13 @@
 #pragma once
 
 struct SyncValSettings {
-    bool submit_time_validation = true;
+    bool full_validation = false;
+    bool record_time_validation = true;
+    bool legacy_submit_time_validation = true;  // TODO: remove after refactor
     bool shader_accesses_heuristic = false;
+
+    // TODO: remove this and replace with direct record_time_validation access after refactor
+    bool IsRecordTimeValidationEnabled() const { return record_time_validation || legacy_submit_time_validation; }
 
     // This validation currently is controlled only by the settings and is disabled by default.
     // There is a discussion https://gitlab.khronos.org/vulkan/vulkan/-/issues/4513 to clarify

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2564,7 +2564,7 @@ void SyncValidator::PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t 
 }
 
 void SyncValidator::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject& record_obj) {
-    if (record_obj.result != VK_SUCCESS || !syncval_settings.submit_time_validation || queue == VK_NULL_HANDLE) {
+    if (record_obj.result != VK_SUCCESS || !syncval_settings.legacy_submit_time_validation || queue == VK_NULL_HANDLE) {
         return;
     }
     const QueueId waited_queue = GetQueueId(queue);
@@ -2612,7 +2612,7 @@ void SyncValidator::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordOb
 bool SyncValidator::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
                                                    const ErrorObject& error_obj) const {
     bool skip = false;
-    if (!syncval_settings.submit_time_validation) {
+    if (!syncval_settings.legacy_submit_time_validation) {
         return skip;
     }
     std::lock_guard lock_guard(queue_mutex_);
@@ -2696,7 +2696,7 @@ uint32_t SyncValidator::SetupPresentInfo(const VkPresentInfoKHR& present_info, B
 void SyncValidator::PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
                                                       VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex,
                                                       const RecordObject& record_obj) {
-    if (!syncval_settings.submit_time_validation) {
+    if (!syncval_settings.legacy_submit_time_validation) {
         return;
     }
     RecordAcquireNextImageState(device, swapchain, timeout, semaphore, fence, pImageIndex, record_obj);
@@ -2704,7 +2704,7 @@ void SyncValidator::PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapcha
 
 void SyncValidator::PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo,
                                                        uint32_t* pImageIndex, const RecordObject& record_obj) {
-    if (!syncval_settings.submit_time_validation) {
+    if (!syncval_settings.legacy_submit_time_validation) {
         return;
     }
     RecordAcquireNextImageState(device, pAcquireInfo->swapchain, pAcquireInfo->timeout, pAcquireInfo->semaphore,
@@ -2769,7 +2769,7 @@ void SyncValidator::RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR 
 bool SyncValidator::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
                                                const ErrorObject& error_obj) const {
     bool skip = false;
-    if (!syncval_settings.submit_time_validation) {
+    if (!syncval_settings.legacy_submit_time_validation) {
         return skip;
     }
 
@@ -2784,7 +2784,7 @@ bool SyncValidator::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCou
 bool SyncValidator::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                                 const ErrorObject& error_obj) const {
     bool skip = false;
-    if (!syncval_settings.submit_time_validation) {
+    if (!syncval_settings.legacy_submit_time_validation) {
         return skip;
     }
     std::lock_guard lock_guard(queue_mutex_);
@@ -2985,7 +2985,7 @@ bool SyncValidator::PropagateTimelineSignals(SignalsUpdate& signals_update) {
 }
 
 void SyncValidator::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, const RecordObject& record_obj) {
-    if (!syncval_settings.submit_time_validation) {
+    if (!syncval_settings.legacy_submit_time_validation) {
         return;
     }
     if (record_obj.result == VK_SUCCESS) {
@@ -2996,7 +2996,7 @@ void SyncValidator::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence,
 
 void SyncValidator::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll,
                                                 uint64_t timeout, const RecordObject& record_obj) {
-    if (!syncval_settings.submit_time_validation) {
+    if (!syncval_settings.legacy_submit_time_validation) {
         return;
     }
     if ((record_obj.result == VK_SUCCESS) && ((VK_TRUE == waitAll) || (1 == fenceCount))) {
@@ -3010,7 +3010,7 @@ void SyncValidator::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceC
 bool SyncValidator::PreCallValidateSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
                                                    const ErrorObject& error_obj) const {
     bool skip = false;
-    if (!syncval_settings.submit_time_validation) {
+    if (!syncval_settings.legacy_submit_time_validation) {
         return skip;
     }
     // Although SignalSemaphore does not run on the queue, the signalling can resolve
@@ -3053,7 +3053,7 @@ bool SyncValidator::ProcessSignalSemaphore(VkDevice device, const VkSemaphoreSig
 
 void SyncValidator::PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
                                                  const RecordObject& record_obj) {
-    if (!syncval_settings.submit_time_validation) {
+    if (!syncval_settings.legacy_submit_time_validation) {
         return;
     }
     const bool wait_all = pWaitInfo->semaphoreCount == 1 || (pWaitInfo->flags & VK_SEMAPHORE_WAIT_ANY_BIT) == 0;
@@ -3071,7 +3071,7 @@ void SyncValidator::PostCallRecordWaitSemaphoresKHR(VkDevice device, const VkSem
 
 void SyncValidator::PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
                                                            const RecordObject& record_obj) {
-    if (!syncval_settings.submit_time_validation) {
+    if (!syncval_settings.legacy_submit_time_validation) {
         return;
     }
     if (record_obj.result == VK_SUCCESS) {

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -263,12 +263,17 @@ khronos_validation.stateless_param = true
 # Append a section of key-value properties to the error message. Useful for filtering errors.
 khronos_validation.syncval_message_extra_properties = false
 
+# Record-time validation
+# =====================
+# Enable early reporting during command buffer recording, at the command that caused the error. Only a subset of validation can run this early. Full validation runs during queue submission. Disabling this reduces validation overhead.
+khronos_validation.syncval_record_time_validation = true
+
 # Shader accesses heuristic
 # =====================
 # Take into account memory accesses performed by the shader based on SPIR-V static analysis. Warning: can produce false-positives, can ignore certain types of accesses, does not support VK_EXT_descriptor_buffer.
 khronos_validation.syncval_shader_accesses_heuristic = false
 
-# Submit time validation
+# Submit-time validation (legacy)
 # =====================
 # Enable synchronization validation on the boundary between submitted command buffers. This also validates accesses from presentation operations. This option can incur a significant performance cost.
 khronos_validation.syncval_submit_time_validation = true

--- a/tests/stress/sync_val_stress.cpp
+++ b/tests/stress/sync_val_stress.cpp
@@ -28,6 +28,12 @@ static const std::array syncval_disables = {
 void StressSyncVal::InitSyncVal() {
     std::vector<VkLayerSettingEXT> settings;
 
+    // TODO: set syncval_full_validation to True after refactor
+    settings.emplace_back(
+        VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_full_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkFalse});
+    settings.emplace_back(
+        VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_record_time_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue});
+    // TODO: remove after refactor
     settings.emplace_back(
         VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_submit_time_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue});
     settings.emplace_back(

--- a/tests/unit/layer_settings_positive.cpp
+++ b/tests/unit/layer_settings_positive.cpp
@@ -67,6 +67,9 @@ TEST_F(PositiveLayerSettings, AllSettings) {
         {OBJECT_LAYER_NAME, "gpuav_indirect_trace_rays_buffers", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "gpuav_buffer_copies", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "gpuav_index_buffers", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
+        {OBJECT_LAYER_NAME, "syncval_full_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
+        {OBJECT_LAYER_NAME, "syncval_record_time_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
+        // TODO: remove after refactor
         {OBJECT_LAYER_NAME, "syncval_submit_time_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "syncval_shader_accesses_heuristic", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "syncval_message_extra_properties", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -36,22 +36,31 @@ void VkSyncValTest::InitSyncValFramework(const SyncValSettings* p_sync_settings)
         // The main layer configuration can have some options turned off by default,
         // but we might still want that functionality to be available for testing.
         SyncValSettings settings;
-        settings.submit_time_validation = true;
+        settings.legacy_submit_time_validation = true;
         settings.shader_accesses_heuristic = true;
         settings.load_op_after_store_op_validation = true;
         return settings;
     }();
     const SyncValSettings& sync_settings = p_sync_settings ? *p_sync_settings : test_default_sync_settings;
 
-    const auto submit_time_validation = static_cast<VkBool32>(sync_settings.submit_time_validation);
+    const VkBool32 full_validation = static_cast<VkBool32>(sync_settings.full_validation);
+    settings.emplace_back(
+        VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_full_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &full_validation});
+
+    const VkBool32 record_time_validation = static_cast<VkBool32>(sync_settings.record_time_validation);
+    settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_record_time_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT,
+                                            1, &record_time_validation});
+
+    // TODO: remove after refactor
+    const VkBool32 submit_time_validation = static_cast<VkBool32>(sync_settings.legacy_submit_time_validation);
     settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_submit_time_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT,
                                             1, &submit_time_validation});
 
-    const auto shader_accesses_heuristic = static_cast<VkBool32>(sync_settings.shader_accesses_heuristic);
+    const VkBool32 shader_accesses_heuristic = static_cast<VkBool32>(sync_settings.shader_accesses_heuristic);
     settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_shader_accesses_heuristic",
                                             VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &shader_accesses_heuristic});
 
-    const auto load_op_after_store_op_validation = static_cast<VkBool32>(sync_settings.load_op_after_store_op_validation);
+    const VkBool32 load_op_after_store_op_validation = static_cast<VkBool32>(sync_settings.load_op_after_store_op_validation);
     settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_load_op_after_store_op_validation",
                                             VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &load_op_after_store_op_validation});
 
@@ -1359,7 +1368,7 @@ TEST_F(PositiveSyncVal, TexelBufferArrayConstantIndexing) {
 TEST_F(PositiveSyncVal, QSBufferCopyHazardsDisabled) {
     TEST_DESCRIPTION("This test checks that disabling syncval's submit time validation actually disables it");
     SyncValSettings settings;
-    settings.submit_time_validation = false;
+    settings.legacy_submit_time_validation = false;
     RETURN_IF_SKIP(InitSyncValFramework(&settings));
     RETURN_IF_SKIP(InitState());
 


### PR DESCRIPTION
`syncval_full_validation` - [new] The main validation mode. It validates all submitted accesses during `QueueSubmit`, not only command buffer boundaries as the current submit-time validation does. Later, we should investigate whether validation can optionally run during `Retire` for nicer integration with GPU-AV. This mode is expected to be faster than current record-time+submit-time because it does not need separate tracking of `first accesses`.

`syncval_record_time_validation` - [new] Performs the same validation as current implementation during command buffer recording. This pass is optional in the new design. Full validation checks everything, but its report is delayed until `QueueSubmit` or `Retire`. Record-time validation provides early reports, although it does not validate everything (full time validation still happens later). This is useful for development and debugging. Record time validation in general might be less robust than full validation and might not be able to avoid some false-positives (e.g. it can't be integrated with gpu-av). 

`syncval_submit_time_validation` - [current, legacy] The current submit-time validation, which checks command buffer boundaries. It will go away. The removal message will ask to use `syncval_full_validation` instead (that's not the same but will give the same effect). Removal of this mode also means removal of "first accesses" machinery which will save memory and improve performance for the new validation modes. 

The two new validation modes will share the same implementation. Both will just replay commands - record-time will store results in the command buffer context and full validation into the submission context. This differs from the current architecture, where record-time and submit-time use separate implementations.
