### PR TITLE
gpuav: Remove glsl buffer_reference warning

### DIFF
--- a/layers/gpuav/shaders/instrumentation/descriptor_class_general_buffer.comp
+++ b/layers/gpuav/shaders/instrumentation/descriptor_class_general_buffer.comp
@@ -29,7 +29,7 @@ layout(buffer_reference, buffer_reference_align = 8, scalar) buffer DescriptorEn
     DescriptorEncoding data[];
 };
 
-layout(buffer_reference, buffer_reference_align = 8, scalar) buffer UnusedInitializedStatus;
+layout(buffer_reference) buffer UnusedInitializedStatus;
 
 layout(set = kInstDefaultDescriptorSet, binding = kBindingInstDescriptorIndexingOOB, scalar) buffer BoundDescriptorSetsSSBO {
     UnusedInitializedStatus unused_initialized_status;

--- a/layers/gpuav/shaders/instrumentation/descriptor_class_texel_buffer.comp
+++ b/layers/gpuav/shaders/instrumentation/descriptor_class_texel_buffer.comp
@@ -26,7 +26,7 @@ layout(buffer_reference, buffer_reference_align = 8, scalar) buffer DescriptorEn
     DescriptorEncoding data[];
 };
 
-layout(buffer_reference, buffer_reference_align = 8, scalar) buffer UnusedInitializedStatus;
+layout(buffer_reference) buffer UnusedInitializedStatus;
 
 layout(set = kInstDefaultDescriptorSet, binding = kBindingInstDescriptorIndexingOOB, scalar) buffer BoundDescriptorSetsSSBO {
     UnusedInitializedStatus unused_initialized_status;


### PR DESCRIPTION
I added these warning to `glslang` in the past

> descriptor_class_general_buffer.comp:32: 'UnusedInitializedStatus' : the buffer_reference_align layout is ignored when defined in forward declaration 
