### PR TITLE
gpuav: Allow shaders to be written in Slang

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -310,7 +310,8 @@ target_sources(vvl PRIVATE
     ${API_TYPE}/generated/thread_safety_device_defs.h
     ${API_TYPE}/generated/thread_safety_instance_defs.h
     ${API_TYPE}/generated/gpuav_offline_spirv.h
-    ${API_TYPE}/generated/gpuav_offline_spirv.cpp
+    ${API_TYPE}/generated/gpuav_offline_spirv_glsl.cpp
+    ${API_TYPE}/generated/gpuav_offline_spirv_slang.cpp
     ${API_TYPE}/generated/extended_flags_helper_generator.h
     ${API_TYPE}/generated/extended_flags_helper_generator.cpp
     gpuav/core/gpuav.h

--- a/layers/gpuav/shaders/README.md
+++ b/layers/gpuav/shaders/README.md
@@ -1,18 +1,18 @@
 # GPU Assisted Validation Shaders
 
-This directory is for holding shaders that are used for [shader instrumentation](../../docs/gpu_av_shader_instrumentation.md) inside [GPU Assisted Validation](../../docs/gpuav.md). These are turned in SPIR-V when generating code with `generate_spirv.py`　and turned into a header file in [layers/vulkan/generated](../generated/).
+This directory is for holding shaders that are used for [shader instrumentation](../../docs/gpu_av_shader_instrumentation.md) inside [GPU Assisted Validation](../../docs/gpuav.md). These are turned in SPIR-V when generating code with `compile_gpuav_shaders.py`　and turned into a header file in [layers/vulkan/generated](../generated/).
 
 To regenerate the validation shader, run the following:
 
 ```bash
 # generate all the shaders with glslangValidator at external/glslang/build/install/bin/glslangValidator
-python3 ./scripts/generate_spirv.py
+python3 ./scripts/compile_gpuav_shaders.py
 
 # Using own glslangValidator executable
-python3 ./scripts/generate_spirv.py --glslang path/to/glslangValidator
+python3 ./scripts/compile_gpuav_shaders.py --glslang path/to/glslangValidator
 
 # generate a single shader
-python3 ./scripts/generate_spirv.py --shader layers/gpuav/shaders/gpu_pre_draw.vert
+python3 ./scripts/compile_gpuav_shaders.py --shader layers/gpuav/shaders/gpu_pre_draw.vert
 ```
 
 ## Adding a new shader

--- a/layers/gpuav/spirv/CMakeLists.txt
+++ b/layers/gpuav/spirv/CMakeLists.txt
@@ -65,7 +65,8 @@ target_sources(gpu_av_spirv PRIVATE
     ${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/spirv_grammar_helper.cpp
 
     ${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv.h
-    ${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv.cpp
+    ${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv_glsl.cpp
+    ${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv_slang.cpp
 )
 
 target_include_directories(gpu_av_spirv PRIVATE .
@@ -103,17 +104,23 @@ set(GPUAV_SHADERS_DIR "${VVL_SOURCE_DIR}/layers/gpuav/shaders")
 file(GLOB_RECURSE GPUAV_SHADERS CONFIGURE_DEPENDS
     "${GPUAV_SHADERS_DIR}/*.vert"
     "${GPUAV_SHADERS_DIR}/*.comp"
+    "${GPUAV_SHADERS_DIR}/*.slang"
     "${GPUAV_SHADERS_DIR}/*.h"
 )
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
+# Slang compiler still being optional, do not list its output here
 add_custom_command(
-    OUTPUT "${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv.h" "${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv.cpp"
-    COMMAND Python3::Interpreter "scripts/generate_spirv.py"
+    OUTPUT
+      "${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv.h"
+      "${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv_glsl.cpp"
+    COMMAND Python3::Interpreter "scripts/compile_gpuav_shaders.py"
     DEPENDS ${GPUAV_SHADERS}
     WORKING_DIRECTORY ${VVL_SOURCE_DIR}
     VERBATIM
 )
 add_custom_target(vvl_gpu_av_shaders_spirv
-    DEPENDS "${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv.h" "${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv.cpp"
+    DEPENDS
+    "${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv.h"
+    "${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv_glsl.cpp"
 )
 add_dependencies(gpu_av_spirv vvl_gpu_av_shaders_spirv)

--- a/layers/vulkan/generated/gpuav_offline_spirv.h
+++ b/layers/vulkan/generated/gpuav_offline_spirv.h
@@ -1,5 +1,5 @@
 // *** THIS FILE IS GENERATED - DO NOT EDIT ***
-// See generate_spirv.py for modifications
+// See compile_gpuav_shaders.py for modifications
 
 /***************************************************************************
  *

--- a/layers/vulkan/generated/gpuav_offline_spirv_glsl.cpp
+++ b/layers/vulkan/generated/gpuav_offline_spirv_glsl.cpp
@@ -1,5 +1,5 @@
 // *** THIS FILE IS GENERATED - DO NOT EDIT ***
-// See generate_spirv.py for modifications
+// See compile_gpuav_shaders.py for modifications
 
 /***************************************************************************
  *

--- a/layers/vulkan/generated/gpuav_offline_spirv_slang.cpp
+++ b/layers/vulkan/generated/gpuav_offline_spirv_slang.cpp
@@ -1,0 +1,26 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See compile_gpuav_shaders.py for modifications
+
+/***************************************************************************
+ *
+ * Copyright (c) 2021-2026 The Khronos Group Inc.
+ * Copyright (c) 2021-2026 Valve Corporation
+ * Copyright (c) 2021-2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "gpuav_offline_spirv.h"
+
+// To view SPIR-V, copy contents of an array and paste in https://www.khronos.org/spir/visualizer/

--- a/scripts/compile_gpuav_shaders.py
+++ b/scripts/compile_gpuav_shaders.py
@@ -16,7 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Compile GLSL to SPIR-V. Depends on glslangValidator
+# Compile GLSL to SPIR-V (glslang) and Slang to SPIR-V (slangc).
+# slangc is downloaded by update_deps but may be absent; when missing, Slang shaders are
+# skipped and gpuav_offline_spirv_slang.cpp is left untouched.
 
 import os
 import sys
@@ -51,13 +53,21 @@ def identifierize(s):
     # translate leading digits
     return re.sub("^[^a-zA-Z_]+", "_", s)
 
-def compile_shader(gpu_shaders_dir, filename, glslang_validator, spirv_opt, target_env):
+def shader_name(shader_filename):
+    # Derived from the path only, so it is stable even when the shader is not compiled (Slang without slangc)
+    head_tail = os.path.split(shader_filename)
+    return identifierize(os.path.basename(head_tail[0]) + "_" + head_tail[1])
+
+def compile_shader(gpu_shaders_dir, filename, glslang_validator, slangc, spirv_opt, target_env):
     tmpfile = os.path.basename(filename) + '.tmp'
 
-    # invoke glslangValidator
-    try:
+    if filename.endswith('.slang'):
+        # -allow-glsl so the headers shared with the GLSL shaders (which spell global constants
+        # `const uint` instead of `static const uint`) can be included as is.
+        args = [slangc, filename, '-target', 'spirv', '-emit-spirv-directly', '-fvk-use-scalar-layout',
+                '-allow-glsl', '-profile', 'glsl_450', '-I', gpu_shaders_dir, '-o', tmpfile]
+    else:
         args = [glslang_validator]
-
         if not target_env:
             requires_vulkan_1_2 = ['rgen', 'rint', 'rahit', 'rchit', 'rmiss', 'rcall']
             if filename.split(".")[-1] in requires_vulkan_1_2:
@@ -73,11 +83,12 @@ def compile_shader(gpu_shaders_dir, filename, glslang_validator, spirv_opt, targ
             args += ["--no-link"]
         else:
             args += ["-V"]
-        include_dir = "-I" + gpu_shaders_dir
-        args += [include_dir, "-o", tmpfile, filename]
+        args += ["-I" + gpu_shaders_dir, "-o", tmpfile, filename]
+
+    try:
         subprocess.check_output(args, universal_newlines=True)
     except subprocess.CalledProcessError as e:
-       print(f"Error compiling shader:")
+       print("Error compiling shader:")
        print(e.output, file=sys.stderr)
        if os.path.exists(tmpfile):
             os.remove(tmpfile)
@@ -124,12 +135,10 @@ def compile_shader(gpu_shaders_dir, filename, glslang_validator, spirv_opt, targ
 
     return words
 
-def process_shader(shader_filename, gpu_shaders_dir, glslang, spirv_opt, targetenv):
-    words = compile_shader(gpu_shaders_dir, shader_filename, glslang, spirv_opt, targetenv)
+def process_shader(shader_filename, gpu_shaders_dir, glslang, slangc, spirv_opt, targetenv):
+    words = compile_shader(gpu_shaders_dir, shader_filename, glslang, slangc, spirv_opt, targetenv)
 
-    head_tail = os.path.split(shader_filename)
-    name = os.path.basename(head_tail[0]) + "_" + head_tail[1]
-    name = identifierize(name)
+    name = shader_name(shader_filename)
 
     function_offsets = []
     if "instrumentation" in shader_filename:
@@ -144,11 +153,56 @@ def process_shader(shader_filename, gpu_shaders_dir, glslang, spirv_opt, targete
 
     return ShaderData(name=name, words=words, function_offsets=function_offsets, filename=shader_filename)
 
+def compile_shaders(shaders, gpu_shaders_dir, glslang, slangc, spirv_opt, targetenv, single_thread):
+    data = []
+    failed = False
+    if len(shaders) <= 1 or single_thread:
+        for shader in shaders:
+            try:
+                data.append(process_shader(shader, gpu_shaders_dir, glslang, slangc, spirv_opt, targetenv))
+            except Exception:
+                failed = True
+    else:
+        # glslang will take almost 1 second per shader on Windows (likely due to File I/O issues)
+        # We multi-thread the list of |shaders| to help speed things up
+        with ThreadPoolExecutor() as executor:
+            futures = {executor.submit(process_shader, shader, gpu_shaders_dir, glslang, slangc, spirv_opt, targetenv): shader for shader in shaders}
+            for future in futures:
+                try:
+                    data.append(future.result()) # This will raise exceptions if any occurred inside process_shader
+                except Exception:
+                    failed = True
+    return data, failed
 
-def write_aggregate_files(shader_data_list, apiname, outdir):
-    output_basename = "gpuav_offline_spirv"
-    header_content = []
+
+def write_source(shader_data_list, output_basename, out_file_dir, file_header):
     source_content = []
+    source_content.append(file_header)
+    source_content.append('#include "gpuav_offline_spirv.h"\n')
+    source_content.append("// To view SPIR-V, copy contents of an array and paste in https://www.khronos.org/spir/visualizer/\n")
+
+    for data in shader_data_list:
+        literals = []
+        for i in range(0, len(data.words), COLUMNS):
+            columns = ["0x%08x" % word for word in data.words[i:(i + COLUMNS)]]
+            literals.append(" " * INDENT + ", ".join(columns) + ",")
+        literals_str = "\n".join(literals).removesuffix(',')
+
+        source_content.append(f"[[maybe_unused]] const uint32_t {data.name}_size = {len(data.words)};")
+        source_content.append(f"[[maybe_unused]] const uint32_t {data.name}[{len(data.words)}] = {{\n{literals_str}}};")
+
+        if data.function_offsets:
+            for index, offset in enumerate(data.function_offsets):
+                source_content.append(f'[[maybe_unused]] const uint32_t {data.name}_function_{index}_offset = {offset};')
+        source_content.append("")
+
+    with open(os.path.join(out_file_dir, output_basename + '.cpp'), "w") as f:
+        f.write("\n".join(source_content))
+
+# glsl_data goes to the _glsl.cpp, slang_data to the _slang.cpp; the header declares both.
+# When slang was not compiled, slang_data carries names only (words=None) and the _slang.cpp is left untouched.
+def write_aggregate_files(glsl_data, slang_data, slang_found, apiname, outdir):
+    header_content = []
 
     file_header = f'''// *** THIS FILE IS GENERATED - DO NOT EDIT ***
 // See {os.path.basename(__file__)} for modifications
@@ -180,9 +234,9 @@ def write_aggregate_files(shader_data_list, apiname, outdir):
     header_content.append("// We have found having spirv code defined the header can lead to MSVC not recognizing changes\n")
 
     # Sort for consistent output order
-    shader_data_list.sort(key=lambda x: x.name)
+    all_data = sorted(glsl_data + slang_data, key=lambda x: x.name)
 
-    for data in shader_data_list:
+    for data in all_data:
         header_content.append(f"extern const uint32_t {data.name}_size;")
         header_content.append(f"extern const uint32_t {data.name}[];")
         if data.function_offsets:
@@ -191,27 +245,6 @@ def write_aggregate_files(shader_data_list, apiname, outdir):
                 header_content.append(f'extern const uint32_t {data.name}_function_{index}_offset;')
         header_content.append("") # Add a newline for readability
 
-    source_content.append(file_header)
-    source_content.append(f'#include "{output_basename}.h"\n')
-    source_content.append("// To view SPIR-V, copy contents of an array and paste in https://www.khronos.org/spir/visualizer/\n")
-
-    for data in shader_data_list:
-        literals = []
-        for i in range(0, len(data.words), COLUMNS):
-            columns = ["0x%08x" % word for word in data.words[i:(i + COLUMNS)]]
-            literals.append(" " * INDENT + ", ".join(columns) + ",")
-        literals_str = "\n".join(literals)
-        if literals_str.endswith(','):
-            literals_str = literals_str[:-1]
-
-        source_content.append(f"[[maybe_unused]] const uint32_t {data.name}_size = {len(data.words)};")
-        source_content.append(f"[[maybe_unused]] const uint32_t {data.name}[{len(data.words)}] = {{\n{literals_str}}};")
-
-        if data.function_offsets:
-            for index, offset in enumerate(data.function_offsets):
-                source_content.append(f'[[maybe_unused]] const uint32_t {data.name}_function_{index}_offset = {offset};')
-        source_content.append("")
-
     if outdir:
       out_file_dir = os.path.join(outdir, f'layers/{apiname}/generated')
     else:
@@ -219,8 +252,7 @@ def write_aggregate_files(shader_data_list, apiname, outdir):
 
     os.makedirs(out_file_dir, exist_ok=True)
 
-    out_file_header = os.path.join(out_file_dir, output_basename + '.h')
-    out_file_source = os.path.join(out_file_dir, output_basename + '.cpp')
+    out_file_header = os.path.join(out_file_dir, 'gpuav_offline_spirv.h')
 
     # For the header file, unless you add a new function/file the header is the same
     # To prevent causing things to recompile again, only write to file if different
@@ -237,8 +269,9 @@ def write_aggregate_files(shader_data_list, apiname, outdir):
         with open(out_file_header, "w") as f:
             f.write(new_content)
 
-    with open(out_file_source, "w") as f:
-        f.write("\n".join(source_content))
+    write_source(sorted(glsl_data, key=lambda x: x.name), 'gpuav_offline_spirv_glsl', out_file_dir, file_header)
+    if slang_found:
+        write_source(sorted(slang_data, key=lambda x: x.name), 'gpuav_offline_spirv_slang', out_file_dir, file_header)
 
 
 def main():
@@ -248,13 +281,15 @@ def main():
                         choices=['vulkan'],
                         help='Specify API name (used for output directory structure)')
     parser.add_argument('--glslang', action='store', type=str, help='Path to glslangValidator to use')
+    parser.add_argument('--slang', action='store', type=str, help='Path to slangc to use')
     parser.add_argument('--spirv-opt', action='store', dest='spirv_opt', type=str, help='Path to spirv-opt to use')
     parser.add_argument('--outdir', action='store', type=str, help='Optional path to output directory root')
     parser.add_argument('--targetenv', action='store', type=str, help='Optional --target-env argument passed down to glslangValidator')
     parser.add_argument('--single-thread', action='store_true', help='Run compilation on a single thread (for debugging)')
     args = parser.parse_args()
 
-    shaders_to_compile = []
+    glsl_shaders = []
+    slang_shaders = []
     shader_type = ['vert', 'tesc', 'tese', 'geom', 'frag', 'comp', 'mesh', 'task', 'rgen', 'rint', 'rahit', 'rchit', 'rmiss', 'rcall']
     try:
         gpu_shaders_dir = common_ci.RepoRelative('layers/gpuav/shaders')
@@ -267,13 +302,16 @@ def main():
                  print(f"Warning: Shader directory not found: {dir_path}", file=sys.stderr)
                  continue
              for filename in os.listdir(dir_path):
-                if filename.split(".")[-1].lower() in shader_type: # Use lower() for case-insensitivity
-                    shaders_to_compile.append(os.path.join(dir_path, filename))
+                extension = filename.split(".")[-1].lower() # Use lower() for case-insensitivity
+                if extension in shader_type:
+                    glsl_shaders.append(os.path.join(dir_path, filename))
+                elif extension == 'slang':
+                    slang_shaders.append(os.path.join(dir_path, filename))
 
     except Exception as e:
          sys.exit(f"Error finding shader directories: {e}")
 
-    if not shaders_to_compile:
+    if not glsl_shaders and not slang_shaders:
         sys.exit("No shader files found to compile.")
 
     external_dir = None
@@ -320,35 +358,28 @@ def main():
         print("Cannot find spirv-opt")
         return
 
-    # compile shaders
-    compiled_shader_data = []
-    compilation_failed = False
+    # default slangc path. slangc is downloaded (not built) by update_deps and may validly be absent.
+    slangc = args.slang if args.slang else common_ci.RepoRelative(os.path.join(external_dir, 'slang/install/bin/slangc'))
+    slangc = find_executable(slangc)
 
-    if len(shaders_to_compile) == 1 or args.single_thread:
-        for shader in shaders_to_compile:
-            try:
-                result = process_shader(shader, gpu_shaders_dir, glslang, spirv_opt, args.targetenv)
-                compiled_shader_data.append(result)
-            except Exception:
-                compilation_failed = True
-    else:
-        # glslang will take almost 1 second per shader on Windows (likely due to File I/O issues)
-        # We multi-thread the list of |shaders_to_compile| to help speed things up
-        with ThreadPoolExecutor() as executor:
-            futures = {executor.submit(process_shader, shader, gpu_shaders_dir, glslang, spirv_opt, args.targetenv): shader for shader in shaders_to_compile}
-
-            for future in futures:
-                shader = futures[future]
-                try:
-                    result = future.result() # This will raise exceptions if any occurred inside process_shader
-                    compiled_shader_data.append(result)
-                except Exception:
-                    compilation_failed = True
-
-    if compilation_failed:
+    # compile GLSL shaders
+    glsl_data, failed = compile_shaders(glsl_shaders, gpu_shaders_dir, glslang, None, spirv_opt, args.targetenv, args.single_thread)
+    if failed:
          sys.exit("One or more shaders failed to compile. Aggregated files will not be generated.")
 
-    write_aggregate_files(compiled_shader_data, args.api, args.outdir)
+    # compile Slang shaders, or leave gpuav_offline_spirv_slang.cpp untouched if slangc is not available
+    slang_found = slangc is not None
+    if slang_found:
+        slang_data, failed = compile_shaders(slang_shaders, gpu_shaders_dir, glslang, slangc, spirv_opt, args.targetenv, args.single_thread)
+        if failed:
+             sys.exit("One or more shaders failed to compile. Aggregated files will not be generated.")
+    else:
+        if slang_shaders:
+            print("Cannot find slangc, skipping Slang shaders (gpuav_offline_spirv_slang.cpp left untouched)")
+        # Names still needed so the header keeps declaring the committed Slang shaders
+        slang_data = [ShaderData(name=shader_name(s), words=None, function_offsets=[], filename=s) for s in slang_shaders]
+
+    write_aggregate_files(glsl_data, slang_data, slang_found, args.api, args.outdir)
 
 
 if __name__ == '__main__':

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -442,7 +442,8 @@ def main(argv):
     verify_exclude = [
         '.clang-format',
         'gpuav_offline_spirv.h',
-        'gpuav_offline_spirv.cpp',
+        'gpuav_offline_spirv_glsl.cpp',
+        'gpuav_offline_spirv_slang.cpp',
         'feature_requirements_helper.h', # https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8969
         'feature_requirements_helper.cpp',
         'feature_not_present.cpp', # this single funciton really fails with various clang-format versions


### PR DESCRIPTION
Add Slang as an optional shader language for GPU-AV's shaders. `slangc` is taken from the update_deps.py, if not found slang shaders are not compiled, but no errors is emitted.
Point is we will only ever edit them on systems capable of compiling.

This PR is needed for changes I am making to GPU-AV + ray tracing validation. Slang allows to easily manipulate pointers, and integration with C++ is a bit more seamless.