### PR TITLE
tests: Make PositiveThreading.Queue faster

### DIFF
--- a/tests/unit/threading_positive.cpp
+++ b/tests/unit/threading_positive.cpp
@@ -299,7 +299,7 @@ TEST_F(PositiveThreading, Queue) {
 
     std::mutex queue_mutex;
 
-    constexpr auto test_duration = seconds{2};
+    constexpr auto test_duration = milliseconds{150};
     const auto timer_begin = steady_clock::now();
 
     const auto& testing_thread1 = [&]() {


### PR DESCRIPTION
150ms is eternity. On my machine each loop on average runs thousands of iterations. It can be hundreds for some runs or in some cases only once because Windows, but that's also good for testing.