### PR TITLE
gpuav: Fix FenceWaiter access by multiple threads

### DIFF
--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -30,6 +30,8 @@
 #include "state_tracker/last_bound_state.h"
 #include "state_tracker/pipeline_layout_state.h"
 
+#include <mutex>
+
 namespace gpuav {
 
 CommandBufferSubState::CommandBufferSubState(Validator& gpuav, vvl::CommandBuffer& cb)
@@ -298,6 +300,8 @@ vko::Buffer& CommandBufferSubState::GetInternalDescriptorHeap() {
 }
 
 struct FenceWaiter {
+    // FenceWaiter is accessed by PostSubmit and by queue thread's Retire at the same time.
+    std::mutex lock;
     std::vector<VkFence> fences;
 };
 
@@ -358,6 +362,7 @@ bool CommandBufferSubState::PostSubmit(QueueSubState& queue, const Location& loc
         }
 
         FenceWaiter& fence_waiter = queue.shared_resources_cache.GetOrCreate<FenceWaiter>();
+        std::lock_guard<std::mutex> fence_waiter_guard(fence_waiter.lock);
         fence_waiter.fences.emplace_back(fence);
     }
 
@@ -619,11 +624,18 @@ void QueueSubState::Retire(vvl::QueueSubmission& submission) {
             DispatchWaitSemaphores(gpuav_.device, &wait_info, 1'000'000'000);
         }
 
-        FenceWaiter* fence_waiter = shared_resources_cache.TryGet<FenceWaiter>();
-        if (fence_waiter && !fence_waiter->fences.empty()) {
-            DispatchWaitForFences(gpuav_.device, uint32_t(fence_waiter->fences.size()), fence_waiter->fences.data(), VK_TRUE,
-                                  UINT64_MAX);
-            fence_waiter->fences.clear();
+        if (FenceWaiter* fence_waiter = shared_resources_cache.TryGet<FenceWaiter>()) {
+            std::vector<VkFence> fences;
+            // Lock for a short time just to move the fences, so DispatchWaitForFences
+            // below does not block PostSubmit from adding new fences.
+            {
+                std::lock_guard<std::mutex> fence_waiter_guard(fence_waiter->lock);
+                fences = std::move(fence_waiter->fences);
+                fence_waiter->fences.clear();
+            }
+            if (!fences.empty()) {
+                DispatchWaitForFences(gpuav_.device, uint32_t(fences.size()), fences.data(), VK_TRUE, UINT64_MAX);
+            }
         }
 
         for (std::vector<vvl::CommandBufferSubmission>& cb_submissions : retiring_) {

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -259,7 +259,8 @@ class QueueSubState : public vvl::QueueSubState {
     bool PostSubmit(vvl::QueueSubmission& submission) override;
     void Retire(vvl::QueueSubmission&) override;
 
-    vko::SharedResourcesCache<false> shared_resources_cache;
+    // Accessed from both the submitting thread (PreSubmit/PostSubmit) and the queue thread (Retire)
+    vko::SharedResourcesCache<true> shared_resources_cache;
 
   protected:
     void SubmitBarrier(const Location &loc, uint64_t seq);

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -2894,6 +2894,36 @@ TEST_F(PositiveGpuAV, ImmutableSamplerIdenticallyDefinedMaintenance4) {
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
 
+TEST_F(PositiveGpuAV, QueueSubmitAndRetirement) {
+    TEST_DESCRIPTION("Concurrent QueueSubmit and submission retirement on the queue thread");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredFeature(vkt::Feature::timelineSemaphore);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.End();
+
+    vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
+    for (uint64_t i = 0; i < 10; i++) {
+        m_default_queue->Submit(m_command_buffer, vkt::TimelineSignal(semaphore, i + 1));
+
+        // Start waiting for the submission to initiate Retire on the queue thread
+        std::atomic<bool> wait_finished{false};
+        std::thread waiter([&semaphore, &wait_finished, i] {
+            semaphore.Wait(i + 1, kWaitTimeout);
+            wait_finished = true;
+        });
+
+        // Keep submitting while the queue thread retires earlier submissions
+        while (!wait_finished) {
+            m_default_queue->Submit(m_command_buffer);
+        }
+        waiter.join();
+        m_default_queue->Wait();
+    }
+}
+
 TEST_F(PositiveGpuAV, QueueSubmitDuringQueryRetire) {
     // Regression test for a deadlock between:
     //   a) a submitting thread (Queue lock -> CB lock in GPU-AV PostSubmit)


### PR DESCRIPTION
This fixes an additional issue found by https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12915.

`FenceWaiter` can be accessed both by `PostSubmit` main thread and `Retire`'s queue thread.
