### PR TITLE
layers: Add debug labels to submit time validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ scripts/.vs
 *~
 *.10x
 *.clangd
+*.zed/*
 
 # BUILD.gn artifacts
 .cipd/

--- a/layers/best_practices/bp_state.cpp
+++ b/layers/best_practices/bp_state.cpp
@@ -866,7 +866,7 @@ void CommandBufferSubState::RecordBindPipeline(VkPipelineBindPoint bind_point, v
     }
 }
 
-void CommandBufferSubState::Submit(vvl::Queue& queue_state, uint32_t perf_submit_pass, const Location& loc) {
+void CommandBufferSubState::Submit(vvl::Queue& queue_state, const vvl::QueueSubmission&, const vvl::CommandBufferSubmission&) {
     for (auto& func : queue_submit_functions) {
         func(queue_state, base);
     }

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -225,7 +225,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordSetDepthTestEnable(VkBool32 depth_test_enable) final;
     void RecordBindPipeline(VkPipelineBindPoint bind_point, vvl::Pipeline& pipeline) final;
 
-    void Submit(vvl::Queue& queue_state, uint32_t perf_submit_pass, const Location& loc) final;
+    void Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission,
+                const vvl::CommandBufferSubmission& cb_submission) final;
 
     // Move to private when possible
     void RecordAttachmentAccess(uint32_t attachment, VkImageAspectFlags aspects);

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -29,6 +29,7 @@
 #include "core_checks/core_validation.h"
 #include "error_message/error_strings.h"
 #include "generated/error_location_helper.h"
+#include "state_tracker/queue_state.h"
 #include "utils/image_layout_utils.h"
 #include "utils/image_utils.h"
 #include "state_tracker/image_state.h"
@@ -234,14 +235,14 @@ struct GlobalLayoutUpdater {
 
 // This validates that the first layout specified in the command buffer for the image
 // is the same as this image's global (actual/current) layout
-bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBuffer& cb_state,
+bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBufferSubmission& cb_submission,
                                             vvl::unordered_map<const vvl::Image*, ImageLayoutMap>& local_image_layout_state) const {
     if (disabled[image_layout_validation]) {
         return false;
     }
     bool skip = false;
     // Iterate over the layout maps for each referenced image
-    for (const auto& [image, cb_layout_map] : cb_state.image_layout_registry) {
+    for (const auto& [image, cb_layout_map] : cb_submission.cb->image_layout_registry) {
         if (!cb_layout_map || cb_layout_map->empty()) {
             continue;
         }
@@ -291,18 +292,21 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::Comm
                 const auto aspect_mask = image_state->subresource_encoder.Decode(intersected_range.begin).aspectMask;
                 const bool matches = ImageLayoutMatches(aspect_mask, image_layout, first_layout);
                 if (!matches) {
+                    // TODO - this should detect the command, not just always use vkCmdDraw
+                    const char* vuid = cb_layout_state.submit_time_layout_mismatch_vuid
+                                           ? cb_layout_state.submit_time_layout_mismatch_vuid
+                                           : "VUID-vkCmdDraw-None-09600";
+                    const std::string debug_region = vvl::CommandBuffer::GetDebugRegionName(
+                        cb_submission.cb->GetLabelCommands(), cb_layout_state.label_command_i, cb_submission.initial_label_stack);
+                    const Location loc_with_region(loc, debug_region);
                     // We can report all the errors for the intersected range directly
                     for (auto index : vvl::range_view<decltype(intersected_range)>(intersected_range)) {
                         const auto subresource = image_state->subresource_encoder.Decode(index);
-                        const LogObjectList objlist(cb_state.Handle(), image_state->Handle());
-                        // TODO - this should detect the command, not just always use vkCmdDraw
-                        const char* vuid = cb_layout_state.submit_time_layout_mismatch_vuid
-                                               ? cb_layout_state.submit_time_layout_mismatch_vuid
-                                               : "VUID-vkCmdDraw-None-09600";
+                        const LogObjectList objlist(cb_submission.cb->Handle(), image_state->Handle());
                         skip |= LogError(
-                            vuid, objlist, loc,
+                            vuid, objlist, loc_with_region,
                             "command buffer %s expects %s (subresource: %s) to be in layout %s--instead, current layout is %s.",
-                            FormatHandle(cb_state).c_str(), FormatHandle(*image_state).c_str(),
+                            FormatHandle(*cb_submission.cb).c_str(), FormatHandle(*image_state).c_str(),
                             string_VkImageSubresource(subresource).c_str(), string_VkImageLayout(first_layout),
                             string_VkImageLayout(image_layout));
                     }
@@ -320,7 +324,7 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::Comm
                     const bool fence_signal = swapchain_image.acquire_fence_status == vvl::AcquireSyncStatus::Signaled;
 
                     if (!swapchain_image.acquired) {
-                        const LogObjectList objlist(cb_state.Handle(), image_state->Handle());
+                        const LogObjectList objlist(cb_submission.cb->Handle(), image_state->Handle());
                         // VUID request: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4784
                         // TODO: remove spec text after VUID is added
                         static const char* acquire_image_usage_spec_text =
@@ -346,7 +350,7 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::Comm
                             }
                             oss << FormatHandle(*swapchain_image.acquire_fence);
                         }
-                        const LogObjectList objlist(cb_state.Handle(), image_state->Handle());
+                        const LogObjectList objlist(cb_submission.cb->Handle(), image_state->Handle());
                         // VUID request: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4784
                         // TODO: remove spec text after VUID is added
                         static const char* acquire_image_usage_spec_text =
@@ -1049,7 +1053,8 @@ bool CoreChecks::ValidateImageBarrierLayouts(const vvl::CommandBuffer& cb_state,
                 });
 
             UpdateCurrentLayout(*local_layout_map, RangeGenerator(image_state.subresource_encoder, normalized_isr),
-                                image_barrier.newLayout, kInvalidLayout, normalized_isr.aspectMask);
+                                image_barrier.newLayout, kInvalidLayout, normalized_isr.aspectMask,
+                                cb_state.GetLastLabelCommandIndex());
         }
     }
     return skip;

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -738,16 +738,16 @@ static Location GetSignaledSemaphoreLocation(const Location& submit_loc, uint32_
 }
 
 bool CoreChecks::ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker,
-                                        const std::vector<std::shared_ptr<vvl::CommandBuffer>>& command_buffers,
+                                        const std::vector<vvl::CommandBufferSubmission>& cb_submissions,
                                         vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, const Location& submit_loc) {
     bool skip = false;
     // Validate image layouts on the command buffer boundaries
     {
         vvl::unordered_map<const vvl::Image*, ImageLayoutMap> local_image_layout_map;
-        for (const auto& cb : command_buffers) {
-            if (cb) {
-                auto cb_guard = cb->ReadLock();
-                skip |= ValidateCmdBufImageLayouts(submit_loc, *cb, local_image_layout_map);
+        for (const auto& cb_submission : cb_submissions) {
+            if (cb_submission.cb) {
+                auto cb_guard = cb_submission.cb->ReadLock();
+                skip |= ValidateCmdBufImageLayouts(submit_loc, cb_submission, local_image_layout_map);
             }
         }
     }
@@ -773,8 +773,8 @@ bool CoreChecks::ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker,
         }
     }
     // Queue family ownership transfer (QFOT) validation
-    for (const auto& cb : command_buffers) {
-        if (cb) {
+    for (const auto& cb_submission : cb_submissions) {
+        if (const auto& cb = cb_submission.cb) {
             auto cb_guard = cb->ReadLock();
             for (const vvl::CommandBuffer* secondary : cb->linked_command_buffers) {
                 skip |= ValidateQueuedQFOTransfers(*secondary, submit_loc);
@@ -783,8 +783,8 @@ bool CoreChecks::ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker,
         }
     }
     if (!skip) {
-        for (const auto& cb : command_buffers) {
-            if (cb) {
+        for (const auto& cb_submission : cb_submissions) {
+            if (const auto& cb = cb_submission.cb) {
                 auto cb_guard = cb->WriteLock();
                 for (vvl::CommandBuffer* secondary : cb->linked_command_buffers) {
                     UpdateCmdBufImageLayouts(*secondary);

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -31,6 +31,7 @@
 #include "state_tracker/event_state.h"
 #include "state_tracker/pipeline_state.h"
 #include "state_tracker/query_state.h"
+#include "state_tracker/queue_state.h"
 #include "state_tracker/render_pass_state.h"
 #include "state_tracker/shader_object_state.h"
 
@@ -312,9 +313,12 @@ void CommandBufferSubState::RecordCopyBufferCommon(vvl::Buffer& src_buffer_state
         dst_ranges_bounds.end = std::max(dst_ranges_bounds.end, region.dstOffset + region.size);
     }
 
+    const uint32_t label_command_i = base.GetLastLabelCommandIndex();
+
     auto queue_submit_validation = [this, &src_buffer_state, &dst_buffer_state, src_ranges = std::move(src_ranges),
-                                    dst_ranges = std::move(dst_ranges), src_ranges_bounds, dst_ranges_bounds,
-                                    loc](const class vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state) -> bool {
+                                    dst_ranges = std::move(dst_ranges), src_ranges_bounds, dst_ranges_bounds, loc,
+                                    label_command_i](const class vvl::Queue& queue_state,
+                                                     const vvl::CommandBufferSubmission& cb_submission) -> bool {
         bool skip = false;
 
         auto src_vk_memory_to_ranges_map = src_buffer_state.GetBoundRanges(src_ranges_bounds, src_ranges);
@@ -336,11 +340,15 @@ void CommandBufferSubState::RecordCopyBufferCommon(vvl::Buffer& src_buffer_state
                 if (src_ranges_it->first.intersects(dst_ranges_it->first)) {
                     auto memory_range_overlap = src_ranges_it->first & dst_ranges_it->first;
 
-                    const LogObjectList objlist(cb_state.Handle(), src_buffer_state.Handle(), dst_buffer_state.Handle(), vk_memory);
+                    const LogObjectList objlist(base.VkHandle(), src_buffer_state.Handle(), dst_buffer_state.Handle(),
+                                                vk_memory);
+                    const std::string dbg_region_name = vvl::CommandBuffer::GetDebugRegionName(
+                        base.GetLabelCommands(), label_command_i, cb_submission.initial_label_stack);
+                    const Location loc_with_dbg_region(loc, dbg_region_name);
                     const bool is_2 = loc.function == vvl::Func::vkCmdCopyBuffer2 || loc.function == vvl::Func::vkCmdCopyBuffer2KHR;
                     const char* vuid = is_2 ? "VUID-VkCopyBufferInfo2-pRegions-00117" : "VUID-vkCmdCopyBuffer-pRegions-00117";
                     skip |= validator.LogError(
-                        vuid, objlist, loc,
+                        vuid, objlist, loc_with_dbg_region,
                         "Copy source buffer range %s (from buffer %s) and destination buffer range %s (from buffer %s) are "
                         "bound to the same memory (%s), "
                         "and end up overlapping on memory range %s.",
@@ -1345,9 +1353,10 @@ void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_c
     });
 }
 
-void CommandBufferSubState::Submit(vvl::Queue& queue_state, uint32_t perf_submit_pass, const Location& loc) {
+void CommandBufferSubState::Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission,
+                                   const vvl::CommandBufferSubmission& cb_submission) {
     for (auto& func : queue_submit_functions) {
-        func(queue_state, base);
+        func(queue_state, cb_submission);
     }
 
     // Update global vvl:Event state with signaling state at the end of the command buffer
@@ -1375,7 +1384,7 @@ void CommandBufferSubState::Submit(vvl::Queue& queue_state, uint32_t perf_submit
     // Update vvl::QueryPool with a query state at the end of the command buffer.
     // Ultimately, it tracks the final query state for the entire submission.
     {
-        const QueryMap local_query_to_state_map = GetLocalQueryMap(perf_submit_pass);
+        const QueryMap local_query_to_state_map = GetLocalQueryMap(queue_submission.perf_submit_pass);
         for (const auto& [query_object, query_state] : local_query_to_state_map) {
             auto query_pool_state = base.dev_data.Get<vvl::QueryPool>(query_object.pool);
             if (!query_pool_state) continue;

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -139,7 +139,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordExecuteCommand(vvl::CommandBuffer &secondary_command_buffer, uint32_t cmd_index, const Location &loc) final;
 
     // Called from the Command Buffer state
-    void Submit(vvl::Queue &queue_state, uint32_t perf_submit_pass, const Location &loc) final;
+    void Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission,
+                const vvl::CommandBufferSubmission& cb_submission) final;
 
     CoreChecks &validator;
 
@@ -210,7 +211,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     std::vector<WaitEvent2SubmitInfo> wait_event2_submit_infos;
 
     // Validation functions run at primary CB queue submit time
-    using QueueCallback = std::function<bool(const class vvl::Queue &queue_state, const vvl::CommandBuffer &cb_state)>;
+    using QueueCallback =
+        std::function<bool(const class vvl::Queue& queue_state, const vvl::CommandBufferSubmission& cb_submission)>;
     std::vector<QueueCallback> queue_submit_functions;
 
     // Validation functions run when secondary CB is executed in primary

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1291,7 +1291,7 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo,
                                       const ErrorObject& error_obj) const override;
 
-    bool ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBuffer& cb_state,
+    bool ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBufferSubmission& cb_submission,
                                     vvl::unordered_map<const vvl::Image*, ImageLayoutMap>& local_image_layout_state) const;
 
     void UpdateCmdBufImageLayouts(const vvl::CommandBuffer& cb_state);
@@ -1616,7 +1616,7 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                      const ErrorObject& error_obj) const override;
     bool ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker,
-                                const std::vector<std::shared_ptr<vvl::CommandBuffer>>& command_buffers,
+                                const std::vector<vvl::CommandBufferSubmission>& command_buffers,
                                 vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, const Location& submit_loc) override;
     bool ProcessPresentBatch(const vvl::Image& swapchain_image, const Location& present_info_loc) override;
     bool IgnoreAllocationSize(const VkMemoryAllocateInfo& allocate_info) const;

--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -454,19 +454,18 @@ void RegisterDebugPrintf(Validator& gpuav, CommandBufferSubState& cb_state) {
                                                             cb.base.GetObjectList(bind_point));
         });
 
-    cb_state.on_cb_completion_functions.emplace_back([](Validator& gpuav, CommandBufferSubState& cb,
-                                                        const CommandBufferSubState::LabelLogging& label_logging,
-                                                        const Location& loc) {
-        debug_printf::CbState* debug_printf_cb_state = cb.shared_resources_cache.TryGet<debug_printf::CbState>();
-        if (!debug_printf_cb_state) {
+    cb_state.on_cb_completion_functions.emplace_back(
+        [](Validator& gpuav, CommandBufferSubState& cb, const vvl::CommandBufferSubmission&, const Location& loc) {
+            debug_printf::CbState* debug_printf_cb_state = cb.shared_resources_cache.TryGet<debug_printf::CbState>();
+            if (!debug_printf_cb_state) {
+                return true;
+            }
+            for (debug_printf::BufferInfo& buffer_info : debug_printf_cb_state->buffer_infos) {
+                uint32_t* output_ptr = (uint32_t*)buffer_info.output_mem_buffer.offset_mapped_ptr;
+                debug_printf::AnalyzeAndGenerateMessage(gpuav, cb.VkHandle(), buffer_info, output_ptr, loc);
+            }
             return true;
-        }
-        for (debug_printf::BufferInfo& buffer_info : debug_printf_cb_state->buffer_infos) {
-            uint32_t* output_ptr = (uint32_t*)buffer_info.output_mem_buffer.offset_mapped_ptr;
-            debug_printf::AnalyzeAndGenerateMessage(gpuav, cb.VkHandle(), buffer_info, output_ptr, loc);
-        }
-        return true;
-    });
+        });
 }
 
 }  // namespace debug_printf

--- a/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
+++ b/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
@@ -144,10 +144,9 @@ void RegisterPostProcessingValidation(Validator& gpuav, CommandBufferSubState& c
     }
 
     // Validate descriptor set accesses done by command buffer submission
-    cb.on_cb_completion_functions.emplace_back([bound_desc_sets_to_pp_buffer_map](
-                                                   Validator& gpuav, CommandBufferSubState& cb,
-                                                   const CommandBufferSubState::LabelLogging& label_logging,
-                                                   const Location& submission_loc) {
+    cb.on_cb_completion_functions.emplace_back([bound_desc_sets_to_pp_buffer_map](Validator& gpuav, CommandBufferSubState& cb,
+                                                                                  const vvl::CommandBufferSubmission& cb_submission,
+                                                                                  const Location& submission_loc) {
         VVL_ZoneScoped;
 
         // We loop each vkCmdBindDescriptorSet, find each VkDescriptorSet that was used in the command buffer, and check
@@ -255,8 +254,8 @@ void RegisterPostProcessingValidation(Validator& gpuav, CommandBufferSubState& c
                     const CommandBufferSubState::CommandErrorLogger& cmd_error_logger =
                         cb.GetErrorLogger(descriptor_access.error_logger_i);
                     context.SetObjlistForGpuAv(&cmd_error_logger.objlist);
-                    std::string debug_region_name =
-                        cb.GetDebugLabelRegion(cmd_error_logger.label_cmd_i, label_logging.initial_label_stack);
+                    std::string debug_region_name = vvl::CommandBuffer::GetDebugRegionName(
+                        cb.base.GetLabelCommands(), cmd_error_logger.label_cmd_i, cb_submission.initial_label_stack);
 
                     Location access_loc(cmd_error_logger.loc.Get(), debug_region_name);
                     context.SetLocationForGpuAv(access_loc);

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -27,6 +27,7 @@
 #include "gpuav/validation_cmd/gpuav_draw.h"
 
 #include "profiling/profiling.h"
+#include "state_tracker/cmd_buffer_state.h"
 #include "state_tracker/last_bound_state.h"
 #include "state_tracker/pipeline_layout_state.h"
 
@@ -167,8 +168,7 @@ void CommandBufferSubState::AddCommandErrorLogger(const Location& loc, const Las
         return;
     }
 
-    const uint32_t label_command_i =
-        base.GetLabelCommands().empty() ? vvl::kNoIndex32 : uint32_t(base.GetLabelCommands().size() - 1);
+    const uint32_t label_command_i = base.GetLastLabelCommandIndex();
     command_error_loggers_.emplace_back(CommandBufferSubState::CommandErrorLogger{
         loc, last_bound ? last_bound->cb_state.GetObjectList(last_bound->bind_point) : LogObjectList{VkHandle()},
         std::move(error_logger_func), label_command_i});
@@ -242,26 +242,6 @@ uint32_t CommandBufferSubState::GetActionCommandIndex(VkPipelineBindPoint bind_p
 }
 
 uint32_t CommandBufferSubState::GetTotalActionCommandCount() const { return draw_index + compute_index + trace_rays_index; }
-
-std::string CommandBufferSubState::GetDebugLabelRegion(uint32_t label_command_i,
-                                                       const std::vector<std::string>& initial_label_stack) const {
-    std::string debug_region_name;
-    if (label_command_i != vvl::kNoIndex32) {
-        debug_region_name = base.GetDebugRegionName(base.GetLabelCommands(), label_command_i, initial_label_stack);
-    } else {
-        // label_command_i == vvl::kNoIndex32 => when the instrumented command was recorded,
-        // no debug label region was yet opened in the corresponding command buffer,
-        // but still a region might have been started in another previously submitted
-        // command buffer. So just compute region name from initial_label_stack.
-        for (const std::string& label_name : initial_label_stack) {
-            if (!debug_region_name.empty()) {
-                debug_region_name += "::";
-            }
-            debug_region_name += label_name;
-        }
-    }
-    return debug_region_name;
-}
 
 vko::Buffer& CommandBufferSubState::GetInternalDescriptorBuffer() {
     if (internal_descriptor_buffer_.IsDestroyed()) {
@@ -372,7 +352,7 @@ bool CommandBufferSubState::PostSubmit(QueueSubState& queue, const Location& loc
 bool CommandBufferSubState::NeedsPostProcess() { return error_output_buffer_range_.buffer != VK_NULL_HANDLE; }
 
 // For the given command buffer, map its debug data buffers and read their contents for analysis.
-void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::string>& initial_label_stack, const Location& loc) {
+void CommandBufferSubState::OnCompletion(VkQueue queue, const vvl::CommandBufferSubmission& cb_submission, const Location& loc) {
     VVL_ZoneScoped;
 
     // CommandBuffer::Destroy can happen on an other thread,
@@ -422,7 +402,8 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::s
                     const CommandErrorLogger& error_logger = GetErrorLogger(error_logger_i);
                     const LogObjectList objlist(queue, error_logger.objlist);
 
-                    std::string debug_region_name = GetDebugLabelRegion(error_logger.label_cmd_i, initial_label_stack);
+                    std::string debug_region_name = vvl::CommandBuffer::GetDebugRegionName(
+                        base.GetLabelCommands(), error_logger.label_cmd_i, cb_submission.initial_label_stack);
                     Location loc_with_debug_region(error_logger.loc.Get(), debug_region_name);
                     error_logger.error_logger_func(error_record_ptr, loc_with_debug_region, objlist);
                 }
@@ -448,9 +429,8 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::s
     }
 
     bool success = true;
-    LabelLogging label_logging = {initial_label_stack};
     for (auto& on_cb_completion_func : on_cb_completion_functions) {
-        success = on_cb_completion_func(gpuav_, *this, label_logging, loc);
+        success = on_cb_completion_func(gpuav_, *this, cb_submission, loc);
         if (!success) {
             break;
         }
@@ -643,11 +623,11 @@ void QueueSubState::Retire(vvl::QueueSubmission& submission) {
                 auto guard = cb_submission.cb->WriteLock();
                 auto& gpu_cb = SubState(*cb_submission.cb);
                 auto loc = submission.loc.Get();
-                gpu_cb.OnCompletion(VkHandle(), cb_submission.initial_label_stack, loc);
+                gpu_cb.OnCompletion(VkHandle(), cb_submission, loc);
                 for (vvl::CommandBuffer* secondary_cb : gpu_cb.base.linked_command_buffers) {
                     auto secondary_guard = secondary_cb->WriteLock();
                     auto& secondary_gpu_cb = SubState(*secondary_cb);
-                    secondary_gpu_cb.OnCompletion(VkHandle(), cb_submission.initial_label_stack, loc);
+                    secondary_gpu_cb.OnCompletion(VkHandle(), cb_submission, loc);
                 }
             }
         }

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -75,8 +75,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     using OnCommandBufferSubmission =
         stdext::inplace_function<void(Validator &gpuav, CommandBufferSubState &cb, VkCommandBuffer per_submission_cb)>;
     using OnCommandBufferCompletion =
-        stdext::inplace_function<bool(Validator &gpuav, CommandBufferSubState &cb,
-                                      const CommandBufferSubState::LabelLogging &label_logging, const Location &submission_loc),
+        stdext::inplace_function<bool(Validator& gpuav, CommandBufferSubState& cb,
+                                      const vvl::CommandBufferSubmission& cb_submission, const Location& submission_loc),
                                  64>;
     using OnPreCommandBufferSubmission =
         stdext::inplace_function<void(Validator &gpuav, CommandBufferSubState &cb, VkCommandBuffer per_pre_submission_cb), 48>;
@@ -106,7 +106,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     [[nodiscard]] bool PreSubmit(QueueSubState &queue, const Location &loc);
     [[nodiscard]] bool PostSubmit(QueueSubState &queue, const Location &loc);
-    void OnCompletion(VkQueue queue, const std::vector<std::string> &initial_label_stack, const Location &loc);
+    void OnCompletion(VkQueue queue, const vvl::CommandBufferSubmission& cb_submission, const Location& loc);
 
     const VkDescriptorSetLayout &GetInstrumentationDescriptorSetLayout() const {
         assert(instrumentation_desc_set_layout_ != VK_NULL_HANDLE);
@@ -124,8 +124,6 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
         assert(cmd_errors_counts_buffer_.VkHandle() != VK_NULL_HANDLE);
         return cmd_errors_counts_buffer_.VkHandle();
     }
-
-    std::string GetDebugLabelRegion(uint32_t label_command_i, const std::vector<std::string> &initial_label_stack) const;
 
     void Destroy() final;
     void Reset(const Location &loc) final;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1906,7 +1906,7 @@ void CommandBuffer::SetImageLayout(const vvl::Image& image_state, const VkImageS
         if (image_state.subresource_encoder.InRange(normalized_subresource_range)) {
             RangeGenerator range_gen(image_state.subresource_encoder, normalized_subresource_range);
             if (UpdateCurrentLayout(*image_layout_map, std::move(range_gen), layout, expected_layout,
-                                    normalized_subresource_range.aspectMask)) {
+                                    normalized_subresource_range.aspectMask, GetLastLabelCommandIndex())) {
                 image_layout_change_count++;  // Change the version of this data to force revalidation
             }
         }
@@ -1918,7 +1918,7 @@ void CommandBuffer::TrackImageViewFirstLayout(const vvl::ImageView& view_state, 
     if (auto image_layout_map = GetOrCreateImageLayoutMap(*view_state.image_state.get())) {
         RangeGenerator range_gen(view_state.range_generator);
         TrackFirstLayout(*image_layout_map, std::move(range_gen), layout, view_state.normalized_subresource_range.aspectMask,
-                         submit_time_layout_mismatch_vuid);
+                         submit_time_layout_mismatch_vuid, GetLastLabelCommandIndex());
     }
 }
 
@@ -1932,7 +1932,7 @@ void CommandBuffer::TrackDepthAttachmentFirstLayout(const vvl::ImageView& view_s
         RangeGenerator range_gen(view_state.image_state->subresource_encoder, image_layout_range);
 
         TrackFirstLayout(*image_layout_map, std::move(range_gen), layout, VK_IMAGE_ASPECT_DEPTH_BIT,
-                         submit_time_layout_mismatch_vuid);
+                         submit_time_layout_mismatch_vuid, GetLastLabelCommandIndex());
     }
 }
 
@@ -1946,7 +1946,7 @@ void CommandBuffer::TrackStencilAttachmentFirstLayout(const vvl::ImageView& view
         RangeGenerator range_gen(view_state.image_state->subresource_encoder, image_layout_range);
 
         TrackFirstLayout(*image_layout_map, std::move(range_gen), layout, VK_IMAGE_ASPECT_STENCIL_BIT,
-                         submit_time_layout_mismatch_vuid);
+                         submit_time_layout_mismatch_vuid, GetLastLabelCommandIndex());
     }
 }
 
@@ -1961,7 +1961,8 @@ void CommandBuffer::TrackImageFirstLayout(const vvl::Image& image_state, const V
         }
         if (image_state.subresource_encoder.InRange(normalized_subresource_range)) {
             RangeGenerator range_gen(image_state.subresource_encoder, normalized_subresource_range);
-            TrackFirstLayout(*image_layout_map, std::move(range_gen), layout, normalized_subresource_range.aspectMask, nullptr);
+            TrackFirstLayout(*image_layout_map, std::move(range_gen), layout, normalized_subresource_range.aspectMask, nullptr,
+                             GetLastLabelCommandIndex());
         }
     }
 }
@@ -2535,20 +2536,6 @@ void CommandBuffer::RecordSetRenderingInputAttachmentIndices(const VkRenderingIn
     SetRenderingInputAttachmentIndices(rendering_attachments, pLocationInfo);
 }
 
-void CommandBuffer::SubmitTimeValidate(Queue& queue_state, uint32_t perf_submit_pass, const Location& loc) {
-    for (const auto& it : video_session_updates) {
-        auto video_session_state = dev_data.Get<vvl::VideoSession>(it.first);
-        auto device_state = video_session_state->DeviceStateWrite();
-        for (const auto& function : it.second) {
-            function(video_session_state.get(), *device_state, /*do_validate*/ false);
-        }
-    }
-
-    for (auto& item : sub_states_) {
-        item.second->Submit(queue_state, perf_submit_pass, loc);
-    }
-}
-
 uint32_t CommandBuffer::GetDynamicRenderingColorAttachmentCount() const {
     return active_render_pass ? active_render_pass->dynamic_rendering_color_attachment_count : 0;
 }
@@ -2698,12 +2685,18 @@ void CommandBuffer::ReplayLabelCommands(const vvl::span<const LabelCommand>& lab
 
 std::string CommandBuffer::GetDebugRegionName(const std::vector<LabelCommand>& label_commands, uint32_t label_command_index,
                                               const std::vector<std::string>& initial_label_stack) {
-    if (label_command_index >= label_commands.size()) {
-        // Can happen due to core validation error when in-use command buffer was re-recorded.
-        // It's a bug if this happens in a valid vulkan program.
-        return {};
+    // If label_command_index is invalid, current command buffer did not open any debug label region.
+    // So just compute a region name from initial_label_stack
+    vvl::span<const LabelCommand> label_commands_to_replay;
+
+    if (label_command_index != vvl::kNoIndex32) {
+        if (label_command_index >= label_commands.size()) {
+            // Can happen due to core validation error when in-use command buffer was re-recorded.
+            // It's a bug if this happens in a valid vulkan program.
+            return {};
+        }
+        label_commands_to_replay = vvl::make_span(label_commands.data(), label_command_index + 1);
     }
-    auto label_commands_to_replay = vvl::make_span(label_commands.data(), label_command_index + 1);
     auto label_stack = initial_label_stack;
     vvl::CommandBuffer::ReplayLabelCommands(label_commands_to_replay, label_stack);
 
@@ -2716,6 +2709,10 @@ std::string CommandBuffer::GetDebugRegionName(const std::vector<LabelCommand>& l
         debug_region += label_name;
     }
     return debug_region;
+}
+
+uint32_t CommandBuffer::GetLastLabelCommandIndex() const {
+    return label_commands_.empty() ? vvl::kNoIndex32 : uint32_t(label_commands_.size() - 1);
 }
 
 std::string CommandBuffer::DescribeInvalidatedState(CBDynamicState dynamic_state) const {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -22,6 +22,7 @@
 #pragma once
 #include <vulkan/vulkan_core.h>
 #include <memory>
+#include "state_tracker/queue_state.h"
 #include "state_tracker/state_object.h"
 #include "state_tracker/image_layout_map.h"
 #include "state_tracker/pipeline_library_state.h"
@@ -46,6 +47,7 @@ class DeviceState;
 class Pipeline;
 class Framebuffer;
 class Queue;
+struct QueueSubmission;
 class RenderPass;
 class VideoSession;
 class VideoSessionParameters;
@@ -798,8 +800,6 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void TrackImageFirstLayout(const vvl::Image &image_state, const VkImageSubresourceRange &subresource_range,
                                int32_t depth_offset, uint32_t depth_extent, VkImageLayout layout);
 
-    void SubmitTimeValidate(Queue &queue_state, uint32_t perf_submit_pass, const Location &loc);
-
     // Helpers to offset into |active_attachments|
     // [all color, all color resolve, depth, depth resolve, stencil, stencil resolve, FragmentDensityMap]
     uint32_t GetDynamicRenderingColorAttachmentCount() const;
@@ -824,6 +824,8 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
 
     const std::vector<LabelCommand> &GetLabelCommands() const { return label_commands_; }
 
+    uint32_t GetLastLabelCommandIndex() const;
+
     // Applies label commands to the label_stack: for "begin label" command it pushes
     // a label on the stack, and for the "end label" command it removes the top label.
     static void ReplayLabelCommands(const vvl::span<const LabelCommand> &label_commands, std::vector<std::string> &label_stack);
@@ -831,6 +833,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     static std::string GetDebugRegionName(const std::vector<LabelCommand>& label_commands, uint32_t label_command_index,
                                           const std::vector<std::string>& initial_label_stack = {});
 
+    auto& GetSubstates() { return sub_states_; }
     // This command buffer might contain a push descriptor set, which is not tracked in the object maps.
     // So the only way to cleanup SubStates on the descriptor set is through here.
     void RemoveOwnedSubState(LayerObjectTypeId id);
@@ -856,6 +859,8 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void RecordVideoEncodeQuantizationMap(const VkVideoEncodeQuantizationMapInfoKHR &quant_map_info);
     void UnbindResources();
 };
+
+struct CommandBufferSubmission;
 
 class CommandBufferSubState {
   public:
@@ -991,7 +996,7 @@ class CommandBufferSubState {
 
     virtual void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {}
 
-    virtual void Submit(Queue &queue_state, uint32_t perf_submit_pass, const Location &loc) {}
+    virtual void Submit(Queue& queue_state, const QueueSubmission& submission, const CommandBufferSubmission& cb_submission) {}
 
     VulkanTypedHandle Handle() const;
     VkCommandBuffer VkHandle() const;

--- a/layers/state_tracker/image_layout_map.cpp
+++ b/layers/state_tracker/image_layout_map.cpp
@@ -108,23 +108,25 @@ static bool IterateLayoutMapRanges(
 }
 
 bool UpdateCurrentLayout(CommandBufferImageLayoutMap& image_layout_map, RangeGenerator&& range_gen, VkImageLayout layout,
-                         VkImageLayout expected_layout, VkImageAspectFlags aspect_mask) {
+                         VkImageLayout expected_layout, VkImageAspectFlags aspect_mask, uint32_t label_command_i) {
     assert(layout != kInvalidLayout);
     ImageLayoutState entry{};
     entry.current_layout = layout;
     entry.first_layout = (expected_layout != kInvalidLayout) ? expected_layout : layout;
     entry.aspect_mask = aspect_mask;
+    entry.label_command_i = label_command_i;
     return UpdateLayoutMap(image_layout_map, std::move(range_gen), entry);
 }
 
 void TrackFirstLayout(CommandBufferImageLayoutMap& image_layout_map, RangeGenerator&& range_gen, VkImageLayout expected_layout,
-                      VkImageAspectFlags aspect_mask, const char* submit_time_layout_mismatch_vuid) {
+                      VkImageAspectFlags aspect_mask, const char* submit_time_layout_mismatch_vuid, uint32_t label_command_i) {
     assert(expected_layout != kInvalidLayout);
     ImageLayoutState entry{};
     entry.current_layout = kInvalidLayout;
     entry.first_layout = expected_layout;
     entry.aspect_mask = aspect_mask;
     entry.submit_time_layout_mismatch_vuid = submit_time_layout_mismatch_vuid;
+    entry.label_command_i = label_command_i;
     UpdateLayoutMap(image_layout_map, std::move(range_gen), entry);
 }
 

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -24,6 +24,7 @@
 #include <memory>
 
 #include "containers/custom_containers.h"
+#include "containers/limits.h"
 #include "containers/small_range_map.h"
 #include "state_tracker/subresource_adapter.h"
 
@@ -51,6 +52,10 @@ struct ImageLayoutState {
     // If not null, this vuid is used to report an error.
     // If null, the current implementation will use VUID-vkCmdDraw-None-09600 until we fix all the places
     const char* submit_time_layout_mismatch_vuid;
+
+    // Index into the recording command buffer's label-command stream at the moment
+    // first_layout was recorded
+    uint32_t label_command_i = vvl::kNoIndex32;
 };
 
 // Tracks image layout state of each subresource of a single image during record time.
@@ -66,13 +71,15 @@ using ImageLayoutRegistry = vvl::unordered_map<VkImage, std::shared_ptr<CommandB
 // Update image layout state during command buffer recording phase.
 // The VkImageLayout parameters must be unnormalized values (as defined by the API) so they can be used in the error messages.
 bool UpdateCurrentLayout(CommandBufferImageLayoutMap& image_layout_map, subresource_adapter::RangeGenerator&& range_gen,
-                         VkImageLayout layout, VkImageLayout expected_layout, VkImageAspectFlags aspect_mask);
+                         VkImageLayout layout, VkImageLayout expected_layout, VkImageAspectFlags aspect_mask,
+                         uint32_t label_command_i);
 
 // Track image layout at the beginning of the command buffer.
 // Typically called by the APIs that specify the expected layout but do not perform a layout transition.
 // The VkImageLayout parameter must be unnormalized value (as defined by the API) so it can be used in the error messages.
 void TrackFirstLayout(CommandBufferImageLayoutMap& image_layout_map, subresource_adapter::RangeGenerator&& range_gen,
-                      VkImageLayout expected_layout, VkImageAspectFlags aspect_mask, const char* submit_time_layout_mismatch_vuid);
+                      VkImageLayout expected_layout, VkImageAspectFlags aspect_mask, const char* submit_time_layout_mismatch_vuid,
+                      uint32_t label_command_i);
 
 // Iterate over layout map subresource ranges that intersect with the ranges defined by RangeGenerator.
 // Runs the callback on each matching layout map range.

--- a/layers/state_tracker/query_state.cpp
+++ b/layers/state_tracker/query_state.cpp
@@ -20,7 +20,6 @@
 
 #include "state_tracker/query_state.h"
 #include "state_tracker/cmd_buffer_state.h"
-#include "state_tracker/render_pass_state.h"
 #include "utils/math_utils.h"
 
 namespace vvl {

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -27,6 +27,20 @@
 
 #include "profiling/profiling.h"
 
+void vvl::CommandBufferSubmission::SubmitTimeValidate(Queue& queue, const QueueSubmission& submission) {
+    for (const auto& it : cb->video_session_updates) {
+        auto video_session_state = cb->dev_data.Get<vvl::VideoSession>(it.first);
+        auto device_state = video_session_state->DeviceStateWrite();
+        for (const auto& function : it.second) {
+            function(video_session_state.get(), *device_state, /*do_validate*/ false);
+        }
+    }
+
+    for (auto& item : cb->GetSubstates()) {
+        item.second->Submit(queue, submission, *this);
+    }
+}
+
 void vvl::QueueSubmission::BeginUse() {
     for (SemaphoreInfo& wait : wait_semaphores) {
         wait.semaphore->BeginUse();
@@ -76,7 +90,7 @@ uint64_t vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission>&& submissions) 
                 secondary_cmd_buffer->submit_count++;
             }
             cb_submission.cb->submit_count++;
-            cb_submission.cb->SubmitTimeValidate(*this, submission.perf_submit_pass, submission.loc.Get());
+            cb_submission.SubmitTimeValidate(*this, submission);
         }
         // seq_ is atomic so we don't need a lock until updating the deque below.
         // Note that this relies on the external synchonization requirements for the

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -22,7 +22,6 @@
 #include "state_tracker/fence_state.h"
 #include "state_tracker/semaphore_state.h"
 #include "error_message/error_location.h"
-#include "chassis/dispatch_object.h"
 #include "vk_layer_config.h"
 #include <condition_variable>
 #include <deque>
@@ -36,8 +35,11 @@ namespace vvl {
 class CommandBuffer;
 class DeviceState;
 class QueueSubState;
+struct QueueSubmission;
 
 struct CommandBufferSubmission {
+    void SubmitTimeValidate(Queue& queue, const QueueSubmission& submission);
+
     std::shared_ptr<vvl::CommandBuffer> cb;
     // Specifically made for GPU-AV, for it has unique problems: Error reporting is done *after*
     // command buffer submissions, not at Pre/PostCall time.

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -88,6 +88,7 @@ class VideoSession;
 class VideoSessionParameters;
 class DataGraphPipelineSession;
 class SubmitTimeTracker;
+struct CommandBufferSubmission;
 struct DescriptorHashing;
 }  // namespace vvl
 
@@ -2346,7 +2347,7 @@ class DeviceProxy : public vvl::BaseDevice {
     // This became even more important after the spec allowed internally synchronized queues,
     // which means the same queue can be used from multiple threads
     virtual bool ProcessSubmissionBatch(const SubmitTimeTracker& tracker,
-                                        const std::vector<std::shared_ptr<vvl::CommandBuffer>>& command_buffers,
+                                        const std::vector<vvl::CommandBufferSubmission>& command_buffers,
                                         vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, const Location& submit_loc) {
         return false;
     }

--- a/layers/state_tracker/submit_time_tracker.cpp
+++ b/layers/state_tracker/submit_time_tracker.cpp
@@ -36,11 +36,7 @@ void SubmitTimeTracker::OnDestroyTimelineSemaphore(VkSemaphore timeline) {
 }
 
 bool SubmitTimeTracker::ProcessQueueSubmission(VkQueue queue, const QueueSubmission& submission) const {
-    std::vector<std::shared_ptr<CommandBuffer>> command_buffers;
-    command_buffers.reserve(submission.cb_submissions.size());
-    for (const auto& cb_info : submission.cb_submissions) {
-        command_buffers.emplace_back(cb_info.cb);
-    }
+    std::vector<CommandBufferSubmission> command_buffers = submission.cb_submissions;
 
     std::vector<VkSemaphoreSubmitInfo> wait_semaphores;
     wait_semaphores.reserve(submission.wait_semaphores.size());
@@ -87,7 +83,7 @@ bool SubmitTimeTracker::ProcessPresent(const VkPresentInfoKHR& present_info, con
     return skip;
 }
 
-bool SubmitTimeTracker::ProcessBatch(std::vector<std::shared_ptr<CommandBuffer>>&& command_buffers,
+bool SubmitTimeTracker::ProcessBatch(std::vector<CommandBufferSubmission>&& cb_submissions,
                                      vvl::span<const VkSemaphoreSubmitInfo> wait_semaphores,
                                      vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, VkQueue queue,
                                      const Location& submit_loc) {
@@ -99,14 +95,14 @@ bool SubmitTimeTracker::ProcessBatch(std::vector<std::shared_ptr<CommandBuffer>>
     const bool has_pending_waits = !unresolved_batches.empty() || !unresolved_timeline_waits.empty();
     if (has_pending_waits) {
         UnresolvedBatch batch(submit_loc);
-        batch.command_buffers = std::move(command_buffers);
+        batch.cb_submissions = std::move(cb_submissions);
         batch.unresolved_timeline_waits = std::move(unresolved_timeline_waits);
         batch.signals.assign(signal_semaphores.begin(), signal_semaphores.end());
         unresolved_batches.emplace_back(std::move(batch));
         return skip;
     }
 
-    skip |= validator_.ProcessSubmissionBatch(*this, command_buffers, signal_semaphores, submit_loc);
+    skip |= validator_.ProcessSubmissionBatch(*this, cb_submissions, signal_semaphores, submit_loc);
 
     const bool new_timeline_signals = RegisterTimelineSignals(signal_semaphores);
     if (new_timeline_signals) {
@@ -166,7 +162,7 @@ bool SubmitTimeTracker::PropagateTimelineSignals() {
                     break;
                 }
                 const auto signals = vvl::span<const VkSemaphoreSubmitInfo>(batch.signals.data(), batch.signals.size());
-                skip |= validator_.ProcessSubmissionBatch(*this, batch.command_buffers, signals, batch.submit_loc_capture.Get());
+                skip |= validator_.ProcessSubmissionBatch(*this, batch.cb_submissions, signals, batch.submit_loc_capture.Get());
                 new_timeline_signals |= RegisterTimelineSignals(batch.signals);
                 batches.erase(batches.begin());
             }

--- a/layers/state_tracker/submit_time_tracker.h
+++ b/layers/state_tracker/submit_time_tracker.h
@@ -19,6 +19,7 @@
 #include "containers/custom_containers.h"
 #include "containers/span.h"
 #include "error_message/error_location.h"
+#include "state_tracker/queue_state.h"
 #include <vulkan/vulkan.h>
 #include <memory>
 #include <mutex>
@@ -38,7 +39,7 @@ struct UnresolvedBatch {
     LocationCapture submit_loc_capture;
 
     // Command buffers to validate when dependencies are resolved
-    std::vector<std::shared_ptr<CommandBuffer>> command_buffers;
+    std::vector<CommandBufferSubmission> cb_submissions;
 
     // Timeline waits that block this batch
     std::vector<VkSemaphoreSubmitInfo> unresolved_timeline_waits;
@@ -67,8 +68,7 @@ class SubmitTimeTracker {
     std::optional<uint64_t> GetTimelineValue(VkSemaphore timeline) const;
 
   private:
-    bool ProcessBatch(std::vector<std::shared_ptr<CommandBuffer>>&& command_buffers,
-                      vvl::span<const VkSemaphoreSubmitInfo> wait_semaphores,
+    bool ProcessBatch(std::vector<CommandBufferSubmission>&& cb_submissions, vvl::span<const VkSemaphoreSubmitInfo> wait_semaphores,
                       vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, VkQueue queue, const Location& submit_loc);
     bool ProcessSignal(VkSemaphore timeline, uint64_t signal_value);
 

--- a/tests/unit/image_layout.cpp
+++ b/tests/unit/image_layout.cpp
@@ -109,6 +109,44 @@ TEST_F(NegativeImageLayout, Blit) {
     m_command_buffer.End();
 }
 
+TEST_F(NegativeImageLayout, SubmitTimeDebugRegion) {
+    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkFormat fmt = VK_FORMAT_R8G8B8A8_UNORM;
+    vkt::Image img_src_transfer(*m_device, 64, 64, fmt, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image img_color(*m_device, 64, 64, fmt,
+                         VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+
+    img_src_transfer.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+    img_color.SetLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+
+    VkImageBlit blit_region = {};
+    blit_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    blit_region.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    blit_region.srcOffsets[0] = {0, 0, 0};
+    blit_region.srcOffsets[1] = {32, 32, 1};
+    blit_region.dstOffsets[0] = {32, 32, 0};
+    blit_region.dstOffsets[1] = {64, 64, 1};
+
+    VkDebugUtilsLabelEXT label = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    label.pLabelName = "FrameWork";
+    vk::CmdBeginDebugUtilsLabelEXT(m_command_buffer, &label);
+    label.pLabelName = "BlitPass";
+    vk::CmdBeginDebugUtilsLabelEXT(m_command_buffer, &label);
+    vk::CmdBlitImage(m_command_buffer, img_src_transfer, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, img_color, VK_IMAGE_LAYOUT_GENERAL,
+                     1, &blit_region, VK_FILTER_LINEAR);
+    vk::CmdEndDebugUtilsLabelEXT(m_command_buffer);
+    vk::CmdEndDebugUtilsLabelEXT(m_command_buffer);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredErrorRegex("VUID-vkCmdDraw-None-09600", "Debug region: FrameWork::BlitPass");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeImageLayout, Compute) {
     TEST_DESCRIPTION("Attempt to use an image with an invalid layout in a compute shader");
 


### PR DESCRIPTION
part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8985

Trying to unify how sync val, GPU-AV and now Core validation manage debug labels is more complex than I thought, I really don't like the plumbing to store this "label_command_i" necessary to get debug labels at validation time. Trying to all systems seems needlessly tedious though, so I propose this PR.

Side note: While trying to understand code flow, and even though it was not necessary to get things working, I slightly changed `vvl::Queue::PreSubmit` so the `SubmitTimeValidate` call is easier to understand.