### PR TITLE
sync: Unify record/submit-time error messages

### DIFF
--- a/layers/sync/sync_command.cpp
+++ b/layers/sync/sync_command.cpp
@@ -27,6 +27,22 @@
 
 namespace syncval {
 
+static LogObjectList BaseObjectList(const SyncEnvironment& env, const CommandBufferContext& cb_context,
+                                    const VulkanTypedHandle& resource) {
+    LogObjectList objlist;
+    const VulkanTypedHandle& cb_handle = cb_context.GetCBState().Handle();
+
+    // During recording, env.handle is the command buffer handle. Skip to avoid duplication.
+    if (env.handle != cb_handle) {
+        // During replay, env.handle is the handle of the replayer (queue or primary command buffer).
+        objlist.add(env.handle);
+    }
+
+    objlist.add(cb_handle);
+    objlist.add(resource);
+    return objlist;
+}
+
 bool ReplayCommands(SyncEnvironment& env, AccessContext& access_context, const CommandBufferContext& cb_context,
                     ResourceUsageTag base_tag, const Location& loc) {
     bool skip = false;
@@ -86,40 +102,27 @@ bool BufferCopyCommand::Validate(const CommandBufferContext& cb_context, const L
 }
 
 bool BufferCopyCommand::Validate(const SyncEnvironment& env, const AccessContext& access_context,
-                                 const CommandBufferContext& cb_context, ResourceUsageTag command_tag, const Location& loc) const {
+                                 const CommandBufferContext& cb_context, ResourceUsageTag replay_tag, const Location& loc) const {
     bool skip = false;
     const SyncValidator& validator = env.validator;
-    const bool submit_time = env.handle.type == kVulkanObjectTypeQueue;
-
-    // TODO: Remove SubmitTimeError and extend BufferCopyError with submit-time details after
-    // command-base validation replaces current model. Until then, try to preserve identical
-    // error output so old and new can be compared during development.
 
     for (const auto [region_index, region] : vvl::enumerate(regions)) {
         const AccessRange src_range = MakeRange(src_buffer, region.src_offset, region.size);
         auto src_hazard = access_context.DetectHazard(src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
         if (src_hazard.IsHazard()) {
-            const LogObjectList objlist = submit_time ? LogObjectList(env.handle, cb_context.GetCBState().Handle())
-                                                      : LogObjectList(cb_context.GetCBState().Handle(), src_buffer.Handle());
-            const std::string error =
-                submit_time
-                    ? validator.error_messages_.SubmitTimeError(env, src_hazard, cb_context, command_tag, loc.index,
-                                                                validator.FormatHandle(src_buffer))
-                    : validator.error_messages_.BufferCopyError(env, src_hazard, loc.function, validator.FormatHandle(src_buffer),
-                                                                uint32_t(region_index), src_range);
+            const LogObjectList objlist = BaseObjectList(env, cb_context, src_buffer.Handle());
+            const std::string resource_description = validator.FormatHandle(src_buffer);
+            const std::string error = validator.error_messages_.BufferCopyError(
+                env, src_hazard, cb_context, replay_tag, loc, resource_description, uint32_t(region_index), src_range);
             skip |= validator.SyncError(src_hazard.Hazard(), objlist, loc, error);
         }
         const AccessRange dst_range = MakeRange(dst_buffer, region.dst_offset, region.size);
         auto dst_hazard = access_context.DetectHazard(dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
         if (dst_hazard.IsHazard()) {
-            const LogObjectList objlist = submit_time ? LogObjectList(env.handle, cb_context.GetCBState().Handle())
-                                                      : LogObjectList(cb_context.GetCBState().Handle(), dst_buffer.Handle());
-            const std::string error =
-                submit_time
-                    ? validator.error_messages_.SubmitTimeError(env, dst_hazard, cb_context, command_tag, loc.index,
-                                                                validator.FormatHandle(dst_buffer))
-                    : validator.error_messages_.BufferCopyError(env, dst_hazard, loc.function, validator.FormatHandle(dst_buffer),
-                                                                uint32_t(region_index), dst_range);
+            const LogObjectList objlist = BaseObjectList(env, cb_context, dst_buffer.Handle());
+            const std::string resource_description = validator.FormatHandle(dst_buffer);
+            const std::string error = validator.error_messages_.BufferCopyError(
+                env, dst_hazard, cb_context, replay_tag, loc, resource_description, uint32_t(region_index), dst_range);
             skip |= validator.SyncError(dst_hazard.Hazard(), objlist, loc, error);
         }
         if (skip) {
@@ -171,33 +174,26 @@ bool ImageCopyCommand::Validate(const SyncEnvironment& env, const AccessContext&
                                 const CommandBufferContext& cb_context, ResourceUsageTag replay_tag, const Location& loc) const {
     bool skip = false;
     const SyncValidator& validator = env.validator;
-    const bool submit_time = env.handle.type == kVulkanObjectTypeQueue;
 
     for (const auto [region_index, region] : vvl::enumerate(regions)) {
         auto src_hazard = access_context.DetectHazard(src_image, RangeFromLayers(region.srcSubresource), region.srcOffset,
                                                       region.extent, SYNC_COPY_TRANSFER_READ);
         if (src_hazard.IsHazard()) {
-            const LogObjectList objlist = submit_time ? LogObjectList(env.handle, cb_context.GetCBState().Handle())
-                                                      : LogObjectList(cb_context.GetCBState().Handle(), src_image.Handle());
-            const std::string error = submit_time
-                                          ? validator.error_messages_.SubmitTimeError(env, src_hazard, cb_context, replay_tag,
-                                                                                      loc.index, validator.FormatHandle(src_image))
-                                          : validator.error_messages_.ImageCopyResolveBlitError(
-                                                env, src_hazard, loc.function, validator.FormatHandle(src_image),
-                                                uint32_t(region_index), region.srcOffset, region.extent, region.srcSubresource);
+            const LogObjectList objlist = BaseObjectList(env, cb_context, src_image.Handle());
+            const std::string resource_description = validator.FormatHandle(src_image);
+            const std::string error = validator.error_messages_.ImageCopyResolveBlitError(
+                env, src_hazard, cb_context, replay_tag, loc, resource_description, uint32_t(region_index), region.srcOffset,
+                region.extent, region.srcSubresource);
             skip |= validator.SyncError(src_hazard.Hazard(), objlist, loc, error);
         }
         auto dst_hazard = access_context.DetectHazard(dst_image, RangeFromLayers(region.dstSubresource), region.dstOffset,
                                                       region.extent, SYNC_COPY_TRANSFER_WRITE);
         if (dst_hazard.IsHazard()) {
-            const LogObjectList objlist = submit_time ? LogObjectList(env.handle, cb_context.GetCBState().Handle())
-                                                      : LogObjectList(cb_context.GetCBState().Handle(), dst_image.Handle());
-            const std::string error = submit_time
-                                          ? validator.error_messages_.SubmitTimeError(env, dst_hazard, cb_context, replay_tag,
-                                                                                      loc.index, validator.FormatHandle(dst_image))
-                                          : validator.error_messages_.ImageCopyResolveBlitError(
-                                                env, dst_hazard, loc.function, validator.FormatHandle(dst_image),
-                                                uint32_t(region_index), region.dstOffset, region.extent, region.dstSubresource);
+            const LogObjectList objlist = BaseObjectList(env, cb_context, dst_image.Handle());
+            const std::string resource_description = validator.FormatHandle(dst_image);
+            const std::string error = validator.error_messages_.ImageCopyResolveBlitError(
+                env, dst_hazard, cb_context, replay_tag, loc, resource_description, uint32_t(region_index), region.dstOffset,
+                region.extent, region.dstSubresource);
             skip |= validator.SyncError(dst_hazard.Hazard(), objlist, loc, error);
         }
         if (skip) {
@@ -244,6 +240,8 @@ bool BarrierCommand::Validate(const CommandBufferContext& cb_context, const Loca
 bool BarrierCommand::Validate(const SyncEnvironment& env, const AccessContext& access_context,
                               const CommandBufferContext& cb_context, ResourceUsageTag replay_tag, const Location& loc) const {
     bool skip = false;
+    const SyncValidator& validator = env.validator;
+
     for (const auto& image_barrier : barrier_set.image_barriers) {
         if (!image_barrier.layout_transition) {
             // The only accesses that originate from the pipeline barrier are layout transitions
@@ -251,25 +249,18 @@ bool BarrierCommand::Validate(const SyncEnvironment& env, const AccessContext& a
         }
         const vvl::Image& image_state = *image_barrier.image;
         const bool can_transition_depth_slices =
-            CanTransitionDepthSlices(env.validator.extensions, image_state.GetImageType(), image_state.create_flags);
+            CanTransitionDepthSlices(validator.extensions, image_state.GetImageType(), image_state.create_flags);
 
         const auto hazard = access_context.DetectImageBarrierHazard(
             image_state, image_barrier.barrier.src_exec_scope.exec_scope, image_barrier.barrier.src_access_scope,
             image_barrier.subresource_range, can_transition_depth_slices, AccessContext::kDetectAll, env.queue_id);
 
         if (hazard.IsHazard()) {
-            if (replay_tag != kInvalidTag) {
-                LogObjectList objlist(env.handle, cb_context.GetCBState().Handle());
-                const std::string error = env.validator.error_messages_.SubmitTimeError(
-                    env, hazard, cb_context, replay_tag, loc.index, env.validator.FormatHandle(image_state.Handle()));
-                skip |= env.validator.SyncError(hazard.Hazard(), objlist, loc, error);
-            } else {
-                LogObjectList objlist(cb_context.GetCBState().Handle(), image_state.Handle());
-                const std::string resource_description = env.validator.FormatHandle(image_state.Handle());
-                const std::string error =
-                    env.validator.error_messages_.ImageBarrierError(env, hazard, loc.function, resource_description, image_barrier);
-                skip |= env.validator.SyncError(hazard.Hazard(), objlist, loc, error);
-            }
+            const LogObjectList objlist = BaseObjectList(env, cb_context, image_state.Handle());
+            const std::string resource_description = validator.FormatHandle(image_state.Handle());
+            const std::string error = validator.error_messages_.ImageBarrierError(env, hazard, cb_context, replay_tag, loc,
+                                                                                  resource_description, image_barrier);
+            skip |= validator.SyncError(hazard.Hazard(), objlist, loc, error);
         }
     }
     return skip;

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -28,7 +28,52 @@
 
 namespace syncval {
 
-ErrorMessages::ErrorMessages(SyncValidator& validator) : validator_(validator) {}
+vvl::Func ErrorMessages::AddReplayInfo(const SyncEnvironment& env, ResourceUsageTagEx prior_tag_ex,
+                                       const CommandBufferContext& cb_context, ResourceUsageTag replay_tag, const Location& loc,
+                                       AdditionalMessageInfo& additional_info) const {
+    if (replay_tag == kInvalidTag) {
+        return loc.function;
+    }
+    const ResourceUsageInfo recorded_usage_info = cb_context.GetResourceUsageInfo(ResourceUsageTagEx{replay_tag});
+
+    additional_info.message_type_override = "SubmitTimeError";
+    additional_info.properties.Add(kPropertyCommandBufferIndex, loc.index);
+    if (!recorded_usage_info.debug_region_name.empty()) {
+        additional_info.properties.Add(kPropertyDebugRegion, recorded_usage_info.debug_region_name);
+    }
+
+    std::ostringstream ss;
+    ss << vvl::String(recorded_usage_info.command);
+    if (!recorded_usage_info.debug_region_name.empty()) {
+        ss << "[" << recorded_usage_info.debug_region_name << "]";
+    }
+    if (env.handle.type == kVulkanObjectTypeQueue) {
+        ss << " (from " << validator_.FormatHandle(cb_context.GetCBState().Handle());
+        ss << " submitted on the current ";
+        ss << validator_.FormatHandle(env.handle) << ")";
+    } else {  // primary command buffer executes secondary one
+        assert(env.handle.type == kVulkanObjectTypeCommandBuffer);
+        ss << " (from the secondary " << validator_.FormatHandle(cb_context.GetCBState().Handle()) << ")";
+    }
+    additional_info.access_initiator = ss.str();
+
+    std::ostringstream ss2;
+    const ResourceUsageInfo prior_usage_info = env.usage_info_provider.GetResourceUsageInfo(prior_tag_ex);
+    if (prior_usage_info.queue) {
+        if (prior_usage_info.cb) {
+            ss2 << "(from " << validator_.FormatHandle(prior_usage_info.cb->Handle());
+            ss2 << " submitted on " << validator_.FormatHandle(prior_usage_info.queue->Handle()) << ")";
+        } else {  // QueuePresent case (not recorded into command buffer)
+            ss2 << "(submitted on " << validator_.FormatHandle(prior_usage_info.queue->Handle()) << ")";
+        }
+    } else if (prior_usage_info.cb) {
+        // TODO: distinuish between "native" primary command buffer commands and
+        // command recorded from the secondary command buffers.
+        ss2 << "(from the primary " << validator_.FormatHandle(prior_usage_info.cb->Handle()) << ")";
+    }
+    additional_info.brief_description_end_text = ss2.str();
+    return recorded_usage_info.command;
+}
 
 std::string ErrorMessages::Error(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                                  const std::string& resource_description, const char* message_type,
@@ -38,6 +83,9 @@ std::string ErrorMessages::Error(const SyncEnvironment& env, const HazardResult&
     if (validator_.syncval_settings.message_extra_properties) {
         if (!message.empty() && message.back() != '\n') {
             message += '\n';
+        }
+        if (additional_info.message_type_override) {
+            message_type = additional_info.message_type_override;
         }
         const ReportProperties properties = GetErrorMessageProperties(env, hazard, command, message_type, additional_info);
         message += properties.FormatExtraPropertiesSection();
@@ -59,9 +107,8 @@ std::string ErrorMessages::BufferError(const HazardResult& hazard, const Command
 }
 
 std::string ErrorMessages::BufferCopyError(const SyncEnvironment& env, const HazardResult& hazard, const vvl::Func command,
-                                           const std::string& resource_description, uint32_t region_index,
-                                           AccessRange range) const {
-    AdditionalMessageInfo additional_info;
+                                           const std::string& resource_description, uint32_t region_index, AccessRange range,
+                                           AdditionalMessageInfo additional_info) const {
     additional_info.properties.Add(kPropertyRegionIndex, region_index);
 
     std::ostringstream ss;
@@ -69,9 +116,18 @@ std::string ErrorMessages::BufferCopyError(const SyncEnvironment& env, const Haz
     ss << "  offset = " << range.begin << ",\n";
     ss << "  size = " << range.end - range.begin << "\n";
     ss << "}\n";
-    additional_info.message_end_text = ss.str();
+    additional_info.message_end_text += ss.str();
 
     return Error(env, hazard, command, resource_description, "BufferCopyError", additional_info);
+}
+
+std::string ErrorMessages::BufferCopyError(const SyncEnvironment& env, const HazardResult& hazard,
+                                           const CommandBufferContext& cb_context, ResourceUsageTag replay_tag, const Location& loc,
+                                           const std::string& resource_description, uint32_t region_index,
+                                           AccessRange range) const {
+    AdditionalMessageInfo additional_info;
+    const vvl::Func command = AddReplayInfo(env, hazard.TagEx(), cb_context, replay_tag, loc, additional_info);
+    return BufferCopyError(env, hazard, command, resource_description, region_index, range, std::move(additional_info));
 }
 
 std::string ErrorMessages::AccelerationStructureError(const HazardResult& hazard, const CommandBufferContext& cb_context,
@@ -100,7 +156,8 @@ std::string ErrorMessages::AccelerationStructureError(const HazardResult& hazard
 std::string ErrorMessages::ImageCopyResolveBlitError(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                                                      const std::string& resource_description, uint32_t region_index,
                                                      const VkOffset3D& offset, const VkExtent3D& extent,
-                                                     const VkImageSubresourceLayers& subresource) const {
+                                                     const VkImageSubresourceLayers& subresource,
+                                                     AdditionalMessageInfo additional_info) const {
     const char* action = nullptr;
     const char* message_type = nullptr;
     if (IsValueIn(command, {vvl::Func::vkCmdBlitImage, vvl::Func::vkCmdBlitImage2, vvl::Func::vkCmdBlitImage2KHR})) {
@@ -121,11 +178,21 @@ std::string ErrorMessages::ImageCopyResolveBlitError(const SyncEnvironment& env,
     ss << "  subresource = {" << string_VkImageSubresourceLayers(subresource) << "}\n";
     ss << "}\n";
 
-    AdditionalMessageInfo additional_info;
-    additional_info.message_end_text = ss.str();
+    additional_info.message_end_text += ss.str();
     additional_info.properties.Add(kPropertyRegionIndex, region_index);
 
     return Error(env, hazard, command, resource_description, message_type, additional_info);
+}
+
+std::string ErrorMessages::ImageCopyResolveBlitError(const SyncEnvironment& env, const HazardResult& hazard,
+                                                     const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+                                                     const Location& loc, const std::string& resource_description,
+                                                     uint32_t region_index, const VkOffset3D& offset, const VkExtent3D& extent,
+                                                     const VkImageSubresourceLayers& subresource) const {
+    AdditionalMessageInfo additional_info;
+    const vvl::Func command = AddReplayInfo(env, hazard.TagEx(), cb_context, replay_tag, loc, additional_info);
+    return ImageCopyResolveBlitError(env, hazard, command, resource_description, region_index, offset, extent, subresource,
+                                     std::move(additional_info));
 }
 
 std::string ErrorMessages::ImageClearError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
@@ -405,8 +472,8 @@ std::string ErrorMessages::RenderPassFinalLayoutTransitionVsStoreOrResolveError(
 }
 
 std::string ErrorMessages::ImageBarrierError(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
-                                             const std::string& resource_description, const SyncImageBarrier& barrier) const {
-    AdditionalMessageInfo additional_info;
+                                             const std::string& resource_description, const SyncImageBarrier& barrier,
+                                             AdditionalMessageInfo additional_info) const {
     additional_info.access_action = "performs image layout transition on the";
 
     std::ostringstream ss;
@@ -416,9 +483,18 @@ std::string ErrorMessages::ImageBarrierError(const SyncEnvironment& env, const H
     ss << "  dstStageMask = " << string_VkPipelineStageFlags2(barrier.barrier.dst_exec_scope.stage_mask) << ",\n";
     ss << "  dstAccessMask = " << string_VkAccessFlags2(barrier.barrier.original_dst_access) << ",\n";
     ss << "}\n";
-    additional_info.message_end_text = ss.str();
+    additional_info.message_end_text += ss.str();
 
     return Error(env, hazard, command, resource_description, "ImageBarrierError", additional_info);
+}
+
+std::string ErrorMessages::ImageBarrierError(const SyncEnvironment& env, const HazardResult& hazard,
+                                             const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+                                             const Location& loc, const std::string& resource_description,
+                                             const SyncImageBarrier& barrier) const {
+    AdditionalMessageInfo additional_info;
+    const vvl::Func command = AddReplayInfo(env, hazard.TagEx(), cb_context, replay_tag, loc, additional_info);
+    return ImageBarrierError(env, hazard, command, resource_description, barrier, std::move(additional_info));
 }
 
 std::string ErrorMessages::FirstUseError(const SyncEnvironment& env, const HazardResult& hazard,
@@ -435,10 +511,10 @@ std::string ErrorMessages::FirstUseError(const SyncEnvironment& env, const Hazar
 }
 
 std::string ErrorMessages::SubmitTimeError(const SyncEnvironment& env, const HazardResult& hazard,
-                                           const CommandBufferContext& recorded_context, ResourceUsageTag command_tag,
+                                           const CommandBufferContext& recorded_context, ResourceUsageTag replay_tag,
                                            uint32_t command_buffer_index, const std::string& resource_description) const {
     const ResourceUsageInfo prior_usage_info = env.usage_info_provider.GetResourceUsageInfo(hazard.TagEx());
-    const ResourceUsageInfo recorded_usage_info = recorded_context.GetResourceUsageInfo(ResourceUsageTagEx{command_tag});
+    const ResourceUsageInfo recorded_usage_info = recorded_context.GetResourceUsageInfo(ResourceUsageTagEx{replay_tag});
 
     AdditionalMessageInfo additional_info;
     additional_info.properties.Add(kPropertyCommandBufferIndex, command_buffer_index);

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -40,7 +40,7 @@ struct SyncImageBarrier;
 
 class ErrorMessages {
   public:
-    explicit ErrorMessages(SyncValidator& validator);
+    explicit ErrorMessages(SyncValidator& validator) : validator_(validator) {}
 
     std::string Error(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
                       const std::string& resource_description, const char* message_type,
@@ -50,15 +50,28 @@ class ErrorMessages {
                             const std::string& resource_description, const AccessRange range,
                             AdditionalMessageInfo additional_info = {}) const;
 
+    // TODO: temp legacy version
     std::string BufferCopyError(const SyncEnvironment& env, const HazardResult& hazard, const vvl::Func command,
-                                const std::string& resouce_description, uint32_t region_index, AccessRange range) const;
+                                const std::string& resouce_description, uint32_t region_index, AccessRange range,
+                                AdditionalMessageInfo additional_info = {}) const;
+
+    std::string BufferCopyError(const SyncEnvironment& env, const HazardResult& hazard, const CommandBufferContext& cb_context,
+                                ResourceUsageTag replay_tag, const Location& loc, const std::string& resource_description,
+                                uint32_t region_index, AccessRange range) const;
 
     std::string AccelerationStructureError(const HazardResult& hazard, const CommandBufferContext& cb_context,
                                            const vvl::Func command, const std::string& resource_description,
                                            const AccessRange range, VkAccelerationStructureKHR as,
                                            const Location& as_location) const;
 
+    // TODO: temp legacy version
     std::string ImageCopyResolveBlitError(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
+                                          const std::string& resource_description, uint32_t region_index, const VkOffset3D& offset,
+                                          const VkExtent3D& extent, const VkImageSubresourceLayers& subresource,
+                                          AdditionalMessageInfo additional_info = {}) const;
+
+    std::string ImageCopyResolveBlitError(const SyncEnvironment& env, const HazardResult& hazard,
+                                          const CommandBufferContext& cb_context, ResourceUsageTag replay_tag, const Location& loc,
                                           const std::string& resource_description, uint32_t region_index, const VkOffset3D& offset,
                                           const VkExtent3D& extent, const VkImageSubresourceLayers& subresource) const;
 
@@ -127,14 +140,20 @@ class ErrorMessages {
                                                                      VkImageLayout old_layout, VkImageLayout new_layout,
                                                                      uint32_t store_resolve_subpass) const;
 
+    // TODO: temp legacy version
     std::string ImageBarrierError(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,
-                                  const std::string& resource_description, const SyncImageBarrier& barrier) const;
+                                  const std::string& resource_description, const SyncImageBarrier& barrier,
+                                  AdditionalMessageInfo additional_info = {}) const;
+
+    std::string ImageBarrierError(const SyncEnvironment& env, const HazardResult& hazard, const CommandBufferContext& cb_context,
+                                  ResourceUsageTag replay_tag, const Location& loc, const std::string& resource_description,
+                                  const SyncImageBarrier& barrier) const;
 
     std::string FirstUseError(const SyncEnvironment& env, const HazardResult& hazard, const CommandBufferContext& recorded_context,
                               uint32_t command_buffer_index) const;
 
     std::string SubmitTimeError(const SyncEnvironment& env, const HazardResult& hazard,
-                                const CommandBufferContext& recorded_context, ResourceUsageTag command_tag,
+                                const CommandBufferContext& recorded_context, ResourceUsageTag replay_tag,
                                 uint32_t command_buffer_index, const std::string& resource_description) const;
 
     std::string PresentError(const HazardResult& hazard, const QueueBatchContext& batch_context, vvl::Func command,
@@ -142,6 +161,10 @@ class ErrorMessages {
 
     std::string VideoError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                            const std::string& resource_description) const;
+
+  private:
+    vvl::Func AddReplayInfo(const SyncEnvironment& env, ResourceUsageTagEx prior_tag_ex, const CommandBufferContext& cb_context,
+                            ResourceUsageTag replay_tag, const Location& loc, AdditionalMessageInfo& additional_info) const;
 
   private:
     SyncValidator& validator_;

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -61,6 +61,11 @@ struct AdditionalMessageInfo {
     std::string brief_description_end_text;
     std::string pre_synchronization_text;
     std::string message_end_text;
+
+    // TODO: remove when the command conversion is finished and clients are notified
+    // that instead of message_type = SubmitTimeError we will print more specific
+    // message type (as we do during record time validation).
+    const char* message_type_override = nullptr;
 };
 
 ReportProperties GetErrorMessageProperties(const SyncEnvironment& env, const HazardResult& hazard, vvl::Func command,

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -739,8 +739,7 @@ bool QueueBatchContext::ValidateSubmit(const std::vector<CommandBufferConstPtr>&
                                         ? submit_info_loc.dot(vvl::Field::pCommandBuffers, index)
                                         : submit_info_loc.dot(vvl::Field::pCommandBufferInfos, index);
 
-            if (sync_state_.syncval_settings.full_validation) {
-                assert(cb_context.HasAllCommands());
+            if (sync_state_.syncval_settings.full_validation && cb_context.HasAllCommands()) {
                 batch_log_.Import(batch, cb_context, current_label_stack);
                 skip |= ReplayCommands(GetSyncEnvironment(), GetAccessContext(), cb_context, batch.base_tag, cb_loc);
             } else {


### PR DESCRIPTION
With command replay, all information is available at submit time.
There is no need to use `SubmitTimeError` (simplified reporting used by
legacy submit-time validation). Instead, use the same error reporting as
during record time, with additional submit-time information such as
queue handle.