### PR TITLE
layers: Make PostSubmit process only new QueueSubmissions

### DIFF
--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -571,32 +571,31 @@ void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission>& submissions) {
     }
 }
 
-void QueueSubState::PostSubmit(std::deque<vvl::QueueSubmission>& submissions) {
-    bool success = true;
-    for (const auto& submission : submissions) {
-        auto loc = submission.loc.Get();
-        for (auto& cb_submission : submission.cb_submissions) {
-            auto guard = cb_submission.cb->ReadLock();
-            auto& gpu_cb = SubState(*cb_submission.cb);
-            success = gpu_cb.PostSubmit(*this, loc);
-            if (!success) {
-                return;
-            }
-            for (auto* secondary_cb : gpu_cb.base.linked_command_buffers) {
-                auto secondary_guard = secondary_cb->ReadLock();
-                auto& secondary_gpu_cb = SubState(*secondary_cb);
-                success = secondary_gpu_cb.PostSubmit(*this, loc);
-                if (!success) {
-                    return;
-                }
+bool QueueSubState::PostSubmit(vvl::QueueSubmission& submission) {
+    auto loc = submission.loc.Get();
+    if (loc.function == vvl::Func::vkQueuePresentKHR) {
+        // Present batches have no GPU-AV work and more importantly, they
+        // must not submit the barrier (the same check as in Retire).
+        return true;
+    }
+    for (auto& cb_submission : submission.cb_submissions) {
+        auto guard = cb_submission.cb->ReadLock();
+        auto& gpu_cb = SubState(*cb_submission.cb);
+        if (!gpu_cb.PostSubmit(*this, loc)) {
+            return false;
+        }
+        for (auto* secondary_cb : gpu_cb.base.linked_command_buffers) {
+            auto secondary_guard = secondary_cb->ReadLock();
+            auto& secondary_gpu_cb = SubState(*secondary_cb);
+            if (!secondary_gpu_cb.PostSubmit(*this, loc)) {
+                return false;
             }
         }
     }
-
-    if (!submissions.empty() && submissions.back().is_last_submission) {
-        auto loc = submissions.back().loc.Get();
-        SubmitBarrier(loc, submissions.back().seq);
+    if (submission.is_last_submission) {
+        SubmitBarrier(loc, submission.seq);
     }
+    return true;
 }
 
 void QueueSubState::Retire(vvl::QueueSubmission& submission) {

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -255,9 +255,9 @@ class QueueSubState : public vvl::QueueSubState {
     QueueSubState(Validator &gpuav, vvl::Queue &q);
     virtual ~QueueSubState();
 
-    void PreSubmit(std::vector<vvl::QueueSubmission> &submissions) override;
-    void PostSubmit(std::deque<vvl::QueueSubmission> &submissions) override;
-    void Retire(vvl::QueueSubmission &) override;
+    void PreSubmit(std::vector<vvl::QueueSubmission>& submissions) override;
+    bool PostSubmit(vvl::QueueSubmission& submission) override;
+    void Retire(vvl::QueueSubmission&) override;
 
     vko::SharedResourcesCache<false> shared_resources_cache;
 

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -104,6 +104,20 @@ uint64_t vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission>&& submissions) 
     }
     {
         auto guard = Lock();
+
+        // Register the seq of the first QueueSubmission that PostSubmit should process.
+        // submissions_ may contain previously submitted batches that were already
+        // PostSubmit-processed but have not been Retired yet.
+        if (!submissions.empty()) {
+            if (first_seq_to_post_process_ == 0) {
+                first_seq_to_post_process_ = submissions.front().seq;
+            } else {
+                // PreSubmit can run twice without a PostSubmit in between (e.g. internally sync queues).
+                // Take the smaller seq so the earlier batch is not skipped.
+                first_seq_to_post_process_ = std::min(first_seq_to_post_process_, submissions.front().seq);
+            }
+        }
+
         submissions_.insert(submissions_.end(), std::make_move_iterator(submissions.begin()),
                             std::make_move_iterator(submissions.end()));
         if (!thread_) {
@@ -111,6 +125,30 @@ uint64_t vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission>&& submissions) 
         }
     }
     return last_batch_seq;
+}
+
+void vvl::Queue::PostSubmit() {
+    auto guard = Lock();
+    if (!submissions_.empty()) {
+        if (first_seq_to_post_process_ != 0) {
+            for (auto& item : sub_states_) {
+                for (vvl::QueueSubmission& submission : submissions_) {
+                    if (submission.seq < first_seq_to_post_process_) {
+                        continue;
+                    }
+                    if (!item.second->PostSubmit(submission)) {
+                        break;
+                    }
+                }
+            }
+        }
+        // Wait on the external fence because we may not be able to track when it's signaled
+        QueueSubmission& submission = submissions_.back();
+        if (submission.has_external_fence) {
+            submission.fence->NotifyAndWait(submission.loc.Get());
+        }
+    }
+    first_seq_to_post_process_ = 0;
 }
 
 void vvl::Queue::Notify(uint64_t until_seq) {
@@ -273,20 +311,6 @@ void vvl::Queue::Destroy() {
         item.second->Destroy();
     }
     StateObject::Destroy();
-}
-
-void vvl::Queue::PostSubmit() {
-    auto guard = Lock();
-    if (!submissions_.empty()) {
-        for (auto& item : sub_states_) {
-            item.second->PostSubmit(submissions_);
-        }
-        // Wait on the external fence because we may not be able to track when it's signaled
-        QueueSubmission& submission = submissions_.back();
-        if (submission.has_external_fence) {
-            submission.fence->NotifyAndWait(submission.loc.Get());
-        }
-    }
 }
 
 vvl::QueueSubmission* vvl::Queue::NextSubmission() {

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -223,6 +223,7 @@ class Queue : public StateObject, public SubStateManager<QueueSubState> {
     std::deque<QueueSubmission> submissions_;
     std::atomic<uint64_t> seq_{0};
     uint64_t request_seq_{0};
+    uint64_t first_seq_to_post_process_{0};
     bool exit_thread_{false};
     mutable std::mutex lock_;
     // condition to wake up the queue's thread
@@ -245,9 +246,12 @@ class QueueSubState {
     virtual ~QueueSubState() {}
     virtual void Destroy() {}
 
-    virtual void PreSubmit(std::vector<QueueSubmission> &submissions) {}
-    virtual void PostSubmit(std::deque<QueueSubmission> &submissions_) {}
-    virtual void Retire(QueueSubmission &submission) {}
+    virtual void PreSubmit(std::vector<QueueSubmission>& submissions) {}
+
+    // Return false in case of failure to stop processing the remaining batches from the same submit
+    virtual bool PostSubmit(QueueSubmission& submission) { return true; }
+
+    virtual void Retire(QueueSubmission& submission) {}
 
     VulkanTypedHandle Handle() const { return base.Handle(); }
     VkQueue VkHandle() const { return base.VkHandle(); }

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -16,7 +16,9 @@
  */
 
 #include <vulkan/vulkan_core.h>
+#include <atomic>
 #include <cstdint>
+#include <thread>
 #include <vector>
 #include "layer_validation_tests.h"
 #include "buffer_helper.h"
@@ -2890,4 +2892,49 @@ TEST_F(PositiveGpuAV, ImmutableSamplerIdenticallyDefinedMaintenance4) {
     m_command_buffer.End();
 
     m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+TEST_F(PositiveGpuAV, QueueSubmitDuringQueryRetire) {
+    // Regression test for a deadlock between:
+    //   a) a submitting thread (Queue lock -> CB lock in GPU-AV PostSubmit)
+    //   b) the queue thread (CB lock -> Queue lock in query retirement)
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12899");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredFeature(vkt::Feature::timelineSemaphore);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+    if (m_device->Physical().queue_properties_[m_device->graphics_queue_node_index_].timestampValidBits == 0) {
+        GTEST_SKIP() << "Device graphic queue has timestampValidBits of 0, skipping.";
+    }
+
+    const uint32_t query_count = 32;
+    vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, query_count);
+
+    m_command_buffer.Begin();
+    vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, query_count);
+    for (uint32_t i = 0; i < query_count; i++) {
+        vk::CmdWriteTimestamp(m_command_buffer, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool, i);
+    }
+    m_command_buffer.End();
+
+    vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
+    for (uint64_t i = 0; i < 10; i++) {
+        m_default_queue->Submit(m_command_buffer, vkt::TimelineSignal(semaphore, i + 1));
+
+        // Start waiting for submission to initiate Retire on the queue thread
+        std::atomic<bool> wait_finished{false};
+        std::thread waiter([&semaphore, &wait_finished, i] {
+            semaphore.Wait(i + 1, kWaitTimeout);
+            wait_finished = true;
+        });
+
+        // Before the fix, PostSubmit (that does Queue lock -> CB lock) was mistakenly
+        // re-applied to batches from the previous submissions . If such a batch was in
+        // the middle of query retirement (CB lock -> Queue lock) this led to deadlock.
+        while (!wait_finished) {
+            m_default_queue->Submit(vkt::no_cmd);
+        }
+        waiter.join();
+        m_default_queue->Wait();
+    }
 }


### PR DESCRIPTION
The first part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12899 fix.

There was this problem with `QueueSubmit(new_batches)` processing:
```
PreSubmit(new_batches)
submissions_ += new_batches
PostSubmit(submissions_) // !!! has to be PostSubmit(new_batches)
```

`PostSubmit` has to process newly submitted batches, but in the current code it processes all pending batches (`submissions_`) - the extra batches were already PostSubmit-processed. This was introduced in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10206. This PR detects which batches in the `submissions_` list correspond to `new_batches` and processes only those.

This duplication of PostProcess exposed a mutex lock inversion. This PR is not a fix of the lock inversion but rather a removal of the situation in which it happens. There is another way to trigger the lock inversion by resubmitting the same command buffer. I will use that scenario to fix the lock inversion as a separate change.