### PR TITLE
tests: Decrease test limits

### DIFF
--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -984,8 +984,12 @@ TEST_F(PositiveSyncVal, GetSemaphoreCounterFromMultipleThreads) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
-    constexpr uint64_t max_signal_value = 5'000;  // 15'000 in the original version for stress testing
-    constexpr int waiter_count = 8;               // 24 in the original version for stress testing
+    // 15'000 in the original version for stress testing, then 5K, now it's 1K
+    // Don't make it smaller, threading tests need iterations.
+    constexpr uint64_t max_signal_value = 1'000;
+
+    // 24 in the original version for stress testing, then 8, now it's 5
+    constexpr int waiter_count = 5;
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     ThreadTimeoutHelper timeout_helper(waiter_count + 1 /* signaling thread*/);

--- a/tests/unit/sync_val_wsi_positive.cpp
+++ b/tests/unit/sync_val_wsi_positive.cpp
@@ -149,7 +149,10 @@ TEST_F(PositiveSyncValWsi, ThreadedSubmitAndFenceWaitAndPresent) {
         GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
-    constexpr int N = 100;  // Initially 1000 for higher repro rate
+    // Initially 1000 for higher repro rate, then 100, now it's 50.
+    // Don't make it smaller, threading tests need iterations.
+    constexpr int N = 50;
+
     std::mutex queue_mutex;
 
     // Worker thread submits accesses and waits on the fence.
@@ -294,7 +297,7 @@ TEST_F(PositiveSyncValWsi, RecreateBuffer) {
     // NOTE: This test can be used for manual inspection of memory usage.
     // Increase frame count and observe that the test does not continuously allocate memory.
     // Syncval should not track ranges of deleted resources.
-    const int frame_count = 100;
+    const int frame_count = 20;
 
     for (int i = 0; i < frame_count; i++) {
         const uint32_t image_index = m_swapchain.AcquireNextImage(current_fence, kWaitTimeout);
@@ -354,7 +357,7 @@ TEST_F(PositiveSyncValWsi, RecreateImage) {
     // NOTE: This test can be used for manual inspection of memory usage.
     // Increase frame count and observe that the test does not continuously allocate memory.
     // Syncval should not track ranges of deleted resources.
-    const int frame_count = 100;
+    const int frame_count = 20;
 
     for (int i = 0; i < frame_count; i++) {
         const uint32_t image_index = m_swapchain.AcquireNextImage(current_fence, kWaitTimeout);
@@ -1086,7 +1089,11 @@ TEST_F(PositiveSyncValWsi, ConcurrentPresentAndSubmit) {
     }
 
     const auto swapchain_images = m_swapchain.GetImages();
-    const int N = 100;  // Initially 500 for higher repro rate
+
+    // Initially 500 for higher repro rate, then 100, now it's 50.
+    // Don't make it smaller, threading tests need iterations.
+    // In case of regression increase to 500 to simplify investigation.
+    const int N = 50;
 
     std::atomic<bool> bailout{false};
     monitor_.SetBailout(&bailout);
@@ -1145,9 +1152,15 @@ TEST_F(PositiveSyncValWsi, ConcurrentPresentMultipleSwapchains) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(InitSyncVal());
 
-    const uint32_t num_threads = 6; /* Initially 8 */
+    // Initially 8, now it's 6. We couldn't repro with 5.
+    // In case of regression increase to 8 to simplify investigation.
+    const uint32_t num_threads = 6;
+
+    // Initially 200, then 100, now it's 30.
+    // In case of regression increase to 200 to simplify investigation.
+    const uint32_t N = 30;
+
     const uint32_t num_frames_in_flight = 2;
-    const uint32_t N = 100; /* Initially 200 */
 
     std::mutex queue_mutex;
 

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -1380,7 +1380,10 @@ TEST_F(PositiveWsi, PresentFenceRetiresPresentQueueOperation) {
     };
     std::vector<Frame> frames;
 
-    for (uint32_t i = 0; i < 100 /* initially 1000 for higher repro rate*/; i++) {
+    // Initially 1000 for higher repro rate, then 100, now it's 50.
+    // Don't make it smaller.
+    uint32_t N = 50;
+    for (uint32_t i = 0; i < N; i++) {
         // Remove completed frames
         for (auto it = frames.begin(); it != frames.end();) {
             if (it->present_finished_fence.GetStatus() == VK_SUCCESS) {
@@ -2491,7 +2494,6 @@ TEST_F(PositiveWsi, ProgressOnPresentOnlyQueue) {
     }
     const auto swapchain_images = m_swapchain.GetImages();
 
-
     std::vector<vkt::Semaphore> present_wait_semaphores;
     for (size_t i = 0; i < swapchain_images.size(); i++) {
         present_wait_semaphores.emplace_back(*m_device);
@@ -2505,7 +2507,7 @@ TEST_F(PositiveWsi, ProgressOnPresentOnlyQueue) {
 
     // NOTE: This test can be used for manual inspection of memory usage.
     // Increase frame count and observe that the test does not continuously allocate memory.
-    const int frame_count = 100;
+    const int frame_count = 20;
     for (int i = 0; i < frame_count; i++) {
         const vkt::Fence& frame_fence = frame_fences[frame_index];
         const vkt::Semaphore& acquire_semaphore = acquire_semaphores[frame_index];
@@ -2894,7 +2896,6 @@ TEST_F(PositiveWsi, DestroySemaphoreUsedByOldSwapchain3) {
     m_default_queue->Wait();
 }
 
-
 TEST_F(PositiveWsi, PresentModeFifoLatestReady) {
     TEST_DESCRIPTION("Create a swapchain with present mode VK_PRESENT_MODE_FIFO_LATEST_READY_KHR");
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3090,7 +3091,7 @@ TEST_F(PositiveWsi, PresentTimings) {
     past_presentation_timing.timeDomain = VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT;
 
     // Give some time for a frame to land
-    static const uint32_t num_attempts = 100;
+    static const uint32_t num_attempts = 20;
     static const uint32_t wait_time_ms = 17;
     bool present_timing_returned = false;
     for (uint32_t attempt = 0; attempt < num_attempts; attempt++) {


### PR DESCRIPTION
Updated limits. Updated comments for the tests that are sensitive to iteration count. Some of these tests can become close to useless for really low iter count so keep some minimum values. It does not make them super fast but on my machine goes from 2 seconds to less than 1 second.

Some of the tests are less sensitive and just need some iteration count so could decrease the limit more freely.

Related to https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12334.

Did not touch presentation mode in WSI tests. The most affraid it's a different timing and sync behavior (may decide whether AcquireNextImage or Present block or not block for some iterations) and this can make some test not represent the original problem.  Also not sure how it works that IMMEDIATE is not guaratneed to be supported.