### PR TITLE
layers: Move SubmitTimeValidate back to CommandBuffer

### DIFF
--- a/layers/best_practices/bp_state.cpp
+++ b/layers/best_practices/bp_state.cpp
@@ -866,7 +866,7 @@ void CommandBufferSubState::RecordBindPipeline(VkPipelineBindPoint bind_point, v
     }
 }
 
-void CommandBufferSubState::Submit(vvl::Queue& queue_state, const vvl::QueueSubmission&, const vvl::CommandBufferSubmitInfo&) {
+void CommandBufferSubState::Submit(vvl::Queue& queue_state, const vvl::QueueSubmission&, uint32_t) {
     for (auto& func : queue_submit_functions) {
         func(queue_state, base);
     }

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -225,8 +225,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordSetDepthTestEnable(VkBool32 depth_test_enable) final;
     void RecordBindPipeline(VkPipelineBindPoint bind_point, vvl::Pipeline& pipeline) final;
 
-    void Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission,
-                const vvl::CommandBufferSubmitInfo& cb_info) final;
+    void Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission, uint32_t cb_index) final;
 
     // Move to private when possible
     void RecordAttachmentAccess(uint32_t attachment, VkImageAspectFlags aspects);

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -317,7 +317,8 @@ void CommandBufferSubState::RecordCopyBufferCommon(vvl::Buffer& src_buffer_state
 
     auto queue_submit_validation = [this, &src_buffer_state, &dst_buffer_state, src_ranges = std::move(src_ranges),
                                     dst_ranges = std::move(dst_ranges), src_ranges_bounds, dst_ranges_bounds, loc, label_command_i](
-                                       const class vvl::Queue& queue_state, const vvl::CommandBufferSubmitInfo& cb_info) -> bool {
+                                       const class vvl::Queue& queue_state, const vvl::QueueSubmission& submission,
+                                       uint32_t cb_index) -> bool {
         bool skip = false;
 
         auto src_vk_memory_to_ranges_map = src_buffer_state.GetBoundRanges(src_ranges_bounds, src_ranges);
@@ -342,7 +343,7 @@ void CommandBufferSubState::RecordCopyBufferCommon(vvl::Buffer& src_buffer_state
                     const LogObjectList objlist(base.VkHandle(), src_buffer_state.Handle(), dst_buffer_state.Handle(),
                                                 vk_memory);
                     const std::string dbg_region_name = vvl::CommandBuffer::GetDebugRegionName(
-                        base.GetLabelCommands(), label_command_i, cb_info.initial_label_stack);
+                        base.GetLabelCommands(), label_command_i, submission.cb_infos[cb_index].initial_label_stack);
                     const Location loc_with_dbg_region(loc, dbg_region_name);
                     const bool is_2 = loc.function == vvl::Func::vkCmdCopyBuffer2 || loc.function == vvl::Func::vkCmdCopyBuffer2KHR;
                     const char* vuid = is_2 ? "VUID-VkCopyBufferInfo2-pRegions-00117" : "VUID-vkCmdCopyBuffer-pRegions-00117";
@@ -1352,10 +1353,9 @@ void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_c
     });
 }
 
-void CommandBufferSubState::Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission,
-                                   const vvl::CommandBufferSubmitInfo& cb_info) {
+void CommandBufferSubState::Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission, uint32_t cb_index) {
     for (auto& func : queue_submit_functions) {
-        func(queue_state, cb_info);
+        func(queue_state, queue_submission, cb_index);
     }
 
     // Update global vvl:Event state with signaling state at the end of the command buffer

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -139,8 +139,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordExecuteCommand(vvl::CommandBuffer &secondary_command_buffer, uint32_t cmd_index, const Location &loc) final;
 
     // Called from the Command Buffer state
-    void Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission,
-                const vvl::CommandBufferSubmitInfo& cb_info) final;
+    void Submit(vvl::Queue& queue_state, const vvl::QueueSubmission& queue_submission, uint32_t cb_index) final;
 
     CoreChecks &validator;
 
@@ -211,7 +210,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     std::vector<WaitEvent2SubmitInfo> wait_event2_submit_infos;
 
     // Validation functions run at primary CB queue submit time
-    using QueueCallback = std::function<bool(const class vvl::Queue& queue_state, const vvl::CommandBufferSubmitInfo& cb_info)>;
+    using QueueCallback =
+        std::function<bool(const class vvl::Queue& queue_state, const vvl::QueueSubmission& submission, uint32_t cb_index)>;
     std::vector<QueueCallback> queue_submit_functions;
 
     // Validation functions run when secondary CB is executed in primary

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -2536,6 +2536,21 @@ void CommandBuffer::RecordSetRenderingInputAttachmentIndices(const VkRenderingIn
     SetRenderingInputAttachmentIndices(rendering_attachments, pLocationInfo);
 }
 
+void CommandBuffer::SubmitTimeValidate(Queue& queue, const QueueSubmission& submission, uint32_t cb_index) {
+    assert(submission.cb_infos[cb_index].cb.get() == this);
+    for (const auto& it : video_session_updates) {
+        auto video_session_state = dev_data.Get<vvl::VideoSession>(it.first);
+        auto device_state = video_session_state->DeviceStateWrite();
+        for (const auto& function : it.second) {
+            function(video_session_state.get(), *device_state, /*do_validate*/ false);
+        }
+    }
+
+    for (auto& item : sub_states_) {
+        item.second->Submit(queue, submission, cb_index);
+    }
+}
+
 uint32_t CommandBuffer::GetDynamicRenderingColorAttachmentCount() const {
     return active_render_pass ? active_render_pass->dynamic_rendering_color_attachment_count : 0;
 }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -22,7 +22,6 @@
 #pragma once
 #include <vulkan/vulkan_core.h>
 #include <memory>
-#include "state_tracker/queue_state.h"
 #include "state_tracker/state_object.h"
 #include "state_tracker/image_layout_map.h"
 #include "state_tracker/pipeline_library_state.h"
@@ -800,6 +799,8 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void TrackImageFirstLayout(const vvl::Image &image_state, const VkImageSubresourceRange &subresource_range,
                                int32_t depth_offset, uint32_t depth_extent, VkImageLayout layout);
 
+    void SubmitTimeValidate(Queue &queue, const QueueSubmission &submission, uint32_t cb_index);
+
     // Helpers to offset into |active_attachments|
     // [all color, all color resolve, depth, depth resolve, stencil, stencil resolve, FragmentDensityMap]
     uint32_t GetDynamicRenderingColorAttachmentCount() const;
@@ -833,7 +834,6 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     static std::string GetDebugRegionName(const std::vector<LabelCommand>& label_commands, uint32_t label_command_index,
                                           const std::vector<std::string>& initial_label_stack = {});
 
-    auto& GetSubstates() { return sub_states_; }
     // This command buffer might contain a push descriptor set, which is not tracked in the object maps.
     // So the only way to cleanup SubStates on the descriptor set is through here.
     void RemoveOwnedSubState(LayerObjectTypeId id);
@@ -859,8 +859,6 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void RecordVideoEncodeQuantizationMap(const VkVideoEncodeQuantizationMapInfoKHR &quant_map_info);
     void UnbindResources();
 };
-
-struct CommandBufferSubmitInfo;
 
 class CommandBufferSubState {
   public:
@@ -996,7 +994,7 @@ class CommandBufferSubState {
 
     virtual void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {}
 
-    virtual void Submit(Queue& queue_state, const QueueSubmission& submission, const CommandBufferSubmitInfo& cb_info) {}
+    virtual void Submit(Queue& queue_state, const QueueSubmission& submission, uint32_t cb_index) {}
 
     VulkanTypedHandle Handle() const;
     VkCommandBuffer VkHandle() const;

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -27,20 +27,6 @@
 
 #include "profiling/profiling.h"
 
-void vvl::CommandBufferSubmitInfo::SubmitTimeValidate(Queue& queue, const QueueSubmission& submission) {
-    for (const auto& it : cb->video_session_updates) {
-        auto video_session_state = cb->dev_data.Get<vvl::VideoSession>(it.first);
-        auto device_state = video_session_state->DeviceStateWrite();
-        for (const auto& function : it.second) {
-            function(video_session_state.get(), *device_state, /*do_validate*/ false);
-        }
-    }
-
-    for (auto& item : cb->GetSubstates()) {
-        item.second->Submit(queue, submission, *this);
-    }
-}
-
 void vvl::QueueSubmission::BeginUse() {
     for (SemaphoreInfo& wait : wait_semaphores) {
         wait.semaphore->BeginUse();
@@ -83,14 +69,15 @@ uint64_t vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission>&& submissions) 
     }
     uint64_t last_batch_seq = 0;
     for (QueueSubmission& submission : submissions) {
-        for (CommandBufferSubmitInfo& cb_info : submission.cb_infos) {
+        for (uint32_t cb_index = 0; cb_index < submission.cb_infos.size(); cb_index++) {
+            CommandBufferSubmitInfo& cb_info = submission.cb_infos[cb_index];
             auto cb_guard = cb_info.cb->WriteLock();
             for (CommandBuffer* secondary_cmd_buffer : cb_info.cb->linked_command_buffers) {
                 auto secondary_guard = secondary_cmd_buffer->WriteLock();
                 secondary_cmd_buffer->submit_count++;
             }
             cb_info.cb->submit_count++;
-            cb_info.SubmitTimeValidate(*this, submission);
+            cb_info.cb->SubmitTimeValidate(*this, submission, cb_index);
         }
         // seq_ is atomic so we don't need a lock until updating the deque below.
         // Note that this relies on the external synchonization requirements for the

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -38,8 +38,6 @@ class QueueSubState;
 struct QueueSubmission;
 
 struct CommandBufferSubmitInfo {
-    void SubmitTimeValidate(Queue& queue, const QueueSubmission& submission);
-
     std::shared_ptr<vvl::CommandBuffer> cb;
 
     // Snapshot of the queue's debug label stack at the start of this command buffer.


### PR DESCRIPTION
I missed this during https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12962 review but below are the arguments for this change..

`CommandBufferSubmitInfo` is a simple info struct. Adding submit time
functionality makes it a more complex abstraction. Also
`SubmitTimeValidate` method in its current form is temporary - a lot of
submit validation does not work with timeline semaphores and will be
transitioned to `SubmitTimeTracker`.

This also removes the `GetSubstates()` accessor that the original solution
needed. It exposed command buffer substates to outside code and moved
away from the simple initial design - the command buffer iterates over
its substates and that's all.

The substate `Submit` method now takes `QueueSubmission` and a command
buffer index instead of `CommandBufferSubmitInfo`. Before, these
parameters were **correlated** - `cb_info` had to be an element of
`submission.cb_infos`. Now the command buffer entry is derived from the
submission and the index, so inconsistent combinations are not
possible.