### PR TITLE
layers: Fix lock inversion during query retirement

### DIFF
--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -1161,15 +1161,29 @@ void CommandBufferSubState::RecordEncodeVideo(vvl::VideoSession& vs_state, const
     }
 }
 
-void CommandBufferSubState::Retire(uint32_t perf_submit_pass,
-                                   const std::function<bool(const QueryObject&)>& is_query_updated_after) {
+QueryMap CommandBufferSubState::GetLocalQueryMap(uint32_t perf_submit_pass) const {
     QueryMap local_query_to_state_map;
     VkQueryPool first_pool = VK_NULL_HANDLE;
     for (auto& function : query_updates) {
         function(base, /*do_validate*/ false, first_pool, perf_submit_pass, &local_query_to_state_map);
     }
+    return local_query_to_state_map;
+}
 
-    for (const auto& [query_object, query_state] : local_query_to_state_map) {
+void CommandBufferSubState::RetireQueries(uint32_t perf_submit_pass, const QuerySubmissionSnapshot& submission_snapshot) {
+    auto is_query_updated_after = [&submission_snapshot](const QueryObject& query_object) {
+        for (const auto& [snapshot_perf_submit_pass, snapshot_cb] : submission_snapshot) {
+            if (query_object.perf_pass != snapshot_perf_submit_pass) {
+                continue;
+            }
+            if (snapshot_cb->UpdatesQuery(query_object)) {
+                return true;
+            }
+        }
+        return false;
+    };
+    const QueryMap local_query_map = GetLocalQueryMap(perf_submit_pass);
+    for (const auto& [query_object, query_state] : local_query_map) {
         if (query_state == QUERYSTATE_ENDED && !is_query_updated_after(query_object)) {
             auto query_pool_state = base.dev_data.Get<vvl::QueryPool>(query_object.pool);
             if (!query_pool_state) continue;
@@ -1361,11 +1375,7 @@ void CommandBufferSubState::Submit(vvl::Queue& queue_state, uint32_t perf_submit
     // Update vvl::QueryPool with a query state at the end of the command buffer.
     // Ultimately, it tracks the final query state for the entire submission.
     {
-        VkQueryPool first_pool = VK_NULL_HANDLE;
-        QueryMap local_query_to_state_map;
-        for (auto& function : query_updates) {
-            function(base, /*do_validate*/ false, first_pool, perf_submit_pass, &local_query_to_state_map);
-        }
+        const QueryMap local_query_to_state_map = GetLocalQueryMap(perf_submit_pass);
         for (const auto& [query_object, query_state] : local_query_to_state_map) {
             auto query_pool_state = base.dev_data.Get<vvl::QueryPool>(query_object.pool);
             if (!query_pool_state) continue;
@@ -1389,26 +1399,24 @@ void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission>& submissions) {
 }
 
 void QueueSubState::Retire(vvl::QueueSubmission& submission) {
-    auto is_query_updated_after = [this](const QueryObject& query_object) {
+    // Create snapshot of submission related information for queries (locks queue)
+    // before locking command buffers below. This is to avoid lock inversion with
+    // Queue::PostSubmit which also locks queue and then command buffers.
+    CommandBufferSubState::QuerySubmissionSnapshot submission_snapshot;
+    {
         auto guard = base.Lock();
-        bool first_queue_submission = true;
+        bool first_batch = true;
         for (const vvl::QueueSubmission& queue_submission : base.Submissions()) {
             // The current submission is still on the deque, so skip it
-            if (first_queue_submission) {
-                first_queue_submission = false;
+            if (first_batch) {
+                first_batch = false;
                 continue;
             }
             for (const vvl::CommandBufferSubmission& cb_submission : queue_submission.cb_submissions) {
-                if (query_object.perf_pass != queue_submission.perf_submit_pass) {
-                    continue;
-                }
-                if (cb_submission.cb->UpdatesQuery(query_object)) {
-                    return true;
-                }
+                submission_snapshot.emplace_back(queue_submission.perf_submit_pass, cb_submission.cb);
             }
         }
-        return false;
-    };
+    }
 
     for (vvl::CommandBufferSubmission& cb_submission : submission.cb_submissions) {
         CommandBufferSubState& cb_sub_state = SubState(*cb_submission.cb);
@@ -1416,9 +1424,9 @@ void QueueSubState::Retire(vvl::QueueSubmission& submission) {
         for (vvl::CommandBuffer* secondary_cmd_buffer : cb_submission.cb->linked_command_buffers) {
             CommandBufferSubState& secondary_sub_state = SubState(*secondary_cmd_buffer);
             auto secondary_guard = secondary_sub_state.base.WriteLock();
-            secondary_sub_state.Retire(submission.perf_submit_pass, is_query_updated_after);
+            secondary_sub_state.RetireQueries(submission.perf_submit_pass, submission_snapshot);
         }
-        cb_sub_state.Retire(submission.perf_submit_pass, is_query_updated_after);
+        cb_sub_state.RetireQueries(submission.perf_submit_pass, submission_snapshot);
     }
 }
 

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -128,8 +128,10 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordDecodeVideo(vvl::VideoSession &vs_state, const VkVideoDecodeInfoKHR &decode_info, const Location &loc) final;
     void RecordEncodeVideo(vvl::VideoSession &vs_state, const VkVideoEncodeInfoKHR &encode_info, const Location &loc) final;
 
+    QueryMap GetLocalQueryMap(uint32_t perf_submit_pass) const;
     // Only need to retire for core checks to track queries
-    void Retire(uint32_t perf_submit_pass, const std::function<bool(const QueryObject &)> &is_query_updated_after);
+    using QuerySubmissionSnapshot = std::vector<std::pair<uint32_t, std::shared_ptr<vvl::CommandBuffer>>>;
+    void RetireQueries(uint32_t perf_submit_pass, const QuerySubmissionSnapshot& submission_snapshot);
 
     void Reset(const Location &loc) final;
     void Destroy() final;

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -2968,3 +2968,44 @@ TEST_F(PositiveGpuAV, QueueSubmitDuringQueryRetire) {
         m_default_queue->Wait();
     }
 }
+
+TEST_F(PositiveGpuAV, QueueSubmitDuringQueryRetire2) {
+    // Similar to QueueSubmitDuringQueryRetire but resubmits the same command buffer
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12899");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredFeature(vkt::Feature::timelineSemaphore);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+    if (m_device->Physical().queue_properties_[m_device->graphics_queue_node_index_].timestampValidBits == 0) {
+        GTEST_SKIP() << "Device graphics queue has timestampValidBits of 0, skipping.";
+    }
+
+    const uint32_t query_count = 32;
+    vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, query_count);
+
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, query_count);
+    for (uint32_t i = 0; i < query_count; i++) {
+        vk::CmdWriteTimestamp(m_command_buffer, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool, i);
+    }
+    m_command_buffer.End();
+
+    vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
+    for (uint64_t i = 0; i < 10; i++) {
+        m_default_queue->Submit(m_command_buffer, vkt::TimelineSignal(semaphore, i + 1));
+
+        // Start waiting for submission to initiate Retire on the queue thread
+        std::atomic<bool> wait_finished{false};
+        std::thread waiter([&semaphore, &wait_finished, i] {
+            semaphore.Wait(i + 1, kWaitTimeout);
+            wait_finished = true;
+        });
+
+        // Resubmit the same command buffer
+        while (!wait_finished) {
+            m_default_queue->Submit(m_command_buffer);
+        }
+        waiter.join();
+        m_default_queue->Wait();
+    }
+}


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12899

NOTE: The added test found likely GPU-AV issue related to FenceWaiter (it can crash on fence wait). That issue is reproduciable without my today's changes, so it has to be pre-existed. Going to fix that and then either extend this PR or make it a separate fix if it can be reproduced separately. UPDATE: Fixed by https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12916

