### PR TITLE
sync: Introduce command replay during queue submission

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -462,7 +462,7 @@ AccessMap::iterator AccessContext::ResolveGapRecursePrev(const AccessRange& gap_
 // Map entries that intersect range.begin or range.end are split at the intersection point.
 AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, const AccessRange& range,
                                                        SyncAccessIndex access_index, const AttachmentAccess& attachment_access,
-                                                       ResourceUsageTagEx tag_ex, SyncFlags flags) {
+                                                       ResourceUsageTagEx tag_ex, SyncFlags flags, QueueId queue_id) {
     assert(range.non_empty());
     const SyncAccessInfo& access_info = GetAccessInfo(access_index);
 
@@ -499,7 +499,7 @@ AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, 
             // Update
             AccessState& new_access_state = infilled_it->second;
             ApplyGlobalBarriers(new_access_state);
-            new_access_state.Update(access_info, attachment_access, tag_ex, flags);
+            new_access_state.Update(access_info, attachment_access, tag_ex, flags, queue_id);
 
             // Advance current location.
             // Do not advance pos, as it's the next map entry to visit
@@ -516,7 +516,7 @@ AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, 
             // Update
             AccessState& access_state = pos->second;
             ApplyGlobalBarriers(access_state);
-            access_state.Update(access_info, attachment_access, tag_ex, flags);
+            access_state.Update(access_info, attachment_access, tag_ex, flags, queue_id);
 
             // Advance both current location and map entry
             current_begin = pos->first.end;
@@ -532,13 +532,13 @@ AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, 
         // Update
         AccessState& new_access_state = infilled_it->second;
         ApplyGlobalBarriers(new_access_state);
-        new_access_state.Update(access_info, attachment_access, tag_ex, flags);
+        new_access_state.Update(access_info, attachment_access, tag_ex, flags, queue_id);
     }
     return pos;
 }
 
 void AccessContext::UpdateAccessState(const vvl::Buffer& buffer, SyncAccessIndex current_usage, const AccessRange& range,
-                                      ResourceUsageTagEx tag_ex, SyncFlags flags) {
+                                      ResourceUsageTagEx tag_ex, SyncFlags flags, QueueId queue_id) {
     assert(range.valid());
     assert(!finalized_);
 
@@ -556,7 +556,7 @@ void AccessContext::UpdateAccessState(const vvl::Buffer& buffer, SyncAccessIndex
     const AccessRange buffer_range = range + base_address;
 
     auto pos = access_state_map_.LowerBound(buffer_range.begin);
-    DoUpdateAccessState(pos, buffer_range, current_usage, AttachmentAccess::NonAttachment(), tag_ex, flags);
+    DoUpdateAccessState(pos, buffer_range, current_usage, AttachmentAccess::NonAttachment(), tag_ex, flags, queue_id);
 }
 
 void AccessContext::UpdateAccessState(ImageRangeGen& range_gen, SyncAccessIndex current_usage, ResourceUsageTagEx tag_ex,

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -272,7 +272,7 @@ class AccessContext {
     void ResolveChildContexts(vvl::span<AccessContext> subpass_contexts);
 
     void UpdateAccessState(const vvl::Buffer& buffer, SyncAccessIndex current_usage, const AccessRange& range,
-                           ResourceUsageTagEx tag_ex, SyncFlags flags = 0);
+                           ResourceUsageTagEx tag_ex, SyncFlags flags = 0, QueueId queue_id = kQueueIdInvalid);
     void UpdateAccessState(ImageRangeGen& range_gen, SyncAccessIndex current_usage, ResourceUsageTagEx tag_ex, SyncFlags flags = 0);
     void UpdateAttachmentAccessState(ImageRangeGen& range_gen, SyncAccessIndex current_usage,
                                      const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex);
@@ -420,7 +420,8 @@ class AccessContext {
     AccessMap::iterator ResolveGapRecursePrev(const AccessRange& gap_range, AccessMap::iterator pos_hint);
 
     AccessMap::iterator DoUpdateAccessState(AccessMap::iterator pos, const AccessRange& range, SyncAccessIndex access_index,
-                                            const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex, SyncFlags flags);
+                                            const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex, SyncFlags flags,
+                                            QueueId queue_id = kQueueIdInvalid);
 
     // A recursive range walkers for hazard detection, first for the current context
     // and then walks the DAG of the contexts for subpasses

--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -523,7 +523,7 @@ void AccessState::Resolve(const AccessState& other) {
 }
 
 void AccessState::Update(const SyncAccessInfo& usage_info, const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex,
-                         SyncFlags flags) {
+                         SyncFlags flags, QueueId queue_id) {
     const VkPipelineStageFlagBits2 usage_stage = usage_info.stage_mask;
     if (IsRead(usage_info.access_index)) {
         // Mulitple outstanding reads may be of interest and do dependency chains independently
@@ -532,7 +532,7 @@ void AccessState::Update(const SyncAccessInfo& usage_info, const AttachmentAcces
             const auto not_usage_stage = ~usage_stage;
             for (auto& read_access : GetReads()) {
                 if (read_access.stage == usage_stage) {
-                    read_access.Set(usage_stage, usage_info.access_index, attachment_access, tag_ex);
+                    read_access.Set(usage_stage, usage_info.access_index, attachment_access, tag_ex, queue_id);
                 } else if (read_access.barriers & usage_stage) {
                     // If the current access is barriered to this stage, mark it as "known to happen after"
                     read_access.sync_stages |= usage_stage;
@@ -550,7 +550,7 @@ void AccessState::Update(const SyncAccessInfo& usage_info, const AttachmentAcces
                 }
             }
             ReadState new_read_state;
-            new_read_state.Set(usage_stage, usage_info.access_index, attachment_access, tag_ex);
+            new_read_state.Set(usage_stage, usage_info.access_index, attachment_access, tag_ex, queue_id);
             AddRead(new_read_state);
             last_read_stages |= usage_stage;
         }
@@ -561,7 +561,7 @@ void AccessState::Update(const SyncAccessInfo& usage_info, const AttachmentAcces
             input_attachment_read = (usage_info.access_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ);
         }
     } else {
-        SetWrite(usage_info.access_index, attachment_access, tag_ex, flags);
+        SetWrite(usage_info.access_index, attachment_access, tag_ex, flags, queue_id);
     }
     UpdateFirst(tag_ex, usage_info, attachment_access, flags);
 }
@@ -595,12 +595,12 @@ bool HazardResult::IsWAWHazard() const {
 // if the last_reads/last_write were unsafe, we've reported them, in either case the prior access is irrelevant.
 // We can overwrite them as *this* write is now after them.
 void AccessState::SetWrite(SyncAccessIndex access_index, const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex,
-                           SyncFlags flags) {
+                           SyncFlags flags, QueueId queue_id) {
     ClearRead();
     if (!last_write.has_value()) {
         last_write.emplace();
     }
-    last_write->Set(access_index, attachment_access, tag_ex, flags);
+    last_write->Set(access_index, attachment_access, tag_ex, flags, queue_id);
 }
 
 void AccessState::ClearWrite() { last_write.reset(); }
@@ -1098,7 +1098,7 @@ void AccessState::TouchupFirstForLayoutTransition(ResourceUsageTag tag, const Or
 }
 
 void ReadState::Set(VkPipelineStageFlagBits2 stage, SyncAccessIndex access_index, const AttachmentAccess& attachment_access,
-                    ResourceUsageTagEx tag_ex) {
+                    ResourceUsageTagEx tag_ex, QueueId queue_id) {
     assert(access_index != SYNC_ACCESS_INDEX_NONE);
     this->stage = stage;
     this->access_index = access_index;
@@ -1107,7 +1107,7 @@ void ReadState::Set(VkPipelineStageFlagBits2 stage, SyncAccessIndex access_index
     sync_stages = VK_PIPELINE_STAGE_2_NONE;
     tag = tag_ex.tag;
     handle_index = tag_ex.handle_index;
-    queue = kQueueIdInvalid;
+    queue = queue_id;
 }
 
 // Scope test including "queue submission order" effects.  Specifically, accesses from a different queue are not
@@ -1144,14 +1144,14 @@ bool ReadState::InBarrierSourceScope(const BarrierScope& barrier_scope) const {
 }
 
 void WriteState::Set(SyncAccessIndex access_index, const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex,
-                     SyncFlags flags) {
+                     SyncFlags flags, QueueId queue_id) {
     this->access_index = access_index;
     this->attachment_access = attachment_access;
     barriers.reset();
     dependency_chain = VK_PIPELINE_STAGE_2_NONE;
     tag = tag_ex.tag;
     handle_index = tag_ex.handle_index;
-    queue = kQueueIdInvalid;
+    queue = queue_id;
     this->flags = flags;
 }
 

--- a/layers/sync/sync_access_state.h
+++ b/layers/sync/sync_access_state.h
@@ -215,7 +215,7 @@ struct ReadState {
     QueueId queue;
 
     void Set(VkPipelineStageFlagBits2 stage, SyncAccessIndex access_index, const AttachmentAccess& attachment_access,
-             ResourceUsageTagEx tag_ex);
+             ResourceUsageTagEx tag_ex, QueueId queue_id);
 
     ResourceUsageTagEx TagEx() const { return {tag, handle_index}; }
     bool operator==(const ReadState& rhs) const {
@@ -266,7 +266,8 @@ struct WriteState {
 
     SyncFlags flags;
 
-    void Set(SyncAccessIndex access_index, const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex, SyncFlags flags);
+    void Set(SyncAccessIndex access_index, const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex, SyncFlags flags,
+             QueueId queue_id);
     void SetQueueId(QueueId id);
     void MergeBarriers(const WriteState& other);
 
@@ -372,9 +373,9 @@ class AccessState {
                                      QueueId event_queue, ResourceUsageTag event_tag) const;
 
     void Update(const SyncAccessInfo& usage_info, const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex,
-                SyncFlags flags = 0);
+                SyncFlags flags, QueueId queue_id);
     void SetWrite(SyncAccessIndex access_index, const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex,
-                  SyncFlags flags = 0);
+                  SyncFlags flags = 0, QueueId = kQueueIdInvalid);
     void ClearWrite();
     void ClearRead();
     void ClearFirstUse();

--- a/layers/sync/sync_command.cpp
+++ b/layers/sync/sync_command.cpp
@@ -24,10 +24,44 @@
 
 namespace syncval {
 
+bool ReplayCommands(const SyncEnvironment& env, AccessContext& access_context, const CommandBufferContext& cb_context,
+                    ResourceUsageTag base_tag, const Location& loc) {
+    bool skip = false;
+    const CommandData& command_data = cb_context.GetCommandData();
+
+    for (const CommandEntry& entry : cb_context.GetCommands()) {
+        const ResourceUsageTag tag = base_tag + entry.tag;
+
+        std::visit(
+            [&](const auto& storage) {
+                const auto& command = storage.MakeCommand(command_data);
+                const bool command_skip = command.Validate(env, access_context, cb_context, entry.tag, loc);
+                if (!command_skip) {
+                    const ResourceUsageTagEx src_tag_ex{tag, storage.src_handle_index};
+                    const ResourceUsageTagEx dst_tag_ex{tag, storage.dst_handle_index};
+                    command.Apply(env, access_context, src_tag_ex, dst_tag_ex);
+                }
+                skip |= command_skip;
+            },
+            entry.storage);
+    }
+    return skip;
+}
+
 uint32_t CommandData::AddBuffer(const vvl::Buffer& buffer) {
     const uint32_t index = uint32_t(buffers.size());
     buffers.emplace_back(std::static_pointer_cast<const vvl::Buffer>(buffer.shared_from_this()));
     return index;
+}
+
+BufferCopyCommand BufferCopyCommand::Storage::MakeCommand(const CommandData& command_data) const {
+    const vvl::Buffer& src_buffer = *command_data.buffers[src_buffer_index];
+    const vvl::Buffer& dst_buffer = *command_data.buffers[dst_buffer_index];
+    vvl::span<const BufferCopyRegion> regions;
+    if (region_count != 0) {
+        regions = vvl::make_span(&command_data.buffer_copy_regions[first_region], region_count);
+    }
+    return {src_buffer, dst_buffer, regions};
 }
 
 BufferCopyCommand::Storage BufferCopyCommand::MakeStorage(CommandData& command_data, uint32_t src_handle_index,
@@ -42,26 +76,45 @@ BufferCopyCommand::Storage BufferCopyCommand::MakeStorage(CommandData& command_d
     return {src_buffer_index, dst_buffer_index, first_region, region_count, src_handle_index, dst_handle_index};
 }
 
-bool BufferCopyCommand::Validate(const SyncEnvironment& env, const AccessContext& access_context, const Location& loc,
-                                 VulkanTypedHandle command_buffer_handle) const {
+bool BufferCopyCommand::Validate(const CommandBufferContext& cb_context, const Location& loc) const {
+    return Validate(cb_context.GetSyncEnvironment(), cb_context.GetCbAccessContext(), cb_context, kInvalidTag, loc);
+}
+
+bool BufferCopyCommand::Validate(const SyncEnvironment& env, const AccessContext& access_context,
+                                 const CommandBufferContext& cb_context, ResourceUsageTag command_tag, const Location& loc) const {
     bool skip = false;
     const SyncValidator& validator = env.validator;
+    const bool submit_time = env.handle.type == kVulkanObjectTypeQueue;
+
+    // TODO: Remove SubmitTimeError and extend BufferCopyError with submit-time details after
+    // command-base validation replaces current model. Until then, try to preserve identical
+    // error output so old and new can be compared during development.
 
     for (const auto [region_index, region] : vvl::enumerate(regions)) {
         const AccessRange src_range = MakeRange(src_buffer, region.src_offset, region.size);
         auto src_hazard = access_context.DetectHazard(src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
         if (src_hazard.IsHazard()) {
-            const LogObjectList objlist(command_buffer_handle, src_buffer.Handle());
-            const std::string error = validator.error_messages_.BufferCopyError(
-                env, src_hazard, loc.function, validator.FormatHandle(src_buffer), uint32_t(region_index), src_range);
+            const LogObjectList objlist = submit_time ? LogObjectList(env.handle, cb_context.GetCBState().Handle())
+                                                      : LogObjectList(cb_context.GetCBState().Handle(), src_buffer.Handle());
+            const std::string error =
+                submit_time
+                    ? validator.error_messages_.SubmitTimeError(env, src_hazard, cb_context, command_tag, loc.index,
+                                                                validator.FormatHandle(src_buffer))
+                    : validator.error_messages_.BufferCopyError(env, src_hazard, loc.function, validator.FormatHandle(src_buffer),
+                                                                uint32_t(region_index), src_range);
             skip |= validator.SyncError(src_hazard.Hazard(), objlist, loc, error);
         }
         const AccessRange dst_range = MakeRange(dst_buffer, region.dst_offset, region.size);
         auto dst_hazard = access_context.DetectHazard(dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
         if (dst_hazard.IsHazard()) {
-            const LogObjectList objlist(command_buffer_handle, dst_buffer.Handle());
-            const std::string error = validator.error_messages_.BufferCopyError(
-                env, dst_hazard, loc.function, validator.FormatHandle(dst_buffer), uint32_t(region_index), dst_range);
+            const LogObjectList objlist = submit_time ? LogObjectList(env.handle, cb_context.GetCBState().Handle())
+                                                      : LogObjectList(cb_context.GetCBState().Handle(), dst_buffer.Handle());
+            const std::string error =
+                submit_time
+                    ? validator.error_messages_.SubmitTimeError(env, dst_hazard, cb_context, command_tag, loc.index,
+                                                                validator.FormatHandle(dst_buffer))
+                    : validator.error_messages_.BufferCopyError(env, dst_hazard, loc.function, validator.FormatHandle(dst_buffer),
+                                                                uint32_t(region_index), dst_range);
             skip |= validator.SyncError(dst_hazard.Hazard(), objlist, loc, error);
         }
         if (skip) {
@@ -71,13 +124,14 @@ bool BufferCopyCommand::Validate(const SyncEnvironment& env, const AccessContext
     return skip;
 }
 
-void BufferCopyCommand::Apply(AccessContext& access_context, ResourceUsageTagEx src_tag_ex, ResourceUsageTagEx dst_tag_ex) const {
+void BufferCopyCommand::Apply(const SyncEnvironment& env, AccessContext& access_context, ResourceUsageTagEx src_tag_ex,
+                              ResourceUsageTagEx dst_tag_ex) const {
     for (const BufferCopyRegion& region : regions) {
         const AccessRange src_range = MakeRange(src_buffer, region.src_offset, region.size);
-        access_context.UpdateAccessState(src_buffer, SYNC_COPY_TRANSFER_READ, src_range, src_tag_ex);
+        access_context.UpdateAccessState(src_buffer, SYNC_COPY_TRANSFER_READ, src_range, src_tag_ex, 0, env.queue_id);
 
         const AccessRange dst_range = MakeRange(dst_buffer, region.dst_offset, region.size);
-        access_context.UpdateAccessState(dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range, dst_tag_ex);
+        access_context.UpdateAccessState(dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range, dst_tag_ex, 0, env.queue_id);
     }
 }
 

--- a/layers/sync/sync_command.h
+++ b/layers/sync/sync_command.h
@@ -25,11 +25,13 @@ struct VulkanTypedHandle;
 
 namespace vvl {
 class Buffer;
+enum class Func;
 }  // namespace vvl
 
 namespace syncval {
 
 class AccessContext;
+class CommandBufferContext;
 struct SyncEnvironment;
 
 struct BufferCopyRegion {
@@ -57,12 +59,14 @@ struct BufferCopyCommand {
         uint32_t region_count;
         uint32_t src_handle_index;
         uint32_t dst_handle_index;
+        BufferCopyCommand MakeCommand(const CommandData& command_data) const;
     };
-
     Storage MakeStorage(CommandData& command_data, uint32_t src_handle_index, uint32_t dst_handle_index) const;
-    bool Validate(const SyncEnvironment& env, const AccessContext& access_context, const Location& loc,
-                  VulkanTypedHandle command_buffer_handle) const;
-    void Apply(AccessContext& access_context, ResourceUsageTagEx src_tag_ex, ResourceUsageTagEx dst_tag_ex) const;
+    bool Validate(const CommandBufferContext& cb_context, const Location& loc) const;
+    bool Validate(const SyncEnvironment& env, const AccessContext& access_context, const CommandBufferContext& cb_context,
+                  ResourceUsageTag command_tag, const Location& loc) const;
+    void Apply(const SyncEnvironment& env, AccessContext& access_context, ResourceUsageTagEx src_tag_ex,
+               ResourceUsageTagEx dst_tag_ex) const;
 };
 
 using CommandStorage = std::variant<BufferCopyCommand::Storage>;
@@ -72,7 +76,10 @@ using CommandStorage = std::variant<BufferCopyCommand::Storage>;
 // use array of commands instead.
 struct CommandEntry {
     ResourceUsageTag tag;
-    CommandStorage command;
+    CommandStorage storage;
 };
+
+bool ReplayCommands(const SyncEnvironment& env, AccessContext& access_context, const CommandBufferContext& cb_context,
+                    ResourceUsageTag base_tag, const Location& loc);
 
 }  // namespace syncval

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -1610,7 +1610,7 @@ void CommandBufferSubState::RecordCopyBuffer(vvl::Buffer& src_buffer_state, vvl:
     const auto& settings = cb_context.GetSyncState().syncval_settings;
     if (settings.IsRecordTimeValidationEnabled()) {
         AccessContext& access_context = cb_context.GetCbAccessContext();
-        command.Apply(access_context, src_tag_ex, dst_tag_ex);
+        command.Apply(cb_context.GetSyncEnvironment(), access_context, src_tag_ex, dst_tag_ex);
     }
     if (settings.full_validation) {
         cb_context.StoreCommand(tag, command, src_tag_ex.handle_index, dst_tag_ex.handle_index);
@@ -1633,7 +1633,7 @@ void CommandBufferSubState::RecordCopyBuffer2(vvl::Buffer& src_buffer_state, vvl
     const auto& settings = cb_context.GetSyncState().syncval_settings;
     if (settings.IsRecordTimeValidationEnabled()) {
         AccessContext& access_context = cb_context.GetCbAccessContext();
-        command.Apply(access_context, src_tag_ex, dst_tag_ex);
+        command.Apply(cb_context.GetSyncEnvironment(), access_context, src_tag_ex, dst_tag_ex);
     }
     if (settings.full_validation) {
         cb_context.StoreCommand(tag, command, src_tag_ex.handle_index, dst_tag_ex.handle_index);

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -272,6 +272,21 @@ class CommandBufferContext final : public ResourceUsageInfoProvider, public Debu
     std::shared_ptr<CommandBufferSet> GetCBReferencesShared() const { return cbs_referenced_; }
     void ImportRecordedAccessLog(const CommandBufferContext& cb_context);
     const std::vector<ReplayEntry>& GetReplayEntries() const { return replay_entries_; }
+    const std::vector<CommandEntry>& GetCommands() const { return commands_; }
+    const CommandData& GetCommandData() const { return command_data_; }
+
+    // TODO: debug util, remove after convertion to commands is finished
+    bool HasAllCommands() const {
+        if (commands_.size() != access_log_->size()) {
+            return false;
+        }
+        for (size_t i = 0; i < commands_.size(); ++i) {
+            if (commands_[i].tag != i) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     // DebugNameProvider
     std::string GetDebugRegionName(const ResourceUsageRecord& record) const override;

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -423,8 +423,22 @@ std::string ErrorMessages::ImageBarrierError(const SyncEnvironment& env, const H
 
 std::string ErrorMessages::FirstUseError(const SyncEnvironment& env, const HazardResult& hazard,
                                          const CommandBufferContext& recorded_context, uint32_t command_buffer_index) const {
-    const ResourceUsageInfo prior_usage_info = env.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
     const ResourceUsageInfo recorded_usage_info = recorded_context.GetResourceUsageInfo(hazard.RecordedAccess()->TagEx());
+
+    // Use generic "resource" when resource handle is not specified for some reason (likely just a missing code).
+    // TODO: specify resources in EndRenderPass (NegativeSyncVal.QSOBarrierHazard).
+    const std::string resource_description = (recorded_usage_info.resource_handle != NullVulkanTypedHandle)
+                                                 ? validator_.FormatHandle(recorded_usage_info.resource_handle)
+                                                 : "resource";
+    return SubmitTimeError(env, hazard, recorded_context, hazard.RecordedAccess()->TagEx().tag, command_buffer_index,
+                           resource_description);
+}
+
+std::string ErrorMessages::SubmitTimeError(const SyncEnvironment& env, const HazardResult& hazard,
+                                           const CommandBufferContext& recorded_context, ResourceUsageTag command_tag,
+                                           uint32_t command_buffer_index, const std::string& resource_description) const {
+    const ResourceUsageInfo prior_usage_info = env.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
+    const ResourceUsageInfo recorded_usage_info = recorded_context.GetResourceUsageInfo(ResourceUsageTagEx{command_tag});
 
     AdditionalMessageInfo additional_info;
     additional_info.properties.Add(kPropertyCommandBufferIndex, command_buffer_index);
@@ -463,11 +477,6 @@ std::string ErrorMessages::FirstUseError(const SyncEnvironment& env, const Hazar
         additional_info.properties.Add(kPropertyDebugRegion, recorded_usage_info.debug_region_name);
     }
 
-    // Use generic "resource" when resource handle is not specified for some reason (likely just a missing code).
-    // TODO: specify resources in EndRenderPass (NegativeSyncVal.QSOBarrierHazard).
-    const std::string resource_description = (recorded_usage_info.resource_handle != NullVulkanTypedHandle)
-                                                 ? validator_.FormatHandle(recorded_usage_info.resource_handle)
-                                                 : "resource";
     return Error(env, hazard, recorded_usage_info.command, resource_description, "SubmitTimeError", additional_info);
 }
 

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -133,6 +133,10 @@ class ErrorMessages {
     std::string FirstUseError(const SyncEnvironment& env, const HazardResult& hazard, const CommandBufferContext& recorded_context,
                               uint32_t command_buffer_index) const;
 
+    std::string SubmitTimeError(const SyncEnvironment& env, const HazardResult& hazard,
+                                const CommandBufferContext& recorded_context, ResourceUsageTag command_tag,
+                                uint32_t command_buffer_index, const std::string& resource_description) const;
+
     std::string PresentError(const HazardResult& hazard, const QueueBatchContext& batch_context, vvl::Func command,
                              const std::string& resource_description, uint32_t swapchain_index) const;
 

--- a/layers/sync/sync_settings.h
+++ b/layers/sync/sync_settings.h
@@ -26,6 +26,8 @@ struct SyncValSettings {
     // TODO: remove this and replace with direct record_time_validation access after refactor
     bool IsRecordTimeValidationEnabled() const { return record_time_validation || legacy_submit_time_validation; }
 
+    bool IsSubmitTimeProcessingEnabled() const { return legacy_submit_time_validation || full_validation; }
+
     // This validation currently is controlled only by the settings and is disabled by default.
     // There is a discussion https://gitlab.khronos.org/vulkan/vulkan/-/issues/4513 to clarify
     // the spec and under which conditions this validation should be active.

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -739,11 +739,16 @@ bool QueueBatchContext::ValidateSubmit(const std::vector<CommandBufferConstPtr>&
                                         ? submit_info_loc.dot(vvl::Field::pCommandBuffers, index)
                                         : submit_info_loc.dot(vvl::Field::pCommandBufferInfos, index);
 
-            skip |= ValidateFirstUseHazards(GetSyncEnvironment(), cb_context, GetAccessContext(), batch.base_tag, cb_loc);
-
-            // The barriers have already been applied in ValidateFirstUseHazards
-            batch_log_.Import(batch, cb_context, current_label_stack);
-            ResolveSubmittedCommandBuffer(cb_context.GetCbAccessContext(), batch.base_tag);
+            if (sync_state_.syncval_settings.full_validation) {
+                assert(cb_context.HasAllCommands());
+                batch_log_.Import(batch, cb_context, current_label_stack);
+                skip |= ReplayCommands(GetSyncEnvironment(), GetAccessContext(), cb_context, batch.base_tag, cb_loc);
+            } else {
+                skip |= ValidateFirstUseHazards(GetSyncEnvironment(), cb_context, GetAccessContext(), batch.base_tag, cb_loc);
+                // The barriers have already been applied in ValidateFirstUseHazards
+                batch_log_.Import(batch, cb_context, current_label_stack);
+                ResolveSubmittedCommandBuffer(cb_context.GetCbAccessContext(), batch.base_tag);
+            }
             batch.base_tag += cb_context.GetTagCount();
         }
         // Apply debug label commands

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -391,8 +391,7 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
         regions.emplace_back(BufferCopyRegion{region.srcOffset, region.dstOffset, region.size});
     }
     const BufferCopyCommand command{*src_buffer, *dst_buffer, regions};
-    return command.Validate(cb_context.GetSyncEnvironment(), cb_context.GetCbAccessContext(), error_obj.location,
-                            cb_state->Handle());
+    return command.Validate(cb_context, error_obj.location);
 }
 
 bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo,
@@ -417,8 +416,7 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
         regions.emplace_back(BufferCopyRegion{region.srcOffset, region.dstOffset, region.size});
     }
     const BufferCopyCommand command{*src_buffer, *dst_buffer, regions};
-    return command.Validate(cb_context.GetSyncEnvironment(), cb_context.GetCbAccessContext(), error_obj.location,
-                            cb_state->Handle());
+    return command.Validate(cb_context, error_obj.location);
 }
 
 bool SyncValidator::PreCallValidateCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR* pCopyBufferInfo,
@@ -2532,7 +2530,7 @@ void SyncValidator::PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t 
 }
 
 void SyncValidator::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject& record_obj) {
-    if (record_obj.result != VK_SUCCESS || !syncval_settings.legacy_submit_time_validation || queue == VK_NULL_HANDLE) {
+    if (record_obj.result != VK_SUCCESS || !syncval_settings.IsSubmitTimeProcessingEnabled() || queue == VK_NULL_HANDLE) {
         return;
     }
     const QueueId waited_queue = GetQueueId(queue);
@@ -2737,7 +2735,7 @@ void SyncValidator::RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR 
 bool SyncValidator::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
                                                const ErrorObject& error_obj) const {
     bool skip = false;
-    if (!syncval_settings.legacy_submit_time_validation) {
+    if (!syncval_settings.IsSubmitTimeProcessingEnabled()) {
         return skip;
     }
 
@@ -2752,7 +2750,7 @@ bool SyncValidator::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCou
 bool SyncValidator::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                                 const ErrorObject& error_obj) const {
     bool skip = false;
-    if (!syncval_settings.legacy_submit_time_validation) {
+    if (!syncval_settings.IsSubmitTimeProcessingEnabled()) {
         return skip;
     }
     std::lock_guard lock_guard(queue_mutex_);


### PR DESCRIPTION
This introduces how the commands are processed during submissions. That's the point where the full validation happens. The full validation is not enabled by default yet. `NegativeSyncVal.QSBufferCopyVsIdle` was used for testing with full validation enabled manually.