### PR TITLE
layers: Improve attachment message with handle

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1150,7 +1150,7 @@ bool CoreChecks::ValidateDrawDynamicStateValue(const LastBound& last_bound_state
                                      "coverageToColorLocation (%" PRIu32
                                      ") set by vkCmdSetCoverageToColorLocationNV points to a color attachment with format %s.\n%s",
                                      cb_state.dynamic_state_value.coverage_to_color_location, string_VkFormat(format),
-                                     cb_state.DescribeActiveColorAttachment());
+                                     cb_state.DescribeActiveColorAttachment().c_str());
                     }
                 }
             }

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -2621,7 +2621,7 @@ bool CoreChecks::ValidateDrawAttachmentColorBlend(const LastBound& last_bound_st
                              " and the color write enable state of the remaining attachments is undefined.%s\n%s",
                              blend_attachment_count, dynamic_attachment_count,
                              cb_state.DescribeInvalidatedState(CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT).c_str(),
-                             cb_state.DescribeActiveColorAttachment());
+                             cb_state.DescribeActiveColorAttachment().c_str());
             }
         }
     }
@@ -2650,7 +2650,7 @@ bool CoreChecks::ValidateDrawAttachmentColorBlend(const LastBound& last_bound_st
                              "vkCmdSetColorWriteMaskEXT was not set for color attachment index %" PRIu32
                              " for this command buffer.%s\n%s",
                              color_index, cb_state.DescribeInvalidatedState(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT).c_str(),
-                             cb_state.DescribeActiveColorAttachment());
+                             cb_state.DescribeActiveColorAttachment().c_str());
         }
 
         if (dynamic_blend_enable && cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT) &&
@@ -2661,7 +2661,7 @@ bool CoreChecks::ValidateDrawAttachmentColorBlend(const LastBound& last_bound_st
                              "vkCmdSetColorBlendEnableEXT was not set for color attachment index %" PRIu32
                              " for this command buffer.%s\n%s",
                              color_index, cb_state.DescribeInvalidatedState(CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT).c_str(),
-                             cb_state.DescribeActiveColorAttachment());
+                             cb_state.DescribeActiveColorAttachment().c_str());
             continue;  // If no value is set, IsColorBlendEnabled will give garbage
         }
         // The following all rely on color blend
@@ -2696,31 +2696,33 @@ bool CoreChecks::ValidateDrawAttachmentColorBlend(const LastBound& last_bound_st
                                      : "vkCmdSetColorBlendEquationEXT",
                                  color_index, attachment_info.Describe(cb_state, i).c_str(),
                                  last_bound_state.DescribeColorBlendEnabled(color_index).c_str(),
-                                 cb_state.DescribeActiveColorAttachment());
+                                 cb_state.DescribeActiveColorAttachment().c_str());
             }
         } else if (dynamic_equation) {
             // Only possible with pipelines
             if (!cb_state.dynamic_state_value.color_blend_equation_attachments[color_index]) {
                 const LogObjectList objlist(cb_state.Handle(), attachment->VkHandle(), last_bound_state.pipeline_state->Handle());
-                skip |= LogError(
-                    CreateActionVuid(loc.function, vvl::ActionVUID::COLOR_BLEND_EQUATION_10862), objlist, loc,
-                    "The pipeline was created with VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT, but "
-                    "vkCmdSetColorBlendEquationEXT was never set for color attachment index %" PRIu32 " (%s).%s\n%s\n%s",
-                    color_index, attachment_info.Describe(cb_state, i).c_str(),
-                    cb_state.DescribeInvalidatedState(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT).c_str(),
-                    last_bound_state.DescribeColorBlendEnabled(color_index).c_str(), cb_state.DescribeActiveColorAttachment());
+                skip |=
+                    LogError(CreateActionVuid(loc.function, vvl::ActionVUID::COLOR_BLEND_EQUATION_10862), objlist, loc,
+                             "The pipeline was created with VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT, but "
+                             "vkCmdSetColorBlendEquationEXT was never set for color attachment index %" PRIu32 " (%s).%s\n%s\n%s",
+                             color_index, attachment_info.Describe(cb_state, i).c_str(),
+                             cb_state.DescribeInvalidatedState(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT).c_str(),
+                             last_bound_state.DescribeColorBlendEnabled(color_index).c_str(),
+                             cb_state.DescribeActiveColorAttachment().c_str());
             }
         } else if (dynamic_advanced) {
             // Only possible with pipelines
             if (!cb_state.dynamic_state_value.color_blend_advanced_attachments[color_index]) {
                 const LogObjectList objlist(cb_state.Handle(), attachment->VkHandle(), last_bound_state.pipeline_state->Handle());
-                skip |= LogError(
-                    CreateActionVuid(loc.function, vvl::ActionVUID::COLOR_BLEND_EQUATION_10863), objlist, loc,
-                    "The pipeline was created with VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT, but "
-                    "vkCmdSetColorBlendAdvancedEXT was never set for color attachment index %" PRIu32 " (%s).%s\n%s\n%s",
-                    color_index, attachment_info.Describe(cb_state, i).c_str(),
-                    cb_state.DescribeInvalidatedState(CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT).c_str(),
-                    last_bound_state.DescribeColorBlendEnabled(color_index).c_str(), cb_state.DescribeActiveColorAttachment());
+                skip |=
+                    LogError(CreateActionVuid(loc.function, vvl::ActionVUID::COLOR_BLEND_EQUATION_10863), objlist, loc,
+                             "The pipeline was created with VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT, but "
+                             "vkCmdSetColorBlendAdvancedEXT was never set for color attachment index %" PRIu32 " (%s).%s\n%s\n%s",
+                             color_index, attachment_info.Describe(cb_state, i).c_str(),
+                             cb_state.DescribeInvalidatedState(CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT).c_str(),
+                             last_bound_state.DescribeColorBlendEnabled(color_index).c_str(),
+                             cb_state.DescribeActiveColorAttachment().c_str());
             }
         }
 
@@ -2729,15 +2731,16 @@ bool CoreChecks::ValidateDrawAttachmentColorBlend(const LastBound& last_bound_st
                 phys_dev_ext_props.blend_operation_advanced_props.advancedBlendMaxColorAttachments) {
                 LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
                 objlist.add(attachment->Handle());
-                skip |= LogError(
-                    CreateActionVuid(loc.function, vvl::ActionVUID::BLEND_ADVANCED_07480), objlist, loc,
-                    "vkCmdSetColorBlendAdvancedEXT has set color attachment index %" PRIu32
-                    " (%s) to advanced blending, but the total active color attachment count (%zu) is greater than "
-                    "advancedBlendMaxColorAttachments (%" PRIu32 ").%s\n%s\n%s",
-                    color_index, attachment_info.Describe(cb_state, i).c_str(), cb_state.active_color_attachments_index.size(),
-                    phys_dev_ext_props.blend_operation_advanced_props.advancedBlendMaxColorAttachments,
-                    cb_state.DescribeInvalidatedState(CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT).c_str(),
-                    last_bound_state.DescribeColorBlendEnabled(color_index).c_str(), cb_state.DescribeActiveColorAttachment());
+                skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::BLEND_ADVANCED_07480), objlist, loc,
+                                 "vkCmdSetColorBlendAdvancedEXT has set color attachment index %" PRIu32
+                                 " (%s) to advanced blending, but the total active color attachment count (%zu) is greater than "
+                                 "advancedBlendMaxColorAttachments (%" PRIu32 ").%s\n%s\n%s",
+                                 color_index, attachment_info.Describe(cb_state, i).c_str(),
+                                 cb_state.active_color_attachments_index.size(),
+                                 phys_dev_ext_props.blend_operation_advanced_props.advancedBlendMaxColorAttachments,
+                                 cb_state.DescribeInvalidatedState(CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT).c_str(),
+                                 last_bound_state.DescribeColorBlendEnabled(color_index).c_str(),
+                                 cb_state.DescribeActiveColorAttachment().c_str());
             }
         }
 
@@ -2753,7 +2756,7 @@ bool CoreChecks::ValidateDrawAttachmentColorBlend(const LastBound& last_bound_st
                              last_bound_state.DescribeColorBlendEnabled(color_index).c_str(),
                              last_bound_state.DescribeBlendFactorEquation(color_index).c_str(),
                              cb_state.DescribeInvalidatedState(CB_DYNAMIC_STATE_BLEND_CONSTANTS).c_str(),
-                             cb_state.DescribeActiveColorAttachment());
+                             cb_state.DescribeActiveColorAttachment().c_str());
         }
 
         // Validation needing access to spir-v information

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -23,6 +23,7 @@
 #include <vulkan/vulkan_core.h>
 #include <vulkan/utility/vk_format_utils.h>
 #include <memory>
+#include <sstream>
 #include "containers/limits.h"
 #include "error_message/error_location.h"
 #include "generated/command_validation.h"
@@ -113,6 +114,14 @@ std::string AttachmentInfo::Describe(const vvl::CommandBuffer& cb_state, uint32_
 
         ss << ")";
     }
+
+    ss << " (";
+    if (image_view) {
+        ss << cb_state.dev_data.FormatHandle(image_view->Handle());
+    } else {
+        ss << "VK_NULL_HANDLE";
+    }
+    ss << ')';
     return ss.str();
 }
 
@@ -166,14 +175,21 @@ void CommandBuffer::SetActiveSubpass(uint32_t subpass) {
 }
 
 // Put here, instead of vvl::RenderPass for ease of access
-const char* CommandBuffer::DescribeActiveColorAttachment() const {
+std::string CommandBuffer::DescribeActiveColorAttachment() const {
+    std::ostringstream ss;
     if (!active_render_pass) {
-        return "";
-    } else if (active_render_pass->UsesDynamicRendering()) {
-        return "Active color attachments are those where VkRenderingInfo::pColorAttachments[i].imageView != VK_NULL_HANDLE";
+        ss << "[No active rendering instance]";
     } else {
-        return "Active color attachments are those where pSubpasses[i].pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED";
+        ss << "Active color attachments are:\n";
+        for (uint32_t i = 0; i < active_attachments.size(); ++i) {
+            const AttachmentInfo& attachment_info = active_attachments[i];
+            if (!attachment_info.IsColor() || !attachment_info.image_view) {
+                continue;
+            }
+            ss << "  " << attachment_info.Describe(*this, i) << '\n';
+        }
     }
+    return ss.str();
 }
 
 CommandBuffer::CommandBuffer(DeviceState& dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* allocate_info,

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -454,7 +454,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     // only when not using dynamic rendering
     vku::safe_VkRenderPassSampleLocationsBeginInfoEXT sample_locations_begin_info;
     std::vector<SubpassInfo> active_subpasses;
-    const char *DescribeActiveColorAttachment() const;
+    std::string DescribeActiveColorAttachment() const;
 
     VkSubpassContents active_subpass_contents;
     uint32_t GetActiveSubpass() const { return active_subpass_; }


### PR DESCRIPTION
Better error messages, not print the handles and list all the color attachment paths

```
// added the (VkImageView 0x70000000007)
//
Validation Error: [ VUID-vkCmdDraw-None-08644 ] | MessageID = 0x7ac1ebb
vkCmdDraw(): VkRenderingInfo::pColorAttachments[0].imageView (VkImageView 0x70000000007) was created with VK_SAMPLE_COUNT_1_BIT but the last call to vkCmdSetRasterizationSamplesEXT was set to VK_SAMPLE_COUNT_2_BIT.
```

```
Validation Error: [ VUID-vkCmdDraw-attachmentCount-07750 ] | MessageID = 0xbd081170
vkCmdDraw(): There are currently (2) active color attachments, but the last call to vkCmdSetColorWriteEnableEXT() only set the color write enables for attachmentCount of 1 and the color write enable state of the remaining attachments is undefined.
Active color attachments are:
  VkRenderingInfo::pColorAttachments[0].imageView (VkImageView 0x80000000008)
  VkRenderingInfo::pColorAttachments[1].imageView (VkImageView 0x90000000009)
```

```
Validation Error: [ VUID-vkCmdDraw-attachmentCount-07750 ] | MessageID = 0xbd081170
vkCmdDraw(): There are currently (2) active color attachments, but the last call to vkCmdSetColorWriteEnableEXT() only set the color write enables for attachmentCount of 1 and the color write enable state of the remaining attachments is undefined.
Active color attachments are:
  VkRenderPassCreateInfo::pAttachments[0] (Subpass 0, VkSubpassDescription::pColorAttachments[0]) (VkImageView 0x70000000007)
  VkRenderPassCreateInfo::pAttachments[1] (Subpass 0, VkSubpassDescription::pColorAttachments[1]) (VkImageView 0xb000000000b)
```