### PR TITLE
layers: Add AHB Host Image Copy usage VU

### DIFF
--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -362,25 +362,39 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo& alloc
                 }
             }
 
+            if ((image_state->usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT) != 0) {
+                if ((image_state->format_features & VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT) == 0) {
+                    skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-12500", mem_ded_alloc_info->image, dedicated_image_loc,
+                                     "was created with VK_IMAGE_USAGE_HOST_TRANSFER_BIT but the "
+                                     "VkAndroidHardwareBufferFormatProperties2ANDROID::formatFeatures does not contain "
+                                     "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT. (AHB = %p)\nformatFeatures = %s",
+                                     import_ahb_info->buffer, string_VkFormatFeatureFlags2(image_state->format_features).c_str());
+                }
+            }
+
             // First check if any invalid Vulkan usages, then make sure for each used, the matching AHB usage is also included
-            const VkImageUsageFlags valid_vk_usages = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
-                                                      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
-                                                      VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-                                                      VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+            // https://docs.vulkan.org/spec/latest/chapters/memory.html#memory-external-android-hardware-buffer-usage
+            const VkImageUsageFlags valid_vk_usages =
+                VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT | VK_IMAGE_CREATE_PROTECTED_BIT |
+                VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
             if (image_state->usage & ~(valid_vk_usages)) {
                 skip |= LogError(
                     "VUID-VkMemoryAllocateInfo-pNext-02390", mem_ded_alloc_info->image, dedicated_image_loc,
-                    "was created with %s which are not listed in the AHardwareBuffer Usage Equivalence table. (AHB = %p).",
+                    "was created with %s which are not listed in the AHardwareBuffer Usage Equivalence table. (AHB = "
+                    "%p).\nhttps://docs.vulkan.org/spec/latest/chapters/memory.html#memory-external-android-hardware-buffer-usage",
                     string_VkImageUsageFlags2KHR(image_state->usage & ~(valid_vk_usages)).c_str(), import_ahb_info->buffer);
             }
 
-            // Based on vkspec.html#memory-external-android-hardware-buffer-usage
             static std::unordered_map<VkImageUsageFlags2KHR, uint64_t> ahb_usage_map_v2a = {
                 {VK_IMAGE_USAGE_SAMPLED_BIT, (uint64_t)AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE},
                 {VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, (uint64_t)AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE},
                 {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, (uint64_t)AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER},
                 {VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, (uint64_t)AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER},
                 {VK_IMAGE_USAGE_STORAGE_BIT, (uint64_t)AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER},
+                {VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, (uint64_t)AHARDWAREBUFFER_USAGE_GPU_CUBE_MAP},
+                {VK_IMAGE_CREATE_PROTECTED_BIT, (uint64_t)AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT},
             };
 
             for (const auto& [vk_usage, ahb_usage] : ahb_usage_map_v2a) {

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -125,7 +125,8 @@ bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo& create_inf
                          string_VkFormat(create_info.format), string_VkFormatFeatureFlags2(tiling_features).c_str());
     }
 
-    if (((tiling_features & VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT) == 0) && (usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT)) {
+    if (((tiling_features & VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT) == 0) && (usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT) &&
+        GetExternalFormat(create_info.pNext) == 0) {
         skip |= LogError("VUID-VkImageCreateInfo-imageCreateFormatFeatures-09048", device, loc.dot(Field::usage),
                          "includes VK_IMAGE_USAGE_HOST_TRANSFER_BIT, but %s doesn't support "
                          "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT.\n"

--- a/tests/icd/test_icd.cpp
+++ b/tests/icd/test_icd.cpp
@@ -2181,6 +2181,11 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetAndroidHardwareBufferPropertiesANDROID(
         format_prop->format = VK_FORMAT_R8G8B8A8_UNORM;
         format_prop->externalFormat = 37;
     }
+    auto* format_prop2 = vku::FindStructInPNextChain<VkAndroidHardwareBufferFormatProperties2ANDROID>(pProperties->pNext);
+    if (format_prop2) {
+        format_prop2->format = VK_FORMAT_R8G8B8A8_UNORM;
+        format_prop2->externalFormat = 37;
+    }
 
     auto* format_resolve_prop =
         vku::FindStructInPNextChain<VkAndroidHardwareBufferFormatResolvePropertiesANDROID>(pProperties->pNext);

--- a/tests/unit/android_hardware_buffer.cpp
+++ b/tests/unit/android_hardware_buffer.cpp
@@ -528,6 +528,69 @@ TEST_F(NegativeAndroidHardwareBuffer, UnknownFormat) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeAndroidHardwareBuffer, HostImageTransferUsage) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::hostImageCopy);
+    RETURN_IF_SKIP(Init());
+
+    vkt::AHB ahb(AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420, AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE, 64, 64);
+    if (!ahb.handle()) {
+        GTEST_SKIP() << "could not allocate AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420";
+    }
+
+    VkAndroidHardwareBufferFormatProperties2ANDROID ahb_fmt_props2 = vku::InitStructHelper();
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = vku::InitStructHelper(&ahb_fmt_props2);
+    vk::GetAndroidHardwareBufferPropertiesANDROID(device(), ahb.handle(), &ahb_props);
+
+    if (ahb_fmt_props2.externalFormat == 0) {
+        GTEST_SKIP() << "externalFormat was zero";
+    }
+
+    if ((ahb_fmt_props2.formatFeatures & VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT) != 0) {
+        GTEST_SKIP() << "AHB supports VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT";
+    }
+
+    VkExternalFormatANDROID external_format = vku::InitStructHelper();
+    external_format.externalFormat = ahb_fmt_props2.externalFormat;
+
+    VkExternalMemoryImageCreateInfo ext_image_info = vku::InitStructHelper(&external_format);
+    ext_image_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
+
+    VkImageCreateInfo ici = vku::InitStructHelper(&ext_image_info);
+    ici.imageType = VK_IMAGE_TYPE_2D;
+    ici.arrayLayers = 1;
+    ici.extent = {64, 64, 1};
+    ici.format = VK_FORMAT_UNDEFINED;
+    ici.mipLevels = 1;
+    ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    ici.samples = VK_SAMPLE_COUNT_1_BIT;
+    ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_HOST_TRANSFER_BIT;
+    // https://gitlab.khronos.org/vulkan/vulkan/-/work_items/4959#note_626777
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-pNext-02397");
+    vkt::Image image(*m_device, ici, vkt::no_mem);
+
+    VkMemoryDedicatedAllocateInfo dedicated_allocation_info = vku::InitStructHelper();
+    dedicated_allocation_info.image = image;
+    dedicated_allocation_info.buffer = VK_NULL_HANDLE;
+
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_info = vku::InitStructHelper(&dedicated_allocation_info);
+    import_ahb_info.buffer = ahb.handle();
+
+    VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper(&import_ahb_info);
+    if (!SetAllocationInfoImportAHB(m_device, ahb_props, memory_allocate_info)) {
+        GTEST_SKIP() << "No valid memory type index could be found";
+    }
+
+    // https://gitlab.khronos.org/vulkan/vulkan/-/work_items/4959
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkMemoryAllocateInfo-pNext-02390");
+    m_errorMonitor->SetDesiredError("VUID-VkMemoryAllocateInfo-pNext-12500");
+    vkt::DeviceMemory memory(*m_device, memory_allocate_info);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeAndroidHardwareBuffer, GpuUsage) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer has a GPU usage flag.");
 


### PR DESCRIPTION
From https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8443 this adds `VUID-VkMemoryAllocateInfo-pNext-12500` and some other cleanup around AHB because who doesn't like touching AHB in 2026 :upside_down_face: 