### PR TITLE
sync: Introduce command objects for validation

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -408,6 +408,8 @@ vvl_sources = [
   "layers/sync/sync_access_state.h",
   "layers/sync/sync_barrier.cpp",
   "layers/sync/sync_barrier.h",
+  "layers/sync/sync_command.cpp",
+  "layers/sync/sync_command.h",
   "layers/sync/sync_command_buffer.cpp",
   "layers/sync/sync_command_buffer.h",
   "layers/sync/sync_common.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -495,6 +495,8 @@ target_sources(vvl PRIVATE
     sync/sync_access_state.h
     sync/sync_barrier.cpp
     sync/sync_barrier.h
+    sync/sync_command.cpp
+    sync/sync_command.h
     sync/sync_command_buffer.cpp
     sync/sync_command_buffer.h
     sync/sync_common.cpp

--- a/layers/containers/span.h
+++ b/layers/containers/span.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ class enumeration {
     using const_pointer = T const *;
     using iterator = Iterator;
     using const_iterator = const Iterator;
+    using value_type = std::remove_cv_t<T>;
+    using size_type = size_t;
 
     enumeration() = default;
     enumeration(pointer start, size_t n) : data_(start), count_(n) {}

--- a/layers/sync/sync_command.cpp
+++ b/layers/sync/sync_command.cpp
@@ -1,0 +1,56 @@
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sync/sync_command.h"
+#include "sync/sync_access_context.h"
+#include "sync/sync_command_buffer.h"
+#include "sync/sync_validation.h"
+#include "state_tracker/buffer_state.h"
+#include "error_message/logging.h"
+
+namespace syncval {
+
+bool BufferCopyCommand::Validate(const SyncEnvironment& env, const AccessContext& access_context, const Location& loc,
+                                 VulkanTypedHandle command_buffer_handle) const {
+    bool skip = false;
+    const SyncValidator& validator = env.validator;
+
+    for (const auto [region_index, copy_region] : vvl::enumerate(regions)) {
+        const AccessRange src_range = MakeRange(src_buffer, copy_region.src_offset, copy_region.size);
+        auto src_hazard = access_context.DetectHazard(src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
+        if (src_hazard.IsHazard()) {
+            const LogObjectList objlist(command_buffer_handle, src_buffer.Handle());
+            const std::string error = validator.error_messages_.BufferCopyError(
+                env, src_hazard, loc.function, validator.FormatHandle(src_buffer), uint32_t(region_index), src_range);
+            skip |= validator.SyncError(src_hazard.Hazard(), objlist, loc, error);
+        }
+        const AccessRange dst_range = MakeRange(dst_buffer, copy_region.dst_offset, copy_region.size);
+        auto dst_hazard = access_context.DetectHazard(dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
+        if (dst_hazard.IsHazard()) {
+            const LogObjectList objlist(command_buffer_handle, dst_buffer.Handle());
+            const std::string error = validator.error_messages_.BufferCopyError(
+                env, dst_hazard, loc.function, validator.FormatHandle(dst_buffer), uint32_t(region_index), dst_range);
+            skip |= validator.SyncError(dst_hazard.Hazard(), objlist, loc, error);
+        }
+        if (skip) {
+            break;
+        }
+    }
+    return skip;
+}
+
+}  // namespace syncval

--- a/layers/sync/sync_command.h
+++ b/layers/sync/sync_command.h
@@ -1,0 +1,76 @@
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "sync/sync_common.h"
+#include "containers/span.h"
+
+struct Location;
+struct VulkanTypedHandle;
+
+namespace vvl {
+class Buffer;
+}  // namespace vvl
+
+namespace syncval {
+
+class AccessContext;
+struct SyncEnvironment;
+
+struct BufferCopyRegion {
+    VkDeviceSize src_offset;
+    VkDeviceSize dst_offset;
+    VkDeviceSize size;
+};
+
+struct BufferCopyCommand {
+    const vvl::Buffer& src_buffer;
+    const vvl::Buffer& dst_buffer;
+    vvl::span<const BufferCopyRegion> regions;
+    uint32_t src_handle_index = vvl::kNoIndex32;
+    uint32_t dst_handle_index = vvl::kNoIndex32;
+
+    struct Storage {
+        uint32_t src_buffer_index;
+        uint32_t dst_buffer_index;
+        uint32_t first_region;
+        uint32_t region_count;
+        uint32_t src_handle_index;
+        uint32_t dst_handle_index;
+    };
+
+    bool Validate(const SyncEnvironment& env, const AccessContext& access_context, const Location& loc,
+                  VulkanTypedHandle command_buffer_handle) const;
+};
+
+using CommandStorage = std::variant<BufferCopyCommand::Storage>;
+
+// TODO: CommandEntry won't be needed after all commands are introduced.
+// Tag could be derived from command index. Remove entry type when and
+// use array of commands instead.
+struct CommandEntry {
+    ResourceUsageTag tag;
+    CommandStorage command;
+};
+
+struct CommandData {
+    std::vector<std::shared_ptr<vvl::Buffer>> buffers;
+    std::vector<BufferCopyRegion> buffer_copy_regions;
+};
+
+}  // namespace syncval

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -322,6 +322,9 @@ void CommandBufferContext::Reset() {
         cbs_referenced_->push_back(cb_state_->shared_from_this());
     }
     replay_entries_.clear();
+    commands_.clear();
+    command_data_ = {};
+
     command_number_ = 0;
     reset_count_++;
 

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include "sync/sync_command.h"
 #include "sync/sync_event.h"
 #include "sync/sync_render_pass.h"
 #include "sync/sync_replay.h"
@@ -323,6 +324,9 @@ class CommandBufferContext final : public ResourceUsageInfoProvider, public Debu
     std::vector<std::unique_ptr<RenderPassAccessContext>> render_pass_contexts_;
     RenderPassAccessContext* current_renderpass_context_;
     std::vector<ReplayEntry> replay_entries_;
+
+    std::vector<CommandEntry> commands_;
+    CommandData command_data_;
 
     // State during dynamic rendering (dynamic rendering rendering passes must be
     // contained within a single command buffer)

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -58,8 +58,8 @@ std::string ErrorMessages::BufferError(const HazardResult& hazard, const Command
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "BufferError", additional_info);
 }
 
-std::string ErrorMessages::BufferCopyError(const HazardResult& hazard, const CommandBufferContext& cb_context,
-                                           const vvl::Func command, const std::string& resource_description, uint32_t region_index,
+std::string ErrorMessages::BufferCopyError(const SyncEnvironment& env, const HazardResult& hazard, const vvl::Func command,
+                                           const std::string& resource_description, uint32_t region_index,
                                            AccessRange range) const {
     AdditionalMessageInfo additional_info;
     additional_info.properties.Add(kPropertyRegionIndex, region_index);
@@ -71,7 +71,7 @@ std::string ErrorMessages::BufferCopyError(const HazardResult& hazard, const Com
     ss << "}\n";
     additional_info.message_end_text = ss.str();
 
-    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "BufferCopyError", additional_info);
+    return Error(env, hazard, command, resource_description, "BufferCopyError", additional_info);
 }
 
 std::string ErrorMessages::AccelerationStructureError(const HazardResult& hazard, const CommandBufferContext& cb_context,

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -50,7 +50,7 @@ class ErrorMessages {
                             const std::string& resource_description, const AccessRange range,
                             AdditionalMessageInfo additional_info = {}) const;
 
-    std::string BufferCopyError(const HazardResult& hazard, const CommandBufferContext& cb_context, const vvl::Func command,
+    std::string BufferCopyError(const SyncEnvironment& env, const HazardResult& hazard, const vvl::Func command,
                                 const std::string& resouce_description, uint32_t region_index, AccessRange range) const;
 
     std::string AccelerationStructureError(const HazardResult& hazard, const CommandBufferContext& cb_context,

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -374,41 +374,25 @@ void SyncValidator::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchai
 bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
                                                  uint32_t regionCount, const VkBufferCopy* pRegions,
                                                  const ErrorObject& error_obj) const {
-    bool skip = false;
-    const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
-    const AccessContext& access_context = cb_context.GetCbAccessContext();
-
-    // If we have no previous accesses, we have no hazards
+    if (!syncval_settings.IsRecordTimeValidationEnabled()) {
+        return false;
+    }
     auto src_buffer = Get<vvl::Buffer>(srcBuffer);
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
-
-    for (const auto [region_index, copy_region] : vvl::enumerate(pRegions, regionCount)) {
-        if (src_buffer) {
-            const AccessRange src_range = MakeRange(*src_buffer, copy_region.srcOffset, copy_region.size);
-            auto hazard = access_context.DetectHazard(*src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
-            if (hazard.IsHazard()) {
-                const LogObjectList objlist(commandBuffer, srcBuffer);
-                const std::string error = error_messages_.BufferCopyError(hazard, cb_context, error_obj.location.function,
-                                                                          FormatHandle(srcBuffer), region_index, src_range);
-                skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
-            }
-        }
-        if (dst_buffer) {
-            const AccessRange dst_range = MakeRange(*dst_buffer, copy_region.dstOffset, copy_region.size);
-            auto hazard = access_context.DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
-            if (hazard.IsHazard()) {
-                const LogObjectList objlist(commandBuffer, dstBuffer);
-                const std::string error = error_messages_.BufferCopyError(hazard, cb_context, error_obj.location.function,
-                                                                          FormatHandle(dstBuffer), region_index, dst_range);
-                skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
-            }
-        }
-        if (skip) {
-            break;
-        }
+    if (!src_buffer || !dst_buffer) {
+        return false;
     }
-    return skip;
+    const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+
+    small_vector<BufferCopyRegion, 1> regions;
+    regions.reserve(regionCount);
+    for (const VkBufferCopy& region : vvl::make_span(pRegions, regionCount)) {
+        regions.emplace_back(BufferCopyRegion{region.srcOffset, region.dstOffset, region.size});
+    }
+    const BufferCopyCommand command{*src_buffer, *dst_buffer, regions};
+    return command.Validate(cb_context.GetSyncEnvironment(), cb_context.GetCbAccessContext(), error_obj.location,
+                            cb_state->Handle());
 }
 
 bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo,
@@ -431,7 +415,7 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
                 // TODO: there are no tests for this error
                 const LogObjectList objlist(commandBuffer, pCopyBufferInfo->srcBuffer);
                 const std::string error =
-                    error_messages_.BufferCopyError(hazard, cb_context, error_obj.location.function,
+                    error_messages_.BufferCopyError(cb_context.GetSyncEnvironment(), hazard, error_obj.location.function,
                                                     FormatHandle(pCopyBufferInfo->srcBuffer), region_index, src_range);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
@@ -443,7 +427,7 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
                 // TODO: there are no tests for this error
                 const LogObjectList objlist(commandBuffer, pCopyBufferInfo->dstBuffer);
                 const std::string error =
-                    error_messages_.BufferCopyError(hazard, cb_context, error_obj.location.function,
+                    error_messages_.BufferCopyError(cb_context.GetSyncEnvironment(), hazard, error_obj.location.function,
                                                     FormatHandle(pCopyBufferInfo->dstBuffer), region_index, dst_range);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
@@ -940,7 +924,7 @@ bool SyncValidator::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, 
                 if (hazard.IsHazard()) {
                     // PHASE1 TODO -- add tag information to log msg when useful.
                     const LogObjectList objlist(commandBuffer, srcBuffer);
-                    const std::string error = error_messages_.BufferCopyError(hazard, cb_context, loc.function,
+                    const std::string error = error_messages_.BufferCopyError(cb_context.GetSyncEnvironment(), hazard, loc.function,
                                                                               FormatHandle(srcBuffer), region_index, src_range);
                     skip |= SyncError(hazard.Hazard(), objlist, loc, error);
                 }
@@ -1011,7 +995,7 @@ bool SyncValidator::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, 
                 hazard = access_context.DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, dstBuffer);
-                    const std::string error = error_messages_.BufferCopyError(hazard, cb_context, loc.function,
+                    const std::string error = error_messages_.BufferCopyError(cb_context.GetSyncEnvironment(), hazard, loc.function,
                                                                               FormatHandle(dstBuffer), region_index, dst_range);
                     skip |= SyncError(hazard.Hazard(), objlist, loc, error);
                 }


### PR DESCRIPTION
Move vkCmdCopyBuffer record-time validation into BufferCopyCommand.

Introduce initial design concepts that are not used yet.

BufferCopyCommand::Storage is a compact representation of the command. It will be stored during command buffer recording. The validation itself works with full BufferCopyCommand.

CommandData stores variable-sized data and avoids per-command allocations and can support deduplication if needed.