### PR TITLE
layers: Improve ignored attachmentCount error message

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -1721,8 +1721,11 @@ bool CoreChecks::ValidateGraphicsPipelineColorBlendAttachmentState(const vvl::Pi
                                                                    const Location& color_loc) const {
     bool skip = false;
     const auto& attachment_states = pipeline.AttachmentStates();
-    if (attachment_states.empty()) return skip;
-    if (pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT)) return skip;
+    if (attachment_states.empty()) {
+        return skip;
+    } else if (pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT)) {
+        return skip;
+    }
 
     if (!enabled_features.independentBlend && attachment_states.size() > 1) {
         for (size_t i = 1; i < attachment_states.size(); i++) {
@@ -1871,12 +1874,6 @@ bool CoreChecks::ValidateGraphicsPipelineColorBlendAttachmentState(const vvl::Pi
     return skip;
 }
 
-bool CoreChecks::IsColorBlendStateAttachmentCountIgnore(const vvl::Pipeline& pipeline) const {
-    return pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT) &&
-           pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT) &&
-           pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT) &&
-           (pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT) || !enabled_features.advancedBlendCoherentOperations);
-}
 bool CoreChecks::ValidatePipelineColorBlendAdvancedStateCreateInfo(
     const vvl::Pipeline& pipeline, const VkPipelineColorBlendAdvancedStateCreateInfoEXT& color_blend_advanced,
     const Location& color_loc) const {
@@ -1931,11 +1928,13 @@ bool CoreChecks::ValidateGraphicsPipelineColorBlendState(const vvl::Pipeline& pi
     }
 
     if (!null_rp && subpass_desc && color_blend_state->attachmentCount != subpass_desc->colorAttachmentCount) {
-        if (!IsColorBlendStateAttachmentCountIgnore(pipeline)) {
+        if (!pipeline.IsColorBlendStateAttachmentCountIgnore(enabled_features.advancedBlendCoherentOperations)) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-07609", device, color_loc.dot(Field::attachmentCount),
-                             "(%" PRIu32 ") is different than %s pSubpasses[%" PRIu32 "].colorAttachmentCount (%" PRIu32 ").",
+                             "(%" PRIu32 ") is different than %s pSubpasses[%" PRIu32 "].colorAttachmentCount (%" PRIu32
+                             ").\nattachmentCount can be ignored with all the following dynamic states set:\n%s",
                              color_blend_state->attachmentCount, FormatHandle(rp_state->Handle()).c_str(), pipeline.Subpass(),
-                             subpass_desc->colorAttachmentCount);
+                             subpass_desc->colorAttachmentCount,
+                             pipeline.DescribeDynamicStateSet(kColorBlendStateAttachmentCountDynamic).c_str());
         }
     }
 
@@ -2546,24 +2545,21 @@ bool CoreChecks::ValidateGraphicsPipelineNullState(const vvl::Pipeline& pipeline
 
     const bool null_rp = pipeline.IsRenderPassNull();
     if (null_rp) {
-        if (!pipeline.DepthStencilState()) {
-            if (pipeline.fragment_shader_state && !pipeline.fragment_output_state) {
-                if (!pipeline.IsDepthStencilStateDynamic() || !IsExtEnabled(extensions.vk_ext_extended_dynamic_state3)) {
-                    skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-09035", device,
-                                     create_info_loc.dot(Field::pDepthStencilState), "is NULL.");
-                }
+        if (!pipeline.DepthStencilState() && pipeline.fragment_shader_state && !pipeline.fragment_output_state) {
+            if (!pipeline.IsDepthStencilStateDynamic() || !IsExtEnabled(extensions.vk_ext_extended_dynamic_state3)) {
+                skip |= LogError(
+                    "VUID-VkGraphicsPipelineCreateInfo-renderPass-09035", device, create_info_loc.dot(Field::pDepthStencilState),
+                    "is NULL.\nIf the following are all set, it can be NULL\n - VK_EXT_extended_dynamic_state3 (%senabled)\n%s",
+                    IsExtEnabled(extensions.vk_ext_extended_dynamic_state3) ? "" : "not ",
+                    pipeline.DescribeDynamicStateSet(kDepthStencilStateDynamic).c_str());
             }
         }
-    }
-
-    if (IsExtEnabled(extensions.vk_ext_graphics_pipeline_library)) {
+    } else if (IsExtEnabled(extensions.vk_ext_graphics_pipeline_library)) {
+        // if VK_KHR_dynamic_rendering is not enabled, can be null renderpass if using GPL
         if (pipeline.OwnsLibState(pipeline.fragment_output_state) && !pipeline.MultisampleState()) {
-            // if VK_KHR_dynamic_rendering is not enabled, can be null renderpass if using GPL
-            if (!null_rp) {
-                skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderpass-06631", device,
-                                 create_info_loc.dot(Field::pMultisampleState),
-                                 "is NULL, but pipeline is being created with fragment shader that uses samples.");
-            }
+            skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderpass-06631", device,
+                             create_info_loc.dot(Field::pMultisampleState),
+                             "is NULL, but pipeline is being created with fragment shader that uses samples.");
         }
     }
 
@@ -2579,11 +2575,11 @@ bool CoreChecks::ValidateGraphicsPipelineNullState(const vvl::Pipeline& pipeline
                              create_info_loc.dot(Field::pMultisampleState),
                              "is NULL."
                              "\nIf the following are all set, it can be NULL"
-                             "\n  Enable VK_EXT_extended_dynamic_state3 (%senabled)"
-                             "\n  Use VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT (%s)"
-                             "\n  Use VK_DYNAMIC_STATE_SAMPLE_MASK_EXT (%s)"
-                             "\n  Use VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT (%s)"
-                             "\n  Use VK_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT (%s) or enable alphaToOne feature (%s)\n",
+                             "\n - VK_EXT_extended_dynamic_state3 (%senabled)"
+                             "\n - VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT (%s)"
+                             "\n - VK_DYNAMIC_STATE_SAMPLE_MASK_EXT (%s)"
+                             "\n - VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT (%s)"
+                             "\n - VK_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT (%s) or enable alphaToOne feature (%s)\n",
                              IsExtEnabled(extensions.vk_ext_extended_dynamic_state3) ? "" : "not ",
                              pipeline.IsDynamic(CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT) ? "set" : "not set",
                              pipeline.IsDynamic(CB_DYNAMIC_STATE_SAMPLE_MASK_EXT) ? "set" : "not set",
@@ -2595,35 +2591,13 @@ bool CoreChecks::ValidateGraphicsPipelineNullState(const vvl::Pipeline& pipeline
 
     if (!pipeline.RasterizationState()) {
         if (!pipeline_ci.pRasterizationState && pipeline.OwnsLibState(pipeline.pre_raster_state)) {
-            if (!IsExtEnabled(extensions.vk_ext_extended_dynamic_state3) ||
-                !pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT) ||
-                !pipeline.IsDynamic(CB_DYNAMIC_STATE_POLYGON_MODE_EXT) ||
-                !pipeline.IsDynamic(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE) ||
-                !pipeline.IsDynamic(CB_DYNAMIC_STATE_CULL_MODE) || !pipeline.IsDynamic(CB_DYNAMIC_STATE_FRONT_FACE) ||
-                !pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_BIAS_ENABLE) || !pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_BIAS) ||
-                !pipeline.IsDynamic(CB_DYNAMIC_STATE_LINE_WIDTH)) {
-                skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-pRasterizationState-06601", device,
-                                 create_info_loc.dot(Field::pRasterizationState),
-                                 "is NULL."
-                                 "\nIf the following are all set, it can be NULL"
-                                 "\n  Enable VK_EXT_extended_dynamic_state3 (%senabled)"
-                                 "\n  Use VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT (%s)"
-                                 "\n  Use VK_DYNAMIC_STATE_POLYGON_MODE_EXT (%s)"
-                                 "\n  Use VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE (%s)"
-                                 "\n  Use VK_DYNAMIC_STATE_CULL_MODE (%s)"
-                                 "\n  Use VK_DYNAMIC_STATE_FRONT_FACE (%s)"
-                                 "\n  Use VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE (%s)"
-                                 "\n  Use VK_DYNAMIC_STATE_DEPTH_BIAS (%s)"
-                                 "\n  Use VK_DYNAMIC_STATE_LINE_WIDTH (%s)\n",
-                                 IsExtEnabled(extensions.vk_ext_extended_dynamic_state3) ? "" : "not ",
-                                 pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT) ? "set" : "not set",
-                                 pipeline.IsDynamic(CB_DYNAMIC_STATE_POLYGON_MODE_EXT) ? "set" : "not set",
-                                 pipeline.IsDynamic(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE) ? "set" : "not set",
-                                 pipeline.IsDynamic(CB_DYNAMIC_STATE_CULL_MODE) ? "set" : "not set",
-                                 pipeline.IsDynamic(CB_DYNAMIC_STATE_FRONT_FACE) ? "set" : "not set",
-                                 pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_BIAS_ENABLE) ? "set" : "not set",
-                                 pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_BIAS) ? "set" : "not set",
-                                 pipeline.IsDynamic(CB_DYNAMIC_STATE_LINE_WIDTH) ? "set" : "not set");
+            if (!IsExtEnabled(extensions.vk_ext_extended_dynamic_state3) || !pipeline.IsRasterizationStateDynamic()) {
+                skip |= LogError(
+                    "VUID-VkGraphicsPipelineCreateInfo-pRasterizationState-06601", device,
+                    create_info_loc.dot(Field::pRasterizationState),
+                    "is NULL.\nIf the following are all set, it can be NULL\n - VK_EXT_extended_dynamic_state3 (%senabled)\n%s",
+                    IsExtEnabled(extensions.vk_ext_extended_dynamic_state3) ? "" : "not ",
+                    pipeline.DescribeDynamicStateSet(kRasterizationStateDynamic).c_str());
             }
         }
     }
@@ -2769,13 +2743,7 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicState(const vvl::Pipeline& pipel
     }
 
     if (api_version < VK_API_VERSION_1_3 && !enabled_features.extendedDynamicState &&
-        (pipeline.IsDynamic(CB_DYNAMIC_STATE_CULL_MODE) || pipeline.IsDynamic(CB_DYNAMIC_STATE_FRONT_FACE) ||
-         pipeline.IsDynamic(CB_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY) || pipeline.IsDynamic(CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT) ||
-         pipeline.IsDynamic(CB_DYNAMIC_STATE_SCISSOR_WITH_COUNT) ||
-         pipeline.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE) ||
-         pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE) || pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE) ||
-         pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_COMPARE_OP) || pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE) ||
-         pipeline.IsDynamic(CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE) || pipeline.IsDynamic(CB_DYNAMIC_STATE_STENCIL_OP))) {
+        ((pipeline.dynamic_state & kExtendedDynamicState1) != 0)) {
         skip |= LogError(
             "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-03378", device, create_info_loc.dot(Field::pDynamicState),
             "contains dynamic states from VK_EXT_extended_dynamic_state, but the extendedDynamicState feature was not enabled.");
@@ -3384,12 +3352,15 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const vvl::Pipeline& p
         }
 
         if (color_blend_state && rendering_struct->colorAttachmentCount != color_blend_state->attachmentCount &&
-            !IsColorBlendStateAttachmentCountIgnore(pipeline)) {
+            !pipeline.IsColorBlendStateAttachmentCountIgnore(enabled_features.advancedBlendCoherentOperations)) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06055", device,
                              create_info_loc.pNext(Struct::VkPipelineRenderingCreateInfo, Field::colorAttachmentCount),
-                             "(%" PRIu32 ") is different from %s (%" PRIu32 ").", rendering_struct->colorAttachmentCount,
+                             "(%" PRIu32 ") is different from %s (%" PRIu32
+                             ").\nattachmentCount can be ignored with all the following dynamic states set:\n%s",
+                             rendering_struct->colorAttachmentCount,
                              create_info_loc.dot(Field::pColorBlendState).dot(Field::attachmentCount).Fields().c_str(),
-                             color_blend_state->attachmentCount);
+                             color_blend_state->attachmentCount,
+                             pipeline.DescribeDynamicStateSet(kColorBlendStateAttachmentCountDynamic).c_str());
         }
 
         if (const auto* custom_resolve = vku::FindStructInPNextChain<VkCustomResolveCreateInfoEXT>(pipeline.GetCreateInfoPNext())) {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -847,7 +847,6 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateGraphicsPipelineColorBlendAttachmentState(const vvl::Pipeline& pipeline,
                                                            const vku::safe_VkSubpassDescription2* subpass_desc,
                                                            const Location& color_loc) const;
-    bool IsColorBlendStateAttachmentCountIgnore(const vvl::Pipeline& pipeline) const;
     bool ValidatePipelineColorBlendAdvancedStateCreateInfo(
         const vvl::Pipeline& pipeline, const VkPipelineColorBlendAdvancedStateCreateInfoEXT& color_blend_advanced,
         const Location& color_loc) const;

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -18,6 +18,7 @@
  */
 #include "state_tracker/pipeline_state.h"
 #include <vulkan/vulkan_core.h>
+#include <sstream>
 #include "error_message/error_location.h"
 #include "generated/dynamic_state_helper.h"
 #include "state_tracker/descriptor_sets.h"
@@ -603,6 +604,24 @@ static CBDynamicFlags GetRayTracingDynamicState(Pipeline& pipe_state) {
     }
 
     return flags;
+}
+
+std::string Pipeline::DescribeDynamicStateSet(const CBDynamicFlags& states) const {
+    std::ostringstream ss;
+    // enum is not zero based
+    for (int index = 1; index < CB_DYNAMIC_STATE_STATUS_NUM; ++index) {
+        CBDynamicState status = static_cast<CBDynamicState>(index);
+        if (states[status]) {
+            ss << " - " << string_VkDynamicState(ConvertToDynamicState(status)) << ": (" << (IsDynamic(status) ? "set" : "not set")
+               << ")";
+            // This makes no sense https://gitlab.khronos.org/vulkan/vulkan/-/work_items/4956
+            if (status == CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT) {
+                ss << " (only needed if advancedBlendCoherentOperations is false)";
+            }
+            ss << '\n';
+        }
+    }
+    return ss.str();
 }
 
 static bool UsesPipelineRobustness(const void* pNext, const Pipeline& pipe_state) {

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -466,18 +466,25 @@ class Pipeline : public StateObject, public SubStateManager<PipelineSubState> {
     // From https://gitlab.khronos.org/vulkan/vulkan/-/issues/3263
     // None of these require VK_EXT_extended_dynamic_state3
     inline bool IsDepthStencilStateDynamic() const {
-        return IsDynamic(CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE) && IsDynamic(CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE) &&
-               IsDynamic(CB_DYNAMIC_STATE_DEPTH_COMPARE_OP) && IsDynamic(CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE) &&
-               IsDynamic(CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE) && IsDynamic(CB_DYNAMIC_STATE_STENCIL_OP) &&
-               IsDynamic(CB_DYNAMIC_STATE_DEPTH_BOUNDS);
+        return (dynamic_state & kDepthStencilStateDynamic) == kDepthStencilStateDynamic;
     }
 
     // If true, VK_EXT_extended_dynamic_state3 must also have been enabled
-    inline bool IsColorBlendStateDynamic() const {
-        return IsDynamic(CB_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT) && IsDynamic(CB_DYNAMIC_STATE_LOGIC_OP_EXT) &&
-               IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT) && IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT) &&
-               IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT) && IsDynamic(CB_DYNAMIC_STATE_BLEND_CONSTANTS);
+    inline bool IsColorBlendStateDynamic() const { return (dynamic_state & kColorBlendStateDynamic) == kColorBlendStateDynamic; }
+
+    // If true, VK_EXT_extended_dynamic_state3 must also have been enabled
+    inline bool IsRasterizationStateDynamic() const {
+        return (dynamic_state & kRasterizationStateDynamic) == kRasterizationStateDynamic;
     }
+
+    // From VkPipelineColorBlendStateCreateInfo::attachmentCount definition of when it is ignored
+    inline bool IsColorBlendStateAttachmentCountIgnore(bool advance_blend_coherent_operations) const {
+        return IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT) && IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT) &&
+               IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT) &&
+               (IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT) || !advance_blend_coherent_operations);
+    }
+
+    std::string DescribeDynamicStateSet(const CBDynamicFlags& states) const;
 
     template <typename CreateInfo>
     static bool EnablesRasterizationStates(const vvl::DeviceState &device_state, const CreateInfo &create_info) {

--- a/layers/vulkan/generated/dynamic_state_helper.h
+++ b/layers/vulkan/generated/dynamic_state_helper.h
@@ -146,4 +146,40 @@ const CBDynamicFlags kVertexDynamicState =
     CBDynamicFlags(1) << CB_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT |
     CBDynamicFlags(1) << CB_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT;
 
+// Some extra const also used, not sure where to put these otherwise
+//
+// VkPipelineColorBlendStateCreateInfo::attachmentCount
+const CBDynamicFlags kColorBlendStateAttachmentCountDynamic =
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT | CBDynamicFlags(1) << CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT | CBDynamicFlags(1) << CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT;
+
+// VkGraphicsPipelineCreateInfo::pDepthStencilState
+const CBDynamicFlags kDepthStencilStateDynamic =
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE | CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_COMPARE_OP | CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE | CBDynamicFlags(1) << CB_DYNAMIC_STATE_STENCIL_OP |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_BOUNDS;
+
+// VkGraphicsPipelineCreateInfo::pRasterizationState
+const CBDynamicFlags kRasterizationStateDynamic =
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT | CBDynamicFlags(1) << CB_DYNAMIC_STATE_POLYGON_MODE_EXT |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE | CBDynamicFlags(1) << CB_DYNAMIC_STATE_CULL_MODE |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_FRONT_FACE | CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_BIAS_ENABLE |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_BIAS | CBDynamicFlags(1) << CB_DYNAMIC_STATE_LINE_WIDTH;
+
+// VkGraphicsPipelineCreateInfo::pColorBlendState
+const CBDynamicFlags kColorBlendStateDynamic =
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT | CBDynamicFlags(1) << CB_DYNAMIC_STATE_LOGIC_OP_EXT |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT | CBDynamicFlags(1) << CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT | CBDynamicFlags(1) << CB_DYNAMIC_STATE_BLEND_CONSTANTS;
+
+// VK_EXT_extended_dynamic_state
+const CBDynamicFlags kExtendedDynamicState1 =
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_CULL_MODE | CBDynamicFlags(1) << CB_DYNAMIC_STATE_FRONT_FACE |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY | CBDynamicFlags(1) << CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_SCISSOR_WITH_COUNT | CBDynamicFlags(1) << CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE | CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_COMPARE_OP | CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE |
+    CBDynamicFlags(1) << CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE | CBDynamicFlags(1) << CB_DYNAMIC_STATE_STENCIL_OP;
+
 // NOLINTEND

--- a/scripts/generators/dynamic_state_generator.py
+++ b/scripts/generators/dynamic_state_generator.py
@@ -230,6 +230,63 @@ class DynamicStateOutputGenerator(BaseGenerator):
                 seperator = ' |' if (index + 1) != len(states) else ';\n'
                 out.append(f'CBDynamicFlags(1) << CB_{state[3:]}{seperator}\n')
 
+        out.append('''
+            // Some extra const also used, not sure where to put these otherwise
+            //
+            // VkPipelineColorBlendStateCreateInfo::attachmentCount
+            const CBDynamicFlags kColorBlendStateAttachmentCountDynamic =
+                CBDynamicFlags(1) << CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT |
+                CBDynamicFlags(1) << CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT |
+                CBDynamicFlags(1) << CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT |
+                CBDynamicFlags(1) << CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT;
+
+            // VkGraphicsPipelineCreateInfo::pDepthStencilState
+            const CBDynamicFlags kDepthStencilStateDynamic =
+                CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE |
+                CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE |
+                CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_COMPARE_OP |
+                CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE |
+                CBDynamicFlags(1) << CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE |
+                CBDynamicFlags(1) << CB_DYNAMIC_STATE_STENCIL_OP |
+                CBDynamicFlags(1) << CB_DYNAMIC_STATE_DEPTH_BOUNDS;
+
+            // VkGraphicsPipelineCreateInfo::pRasterizationState
+            const CBDynamicFlags kRasterizationStateDynamic =
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_POLYGON_MODE_EXT |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_CULL_MODE |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_FRONT_FACE |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_DEPTH_BIAS_ENABLE |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_DEPTH_BIAS |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_LINE_WIDTH;
+
+            // VkGraphicsPipelineCreateInfo::pColorBlendState
+            const CBDynamicFlags kColorBlendStateDynamic =
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_LOGIC_OP_EXT |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_BLEND_CONSTANTS;
+
+            // VK_EXT_extended_dynamic_state
+            const CBDynamicFlags kExtendedDynamicState1 =
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_CULL_MODE |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_FRONT_FACE |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_SCISSOR_WITH_COUNT |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_DEPTH_COMPARE_OP |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE |
+                CBDynamicFlags(1) <<  CB_DYNAMIC_STATE_STENCIL_OP;
+            ''')
+
+
         self.write("".join(out))
 
     def generateSource(self):


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12945

new error message

```
Validation Error: [ VUID-VkGraphicsPipelineCreateInfo-renderPass-06055 ] | MessageID = 0xcfde2b97
vkCreateGraphicsPipelines(): pCreateInfos[0].pNext<VkPipelineRenderingCreateInfo>.colorAttachmentCount (1) is different from pCreateInfos[0].pColorBlendState->attachmentCount (0).
attachmentCount can be ignored with all the following dynamic state set:
 - VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT: set
 - VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT: not set
 - VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT: set
 - VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT: set (only needed if advancedBlendCoherentOperations is false)
```