### PR TITLE
layers: Rename to CommandBufferSubmitInfo

### DIFF
--- a/layers/best_practices/bp_state.cpp
+++ b/layers/best_practices/bp_state.cpp
@@ -866,7 +866,7 @@ void CommandBufferSubState::RecordBindPipeline(VkPipelineBindPoint bind_point, v
     }
 }
 
-void CommandBufferSubState::Submit(vvl::Queue& queue_state, const vvl::QueueSubmission&, const vvl::CommandBufferSubmission&) {
+void CommandBufferSubState::Submit(vvl::Queue& queue_state, const vvl::QueueSubmission&, const vvl::CommandBufferSubmitInfo&) {
     for (auto& func : queue_submit_functions) {
         func(queue_state, base);
     }

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -226,7 +226,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordBindPipeline(VkPipelineBindPoint bind_point, vvl::Pipeline& pipeline) final;
 
     void Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission,
-                const vvl::CommandBufferSubmission& cb_submission) final;
+                const vvl::CommandBufferSubmitInfo& cb_info) final;
 
     // Move to private when possible
     void RecordAttachmentAccess(uint32_t attachment, VkImageAspectFlags aspects);

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -235,14 +235,14 @@ struct GlobalLayoutUpdater {
 
 // This validates that the first layout specified in the command buffer for the image
 // is the same as this image's global (actual/current) layout
-bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBufferSubmission& cb_submission,
+bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBufferSubmitInfo& cb_info,
                                             vvl::unordered_map<const vvl::Image*, ImageLayoutMap>& local_image_layout_state) const {
     if (disabled[image_layout_validation]) {
         return false;
     }
     bool skip = false;
     // Iterate over the layout maps for each referenced image
-    for (const auto& [image, cb_layout_map] : cb_submission.cb->image_layout_registry) {
+    for (const auto& [image, cb_layout_map] : cb_info.cb->image_layout_registry) {
         if (!cb_layout_map || cb_layout_map->empty()) {
             continue;
         }
@@ -297,16 +297,16 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::Comm
                                            ? cb_layout_state.submit_time_layout_mismatch_vuid
                                            : "VUID-vkCmdDraw-None-09600";
                     const std::string debug_region = vvl::CommandBuffer::GetDebugRegionName(
-                        cb_submission.cb->GetLabelCommands(), cb_layout_state.label_command_i, cb_submission.initial_label_stack);
+                        cb_info.cb->GetLabelCommands(), cb_layout_state.label_command_i, cb_info.initial_label_stack);
                     const Location loc_with_region(loc, debug_region);
                     // We can report all the errors for the intersected range directly
                     for (auto index : vvl::range_view<decltype(intersected_range)>(intersected_range)) {
                         const auto subresource = image_state->subresource_encoder.Decode(index);
-                        const LogObjectList objlist(cb_submission.cb->Handle(), image_state->Handle());
+                        const LogObjectList objlist(cb_info.cb->Handle(), image_state->Handle());
                         skip |= LogError(
                             vuid, objlist, loc_with_region,
                             "command buffer %s expects %s (subresource: %s) to be in layout %s--instead, current layout is %s.",
-                            FormatHandle(*cb_submission.cb).c_str(), FormatHandle(*image_state).c_str(),
+                            FormatHandle(*cb_info.cb).c_str(), FormatHandle(*image_state).c_str(),
                             string_VkImageSubresource(subresource).c_str(), string_VkImageLayout(first_layout),
                             string_VkImageLayout(image_layout));
                     }
@@ -324,7 +324,7 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::Comm
                     const bool fence_signal = swapchain_image.acquire_fence_status == vvl::AcquireSyncStatus::Signaled;
 
                     if (!swapchain_image.acquired) {
-                        const LogObjectList objlist(cb_submission.cb->Handle(), image_state->Handle());
+                        const LogObjectList objlist(cb_info.cb->Handle(), image_state->Handle());
                         // VUID request: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4784
                         // TODO: remove spec text after VUID is added
                         static const char* acquire_image_usage_spec_text =
@@ -350,7 +350,7 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::Comm
                             }
                             oss << FormatHandle(*swapchain_image.acquire_fence);
                         }
-                        const LogObjectList objlist(cb_submission.cb->Handle(), image_state->Handle());
+                        const LogObjectList objlist(cb_info.cb->Handle(), image_state->Handle());
                         // VUID request: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4784
                         // TODO: remove spec text after VUID is added
                         static const char* acquire_image_usage_spec_text =

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -738,16 +738,16 @@ static Location GetSignaledSemaphoreLocation(const Location& submit_loc, uint32_
 }
 
 bool CoreChecks::ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker,
-                                        const std::vector<vvl::CommandBufferSubmission>& cb_submissions,
+                                        const std::vector<vvl::CommandBufferSubmitInfo>& cb_infos,
                                         vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, const Location& submit_loc) {
     bool skip = false;
     // Validate image layouts on the command buffer boundaries
     {
         vvl::unordered_map<const vvl::Image*, ImageLayoutMap> local_image_layout_map;
-        for (const auto& cb_submission : cb_submissions) {
-            if (cb_submission.cb) {
-                auto cb_guard = cb_submission.cb->ReadLock();
-                skip |= ValidateCmdBufImageLayouts(submit_loc, cb_submission, local_image_layout_map);
+        for (const auto& cb_info : cb_infos) {
+            if (cb_info.cb) {
+                auto cb_guard = cb_info.cb->ReadLock();
+                skip |= ValidateCmdBufImageLayouts(submit_loc, cb_info, local_image_layout_map);
             }
         }
     }
@@ -773,8 +773,8 @@ bool CoreChecks::ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker,
         }
     }
     // Queue family ownership transfer (QFOT) validation
-    for (const auto& cb_submission : cb_submissions) {
-        if (const auto& cb = cb_submission.cb) {
+    for (const auto& cb_info : cb_infos) {
+        if (const auto& cb = cb_info.cb) {
             auto cb_guard = cb->ReadLock();
             for (const vvl::CommandBuffer* secondary : cb->linked_command_buffers) {
                 skip |= ValidateQueuedQFOTransfers(*secondary, submit_loc);
@@ -783,8 +783,8 @@ bool CoreChecks::ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker,
         }
     }
     if (!skip) {
-        for (const auto& cb_submission : cb_submissions) {
-            if (const auto& cb = cb_submission.cb) {
+        for (const auto& cb_info : cb_infos) {
+            if (const auto& cb = cb_info.cb) {
                 auto cb_guard = cb->WriteLock();
                 for (vvl::CommandBuffer* secondary : cb->linked_command_buffers) {
                     UpdateCmdBufImageLayouts(*secondary);

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -316,9 +316,8 @@ void CommandBufferSubState::RecordCopyBufferCommon(vvl::Buffer& src_buffer_state
     const uint32_t label_command_i = base.GetLastLabelCommandIndex();
 
     auto queue_submit_validation = [this, &src_buffer_state, &dst_buffer_state, src_ranges = std::move(src_ranges),
-                                    dst_ranges = std::move(dst_ranges), src_ranges_bounds, dst_ranges_bounds, loc,
-                                    label_command_i](const class vvl::Queue& queue_state,
-                                                     const vvl::CommandBufferSubmission& cb_submission) -> bool {
+                                    dst_ranges = std::move(dst_ranges), src_ranges_bounds, dst_ranges_bounds, loc, label_command_i](
+                                       const class vvl::Queue& queue_state, const vvl::CommandBufferSubmitInfo& cb_info) -> bool {
         bool skip = false;
 
         auto src_vk_memory_to_ranges_map = src_buffer_state.GetBoundRanges(src_ranges_bounds, src_ranges);
@@ -343,7 +342,7 @@ void CommandBufferSubState::RecordCopyBufferCommon(vvl::Buffer& src_buffer_state
                     const LogObjectList objlist(base.VkHandle(), src_buffer_state.Handle(), dst_buffer_state.Handle(),
                                                 vk_memory);
                     const std::string dbg_region_name = vvl::CommandBuffer::GetDebugRegionName(
-                        base.GetLabelCommands(), label_command_i, cb_submission.initial_label_stack);
+                        base.GetLabelCommands(), label_command_i, cb_info.initial_label_stack);
                     const Location loc_with_dbg_region(loc, dbg_region_name);
                     const bool is_2 = loc.function == vvl::Func::vkCmdCopyBuffer2 || loc.function == vvl::Func::vkCmdCopyBuffer2KHR;
                     const char* vuid = is_2 ? "VUID-VkCopyBufferInfo2-pRegions-00117" : "VUID-vkCmdCopyBuffer-pRegions-00117";
@@ -1354,9 +1353,9 @@ void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_c
 }
 
 void CommandBufferSubState::Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission,
-                                   const vvl::CommandBufferSubmission& cb_submission) {
+                                   const vvl::CommandBufferSubmitInfo& cb_info) {
     for (auto& func : queue_submit_functions) {
-        func(queue_state, cb_submission);
+        func(queue_state, cb_info);
     }
 
     // Update global vvl:Event state with signaling state at the end of the command buffer
@@ -1398,7 +1397,7 @@ void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission>& submissions) {
         submit_time_tracker->ProcessQueueSubmission(VkHandle(), submission);
 
         // Register pending event wait commands
-        for (const auto& cb_info : submission.cb_submissions) {
+        for (const auto& cb_info : submission.cb_infos) {
             CommandBufferSubState& cb_sub_state = SubState(*cb_info.cb);
             for (const auto& [event, wait_command] : cb_sub_state.first_event_wait_commands) {
                 submission.event_wait_commands.insert({event, wait_command});
@@ -1421,16 +1420,16 @@ void QueueSubState::Retire(vvl::QueueSubmission& submission) {
                 first_batch = false;
                 continue;
             }
-            for (const vvl::CommandBufferSubmission& cb_submission : queue_submission.cb_submissions) {
-                submission_snapshot.emplace_back(queue_submission.perf_submit_pass, cb_submission.cb);
+            for (const vvl::CommandBufferSubmitInfo& cb_info : queue_submission.cb_infos) {
+                submission_snapshot.emplace_back(queue_submission.perf_submit_pass, cb_info.cb);
             }
         }
     }
 
-    for (vvl::CommandBufferSubmission& cb_submission : submission.cb_submissions) {
-        CommandBufferSubState& cb_sub_state = SubState(*cb_submission.cb);
+    for (vvl::CommandBufferSubmitInfo& cb_info : submission.cb_infos) {
+        CommandBufferSubState& cb_sub_state = SubState(*cb_info.cb);
         auto cb_guard = cb_sub_state.base.WriteLock();
-        for (vvl::CommandBuffer* secondary_cmd_buffer : cb_submission.cb->linked_command_buffers) {
+        for (vvl::CommandBuffer* secondary_cmd_buffer : cb_info.cb->linked_command_buffers) {
             CommandBufferSubState& secondary_sub_state = SubState(*secondary_cmd_buffer);
             auto secondary_guard = secondary_sub_state.base.WriteLock();
             secondary_sub_state.RetireQueries(submission.perf_submit_pass, submission_snapshot);

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -140,7 +140,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     // Called from the Command Buffer state
     void Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission,
-                const vvl::CommandBufferSubmission& cb_submission) final;
+                const vvl::CommandBufferSubmitInfo& cb_info) final;
 
     CoreChecks &validator;
 
@@ -211,8 +211,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     std::vector<WaitEvent2SubmitInfo> wait_event2_submit_infos;
 
     // Validation functions run at primary CB queue submit time
-    using QueueCallback =
-        std::function<bool(const class vvl::Queue& queue_state, const vvl::CommandBufferSubmission& cb_submission)>;
+    using QueueCallback = std::function<bool(const class vvl::Queue& queue_state, const vvl::CommandBufferSubmitInfo& cb_info)>;
     std::vector<QueueCallback> queue_submit_functions;
 
     // Validation functions run when secondary CB is executed in primary

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1290,7 +1290,7 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo,
                                       const ErrorObject& error_obj) const override;
 
-    bool ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBufferSubmission& cb_submission,
+    bool ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBufferSubmitInfo& cb_info,
                                     vvl::unordered_map<const vvl::Image*, ImageLayoutMap>& local_image_layout_state) const;
 
     void UpdateCmdBufImageLayouts(const vvl::CommandBuffer& cb_state);
@@ -1614,8 +1614,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                         const ErrorObject& error_obj) const override;
     bool PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                      const ErrorObject& error_obj) const override;
-    bool ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker,
-                                const std::vector<vvl::CommandBufferSubmission>& command_buffers,
+    bool ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker, const std::vector<vvl::CommandBufferSubmitInfo>& cb_infos,
                                 vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, const Location& submit_loc) override;
     bool ProcessPresentBatch(const vvl::Image& swapchain_image, const Location& present_info_loc) override;
     bool IgnoreAllocationSize(const VkMemoryAllocateInfo& allocate_info) const;

--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -455,7 +455,7 @@ void RegisterDebugPrintf(Validator& gpuav, CommandBufferSubState& cb_state) {
         });
 
     cb_state.on_cb_completion_functions.emplace_back(
-        [](Validator& gpuav, CommandBufferSubState& cb, const vvl::CommandBufferSubmission&, const Location& loc) {
+        [](Validator& gpuav, CommandBufferSubState& cb, const vvl::CommandBufferSubmitInfo&, const Location& loc) {
             debug_printf::CbState* debug_printf_cb_state = cb.shared_resources_cache.TryGet<debug_printf::CbState>();
             if (!debug_printf_cb_state) {
                 return true;

--- a/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
+++ b/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
@@ -145,7 +145,7 @@ void RegisterPostProcessingValidation(Validator& gpuav, CommandBufferSubState& c
 
     // Validate descriptor set accesses done by command buffer submission
     cb.on_cb_completion_functions.emplace_back([bound_desc_sets_to_pp_buffer_map](Validator& gpuav, CommandBufferSubState& cb,
-                                                                                  const vvl::CommandBufferSubmission& cb_submission,
+                                                                                  const vvl::CommandBufferSubmitInfo& cb_info,
                                                                                   const Location& submission_loc) {
         VVL_ZoneScoped;
 
@@ -255,7 +255,7 @@ void RegisterPostProcessingValidation(Validator& gpuav, CommandBufferSubState& c
                         cb.GetErrorLogger(descriptor_access.error_logger_i);
                     context.SetObjlistForGpuAv(&cmd_error_logger.objlist);
                     std::string debug_region_name = vvl::CommandBuffer::GetDebugRegionName(
-                        cb.base.GetLabelCommands(), cmd_error_logger.label_cmd_i, cb_submission.initial_label_stack);
+                        cb.base.GetLabelCommands(), cmd_error_logger.label_cmd_i, cb_info.initial_label_stack);
 
                     Location access_loc(cmd_error_logger.loc.Get(), debug_region_name);
                     context.SetLocationForGpuAv(access_loc);

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -352,7 +352,7 @@ bool CommandBufferSubState::PostSubmit(QueueSubState& queue, const Location& loc
 bool CommandBufferSubState::NeedsPostProcess() { return error_output_buffer_range_.buffer != VK_NULL_HANDLE; }
 
 // For the given command buffer, map its debug data buffers and read their contents for analysis.
-void CommandBufferSubState::OnCompletion(VkQueue queue, const vvl::CommandBufferSubmission& cb_submission, const Location& loc) {
+void CommandBufferSubState::OnCompletion(VkQueue queue, const vvl::CommandBufferSubmitInfo& cb_info, const Location& loc) {
     VVL_ZoneScoped;
 
     // CommandBuffer::Destroy can happen on an other thread,
@@ -403,7 +403,7 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const vvl::CommandBuffer
                     const LogObjectList objlist(queue, error_logger.objlist);
 
                     std::string debug_region_name = vvl::CommandBuffer::GetDebugRegionName(
-                        base.GetLabelCommands(), error_logger.label_cmd_i, cb_submission.initial_label_stack);
+                        base.GetLabelCommands(), error_logger.label_cmd_i, cb_info.initial_label_stack);
                     Location loc_with_debug_region(error_logger.loc.Get(), debug_region_name);
                     error_logger.error_logger_func(error_record_ptr, loc_with_debug_region, objlist);
                 }
@@ -430,7 +430,7 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const vvl::CommandBuffer
 
     bool success = true;
     for (auto& on_cb_completion_func : on_cb_completion_functions) {
-        success = on_cb_completion_func(gpuav_, *this, cb_submission, loc);
+        success = on_cb_completion_func(gpuav_, *this, cb_info, loc);
         if (!success) {
             break;
         }
@@ -537,9 +537,9 @@ void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission>& submissions) {
     bool success = true;
     for (const auto& submission : submissions) {
         auto loc = submission.loc.Get();
-        for (auto& cb_submission : submission.cb_submissions) {
-            auto guard = cb_submission.cb->ReadLock();
-            auto& gpu_cb = SubState(*cb_submission.cb);
+        for (auto& cb_info : submission.cb_infos) {
+            auto guard = cb_info.cb->ReadLock();
+            auto& gpu_cb = SubState(*cb_info.cb);
             success = gpu_cb.PreSubmit(*this, loc);
             if (!success) {
                 return;
@@ -563,9 +563,9 @@ bool QueueSubState::PostSubmit(vvl::QueueSubmission& submission) {
         // must not submit the barrier (the same check as in Retire).
         return true;
     }
-    for (auto& cb_submission : submission.cb_submissions) {
-        auto guard = cb_submission.cb->ReadLock();
-        auto& gpu_cb = SubState(*cb_submission.cb);
+    for (auto& cb_info : submission.cb_infos) {
+        auto guard = cb_info.cb->ReadLock();
+        auto& gpu_cb = SubState(*cb_info.cb);
         if (!gpu_cb.PostSubmit(*this, loc)) {
             return false;
         }
@@ -591,7 +591,7 @@ void QueueSubState::Retire(vvl::QueueSubmission& submission) {
         // that signals barrier_sem_. The following timeline wait must not be called.
         return;
     }
-    retiring_.emplace_back(submission.cb_submissions);
+    retiring_.emplace_back(submission.cb_infos);
     if (submission.is_last_submission) {
         VkSemaphoreWaitInfo wait_info = vku::InitStructHelper();
         wait_info.semaphoreCount = 1;
@@ -618,16 +618,16 @@ void QueueSubState::Retire(vvl::QueueSubmission& submission) {
             }
         }
 
-        for (std::vector<vvl::CommandBufferSubmission>& cb_submissions : retiring_) {
-            for (vvl::CommandBufferSubmission& cb_submission : cb_submissions) {
-                auto guard = cb_submission.cb->WriteLock();
-                auto& gpu_cb = SubState(*cb_submission.cb);
+        for (std::vector<vvl::CommandBufferSubmitInfo>& cb_infos : retiring_) {
+            for (vvl::CommandBufferSubmitInfo& cb_info : cb_infos) {
+                auto guard = cb_info.cb->WriteLock();
+                auto& gpu_cb = SubState(*cb_info.cb);
                 auto loc = submission.loc.Get();
-                gpu_cb.OnCompletion(VkHandle(), cb_submission, loc);
+                gpu_cb.OnCompletion(VkHandle(), cb_info, loc);
                 for (vvl::CommandBuffer* secondary_cb : gpu_cb.base.linked_command_buffers) {
                     auto secondary_guard = secondary_cb->WriteLock();
                     auto& secondary_gpu_cb = SubState(*secondary_cb);
-                    secondary_gpu_cb.OnCompletion(VkHandle(), cb_submission, loc);
+                    secondary_gpu_cb.OnCompletion(VkHandle(), cb_info, loc);
                 }
             }
         }

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -75,8 +75,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     using OnCommandBufferSubmission =
         stdext::inplace_function<void(Validator &gpuav, CommandBufferSubState &cb, VkCommandBuffer per_submission_cb)>;
     using OnCommandBufferCompletion =
-        stdext::inplace_function<bool(Validator& gpuav, CommandBufferSubState& cb,
-                                      const vvl::CommandBufferSubmission& cb_submission, const Location& submission_loc),
+        stdext::inplace_function<bool(Validator& gpuav, CommandBufferSubState& cb, const vvl::CommandBufferSubmitInfo& cb_info,
+                                      const Location& submission_loc),
                                  64>;
     using OnPreCommandBufferSubmission =
         stdext::inplace_function<void(Validator &gpuav, CommandBufferSubState &cb, VkCommandBuffer per_pre_submission_cb), 48>;
@@ -106,7 +106,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     [[nodiscard]] bool PreSubmit(QueueSubState &queue, const Location &loc);
     [[nodiscard]] bool PostSubmit(QueueSubState &queue, const Location &loc);
-    void OnCompletion(VkQueue queue, const vvl::CommandBufferSubmission& cb_submission, const Location& loc);
+    void OnCompletion(VkQueue queue, const vvl::CommandBufferSubmitInfo& cb_info, const Location& loc);
 
     const VkDescriptorSetLayout &GetInstrumentationDescriptorSetLayout() const {
         assert(instrumentation_desc_set_layout_ != VK_NULL_HANDLE);
@@ -267,7 +267,7 @@ class QueueSubState : public vvl::QueueSubState {
     VkCommandPool barrier_command_pool_{VK_NULL_HANDLE};
     VkCommandBuffer barrier_command_buffer_{VK_NULL_HANDLE};
     VkSemaphore barrier_sem_{VK_NULL_HANDLE};
-    std::deque<std::vector<vvl::CommandBufferSubmission>> retiring_;
+    std::deque<std::vector<vvl::CommandBufferSubmitInfo>> retiring_;
     const bool timeline_khr_;
 };
 

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -860,7 +860,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void UnbindResources();
 };
 
-struct CommandBufferSubmission;
+struct CommandBufferSubmitInfo;
 
 class CommandBufferSubState {
   public:
@@ -996,7 +996,7 @@ class CommandBufferSubState {
 
     virtual void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {}
 
-    virtual void Submit(Queue& queue_state, const QueueSubmission& submission, const CommandBufferSubmission& cb_submission) {}
+    virtual void Submit(Queue& queue_state, const QueueSubmission& submission, const CommandBufferSubmitInfo& cb_info) {}
 
     VulkanTypedHandle Handle() const;
     VkCommandBuffer VkHandle() const;

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -27,7 +27,7 @@
 
 #include "profiling/profiling.h"
 
-void vvl::CommandBufferSubmission::SubmitTimeValidate(Queue& queue, const QueueSubmission& submission) {
+void vvl::CommandBufferSubmitInfo::SubmitTimeValidate(Queue& queue, const QueueSubmission& submission) {
     for (const auto& it : cb->video_session_updates) {
         auto video_session_state = cb->dev_data.Get<vvl::VideoSession>(it.first);
         auto device_state = video_session_state->DeviceStateWrite();
@@ -45,8 +45,8 @@ void vvl::QueueSubmission::BeginUse() {
     for (SemaphoreInfo& wait : wait_semaphores) {
         wait.semaphore->BeginUse();
     }
-    for (CommandBufferSubmission& cb_submission : cb_submissions) {
-        cb_submission.cb->BeginUse();
+    for (CommandBufferSubmitInfo& cb_info : cb_infos) {
+        cb_info.cb->BeginUse();
     }
     for (SemaphoreInfo& signal : signal_semaphores) {
         signal.semaphore->BeginUse();
@@ -63,8 +63,8 @@ void vvl::QueueSubmission::EndUse() {
     for (SemaphoreInfo& wait : wait_semaphores) {
         wait.semaphore->EndUse();
     }
-    for (CommandBufferSubmission& cb_submission : cb_submissions) {
-        cb_submission.cb->EndUse();
+    for (CommandBufferSubmitInfo& cb_info : cb_infos) {
+        cb_info.cb->EndUse();
     }
     for (SemaphoreInfo& signal : signal_semaphores) {
         signal.semaphore->EndUse();
@@ -83,14 +83,14 @@ uint64_t vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission>&& submissions) 
     }
     uint64_t last_batch_seq = 0;
     for (QueueSubmission& submission : submissions) {
-        for (CommandBufferSubmission& cb_submission : submission.cb_submissions) {
-            auto cb_guard = cb_submission.cb->WriteLock();
-            for (CommandBuffer* secondary_cmd_buffer : cb_submission.cb->linked_command_buffers) {
+        for (CommandBufferSubmitInfo& cb_info : submission.cb_infos) {
+            auto cb_guard = cb_info.cb->WriteLock();
+            for (CommandBuffer* secondary_cmd_buffer : cb_info.cb->linked_command_buffers) {
                 auto secondary_guard = secondary_cmd_buffer->WriteLock();
                 secondary_cmd_buffer->submit_count++;
             }
-            cb_submission.cb->submit_count++;
-            cb_submission.SubmitTimeValidate(*this, submission);
+            cb_info.cb->submit_count++;
+            cb_info.SubmitTimeValidate(*this, submission);
         }
         // seq_ is atomic so we don't need a lock until updating the deque below.
         // Note that this relies on the external synchonization requirements for the

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -37,34 +37,22 @@ class DeviceState;
 class QueueSubState;
 struct QueueSubmission;
 
-struct CommandBufferSubmission {
+struct CommandBufferSubmitInfo {
     void SubmitTimeValidate(Queue& queue, const QueueSubmission& submission);
 
     std::shared_ptr<vvl::CommandBuffer> cb;
-    // Specifically made for GPU-AV, for it has unique problems: Error reporting is done *after*
-    // command buffer submissions, not at Pre/PostCall time.
-    // Contrary to sync val, GPU-AV cannot just look at `GetQueueState()->cmdbuf_label_stack`
-    // to construct an initial label stack. sync-val can do that because validation and error reporting is done
-    // *before* a command buffer list is submitted: validation is performed one command buffer at a time,
-    // and `GetQueueState()->cmdbuf_label_stack` is updated between those validations.
-    // When GPU-AV starts doing error reporting, when command buffers have completed,
-    // the label stack info stored in Queue state is lost.
-    // => GPU-AV needs to track this initial label stack per command buffer submission.
-    std::vector<std::string> initial_label_stack;
 
-    CommandBufferSubmission(std::shared_ptr<vvl::CommandBuffer> cb, std::vector<std::string> initial_label_stack)
-        : cb(std::move(cb)), initial_label_stack(std::move(initial_label_stack)) {}
-    CommandBufferSubmission(CommandBufferSubmission &&other)
-        : cb(std::move(other.cb)), initial_label_stack(std::move(other.initial_label_stack)) {}
-    CommandBufferSubmission &operator=(const CommandBufferSubmission &other) = default;
-    CommandBufferSubmission(const CommandBufferSubmission &) = default;
+    // Snapshot of the queue's debug label stack at the start of this command buffer.
+    // Errors can be reported when Queue::cmdbuf_label_stack has already advanced
+    // (e.g. GPU-AV post-submit error reporting, deferred wait-before-signal batches in core checks).
+    std::vector<std::string> initial_label_stack;
 };
 
 struct QueueSubmission {
-    QueueSubmission(const Location &loc_) : loc(loc_), completed(), waiter(completed.get_future()) {}
+    QueueSubmission(const Location& loc_) : loc(loc_), completed(), waiter(completed.get_future()) {}
 
     bool is_last_submission{false};
-    std::vector<vvl::CommandBufferSubmission> cb_submissions{};
+    std::vector<vvl::CommandBufferSubmitInfo> cb_infos;
 
     std::vector<SemaphoreInfo> wait_semaphores;
     std::vector<SemaphoreInfo> signal_semaphores;
@@ -83,8 +71,9 @@ struct QueueSubmission {
     std::promise<void> completed;
     std::shared_future<void> waiter;
 
-    void AddCommandBuffer(std::shared_ptr<vvl::CommandBuffer> cb_state, std::vector<std::string> initial_label_stack) {
-        cb_submissions.emplace_back(std::move(cb_state), std::move(initial_label_stack));
+    void AddCommandBuffer(const std::shared_ptr<vvl::CommandBuffer>& cb_state,
+                          const std::vector<std::string>& initial_label_stack) {
+        cb_infos.push_back(CommandBufferSubmitInfo{cb_state, initial_label_stack});
     }
 
     void AddSignalSemaphore(std::shared_ptr<Semaphore> &&semaphore_state, uint64_t value) {

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -88,7 +88,7 @@ class VideoSession;
 class VideoSessionParameters;
 class DataGraphPipelineSession;
 class SubmitTimeTracker;
-struct CommandBufferSubmission;
+struct CommandBufferSubmitInfo;
 struct DescriptorHashing;
 }  // namespace vvl
 
@@ -2346,8 +2346,7 @@ class DeviceProxy : public vvl::BaseDevice {
     // especially when a timeline signal resolves pending work on another queue.
     // This became even more important after the spec allowed internally synchronized queues,
     // which means the same queue can be used from multiple threads
-    virtual bool ProcessSubmissionBatch(const SubmitTimeTracker& tracker,
-                                        const std::vector<vvl::CommandBufferSubmission>& command_buffers,
+    virtual bool ProcessSubmissionBatch(const SubmitTimeTracker& tracker, const std::vector<vvl::CommandBufferSubmitInfo>& cb_infos,
                                         vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, const Location& submit_loc) {
         return false;
     }

--- a/layers/state_tracker/submit_time_tracker.cpp
+++ b/layers/state_tracker/submit_time_tracker.cpp
@@ -36,8 +36,6 @@ void SubmitTimeTracker::OnDestroyTimelineSemaphore(VkSemaphore timeline) {
 }
 
 bool SubmitTimeTracker::ProcessQueueSubmission(VkQueue queue, const QueueSubmission& submission) const {
-    std::vector<CommandBufferSubmission> command_buffers = submission.cb_submissions;
-
     std::vector<VkSemaphoreSubmitInfo> wait_semaphores;
     wait_semaphores.reserve(submission.wait_semaphores.size());
     for (const SemaphoreInfo& wait : submission.wait_semaphores) {
@@ -56,7 +54,7 @@ bool SubmitTimeTracker::ProcessQueueSubmission(VkQueue queue, const QueueSubmiss
 
     std::lock_guard lock(mutex_);
     SubmitTimeTracker& this_tracker = *const_cast<SubmitTimeTracker*>(this);
-    return this_tracker.ProcessBatch(std::move(command_buffers), wait_semaphores, signal_semaphores, queue, submission.loc.Get());
+    return this_tracker.ProcessBatch(submission.cb_infos, wait_semaphores, signal_semaphores, queue, submission.loc.Get());
 }
 
 bool SubmitTimeTracker::ProcessSignalSemaphore(const VkSemaphoreSignalInfo& signal_info) const {
@@ -83,7 +81,7 @@ bool SubmitTimeTracker::ProcessPresent(const VkPresentInfoKHR& present_info, con
     return skip;
 }
 
-bool SubmitTimeTracker::ProcessBatch(std::vector<CommandBufferSubmission>&& cb_submissions,
+bool SubmitTimeTracker::ProcessBatch(const std::vector<CommandBufferSubmitInfo>& cb_infos,
                                      vvl::span<const VkSemaphoreSubmitInfo> wait_semaphores,
                                      vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, VkQueue queue,
                                      const Location& submit_loc) {
@@ -95,14 +93,14 @@ bool SubmitTimeTracker::ProcessBatch(std::vector<CommandBufferSubmission>&& cb_s
     const bool has_pending_waits = !unresolved_batches.empty() || !unresolved_timeline_waits.empty();
     if (has_pending_waits) {
         UnresolvedBatch batch(submit_loc);
-        batch.cb_submissions = std::move(cb_submissions);
+        batch.cb_infos = cb_infos;
         batch.unresolved_timeline_waits = std::move(unresolved_timeline_waits);
         batch.signals.assign(signal_semaphores.begin(), signal_semaphores.end());
         unresolved_batches.emplace_back(std::move(batch));
         return skip;
     }
 
-    skip |= validator_.ProcessSubmissionBatch(*this, cb_submissions, signal_semaphores, submit_loc);
+    skip |= validator_.ProcessSubmissionBatch(*this, cb_infos, signal_semaphores, submit_loc);
 
     const bool new_timeline_signals = RegisterTimelineSignals(signal_semaphores);
     if (new_timeline_signals) {
@@ -162,7 +160,7 @@ bool SubmitTimeTracker::PropagateTimelineSignals() {
                     break;
                 }
                 const auto signals = vvl::span<const VkSemaphoreSubmitInfo>(batch.signals.data(), batch.signals.size());
-                skip |= validator_.ProcessSubmissionBatch(*this, batch.cb_submissions, signals, batch.submit_loc_capture.Get());
+                skip |= validator_.ProcessSubmissionBatch(*this, batch.cb_infos, signals, batch.submit_loc_capture.Get());
                 new_timeline_signals |= RegisterTimelineSignals(batch.signals);
                 batches.erase(batches.begin());
             }

--- a/layers/state_tracker/submit_time_tracker.h
+++ b/layers/state_tracker/submit_time_tracker.h
@@ -39,7 +39,7 @@ struct UnresolvedBatch {
     LocationCapture submit_loc_capture;
 
     // Command buffers to validate when dependencies are resolved
-    std::vector<CommandBufferSubmission> cb_submissions;
+    std::vector<CommandBufferSubmitInfo> cb_infos;
 
     // Timeline waits that block this batch
     std::vector<VkSemaphoreSubmitInfo> unresolved_timeline_waits;
@@ -68,7 +68,7 @@ class SubmitTimeTracker {
     std::optional<uint64_t> GetTimelineValue(VkSemaphore timeline) const;
 
   private:
-    bool ProcessBatch(std::vector<CommandBufferSubmission>&& cb_submissions, vvl::span<const VkSemaphoreSubmitInfo> wait_semaphores,
+    bool ProcessBatch(const std::vector<CommandBufferSubmitInfo>& cb_infos, vvl::span<const VkSemaphoreSubmitInfo> wait_semaphores,
                       vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, VkQueue queue, const Location& submit_loc);
     bool ProcessSignal(VkSemaphore timeline, uint64_t signal_value);
 


### PR DESCRIPTION
Follow-up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12095.

`CommandBufferSubmission` -> `CommandBufferSubmitInfo`.

 The main purpose of the updated naming is to emphesize it  is about "Command buffer" and not to create an impression that there is per-command-buffer submission. The variable naming is `cb_info`. The accessed command buffer is `cb_info.cb` (much better than `cb_submission.cb`).

The initial attempt in closed PR used `CommandBufferInfo` which might sound too general. The `Submit` part in `CommandBufferSubmitInfo` suggests it is related to submission operation (`QueueSubmission` type) and not an arbitrary usage of command buffer (`CommandBufferInfo`).

`CommandBufferSubmitInfo` naming follows the spec `VkCommandBufferSubmitInfo` convention but with vvl-specific data.