### PR TITLE
build: Update Slang version

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -124,7 +124,7 @@
             "sub_dir": "slang",
             "build_dir": "slang/download",
             "install_dir": "slang/install",
-            "release": "2025.19.1",
+            "release": "2026.14.1",
             "url_format_map": {
                 "64": "x86_64",
                 "x64": "x86_64",


### PR DESCRIPTION
We are planning to use Slang for GPU-AV to build the offline SPIR-V and wanted to update the Slang version first before we stick to it for a while

We picked this version because it is the latest version on compiler-explorer (godbolt) to test with