### PR TITLE
layers: Use Handle() over VkHandle() for FormatHandle

### DIFF
--- a/layers/best_practices/bp_cmd_buffer.cpp
+++ b/layers/best_practices/bp_cmd_buffer.cpp
@@ -142,8 +142,8 @@ struct EventValidator {
                         "BestPractices-Event-SignalSignaledEvent", objlist, secondary_cb_loc,
                         "%s sets event %s which was already set (in the primary command buffer %s or in the executed secondary "
                         "command buffers). If this is not the desired behavior, the event must be reset before it is set again.",
-                        log.FormatHandle(secondary_cb.VkHandle()).c_str(), log.FormatHandle(event).c_str(),
-                        log.FormatHandle(primary_cb.VkHandle()).c_str());
+                        log.FormatHandle(secondary_cb.Handle()).c_str(), log.FormatHandle(event).c_str(),
+                        log.FormatHandle(primary_cb.Handle()).c_str());
                 }
             }
             signaling_state[event] = signaling_info.signaled;

--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -249,7 +249,7 @@ struct EventValidator {
                         "BestPractices-Event-SignalSignaledEvent", objlist, cb_loc,
                         "%s sets event %s which is already in the signaled state (set by previously submitted command buffers or "
                         "from the host). If this is not the desired behavior, the event must be reset before it is set again.",
-                        bp.FormatHandle(cb.VkHandle()).c_str(), bp.FormatHandle(event).c_str());
+                        bp.FormatHandle(cb.Handle()).c_str(), bp.FormatHandle(event).c_str());
                 }
             }
             signaling_state[event] = info.signaled;

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -59,7 +59,7 @@ bool BestPractices::CheckEventSignalingState(const bp_state::CommandBufferSubSta
         skip |= LogWarning("BestPractices-Event-SignalSignaledEvent", objlist, cb_loc,
                            "%s sets event %s which was already set (in this command buffer or in the executed secondary command "
                            "buffers). If this is not the desired behavior, the event must be reset before it is set again.",
-                           FormatHandle(command_buffer.VkHandle()).c_str(), FormatHandle(event).c_str());
+                           FormatHandle(command_buffer.Handle()).c_str(), FormatHandle(event).c_str());
     }
     return skip;
 }

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -905,9 +905,9 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, cons
                     "Copy source buffer range %s (from buffer %s) and destination buffer range %s (from buffer %s) are bound to "
                     "the same memory (%s), "
                     "and end up overlapping on memory range %s.",
-                    vvl::string_range(*src_ranges_it).c_str(), FormatHandle(src_buffer_state.VkHandle()).c_str(),
-                    vvl::string_range(*dst_ranges_it).c_str(), FormatHandle(dst_buffer_state.VkHandle()).c_str(),
-                    FormatHandle(src_binding->memory_state->VkHandle()).c_str(), vvl::string_range(memory_range_overlap).c_str());
+                    vvl::string_range(*src_ranges_it).c_str(), FormatHandle(src_buffer_state.Handle()).c_str(),
+                    vvl::string_range(*dst_ranges_it).c_str(), FormatHandle(dst_buffer_state.Handle()).c_str(),
+                    FormatHandle(src_binding->memory_state->Handle()).c_str(), vvl::string_range(memory_range_overlap).c_str());
             }
 
             if (*src_ranges_it < *dst_ranges_it) {

--- a/layers/core_checks/cc_device_generated_commands.cpp
+++ b/layers/core_checks/cc_device_generated_commands.cpp
@@ -1134,9 +1134,8 @@ bool CoreChecks::PreCallValidateUpdateIndirectExecutionSetPipelineEXT(
                             "%s was created with a layout %s which is not compatible with the initialPipeline "
                             "layout %s for set "
                             "%" PRIu32 ".\n%s",
-                            FormatHandle(update_pipeline->VkHandle()).c_str(),
-                            FormatHandle(update_pipeline_layout->VkHandle()).c_str(),
-                            FormatHandle(initial_pipeline_layout->VkHandle()).c_str(), set,
+                            FormatHandle(update_pipeline->Handle()).c_str(), FormatHandle(update_pipeline_layout->Handle()).c_str(),
+                            FormatHandle(initial_pipeline_layout->Handle()).c_str(), set,
                             DescribePipelineLayoutSetNonCompatible(set, initial_pipeline_layout.get(), update_pipeline_layout.get())
                                 .c_str());
                         break;

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -152,9 +152,9 @@ bool CoreChecks::ValidateAccelStructsMemoryDoNotOverlap(const Location& function
                          "%s (%s) is backed by buffer (%s) on range %s.\n"
                          "%s (%s) is backed by buffer (%s) on range %s.\n"
                          "The overlapping range for memory (%s) is %s.",
-                         loc_a_str.c_str(), loc_b_str.c_str(), loc_a_str.c_str(), FormatHandle(accel_struct_a.VkHandle()).c_str(),
-                         FormatHandle(buffer_a.state->VkHandle()).c_str(), string_range_hex(range_a).c_str(), loc_b_str.c_str(),
-                         FormatHandle(accel_struct_b.VkHandle()).c_str(), FormatHandle(buffer_b.state->VkHandle()).c_str(),
+                         loc_a_str.c_str(), loc_b_str.c_str(), loc_a_str.c_str(), FormatHandle(accel_struct_a.Handle()).c_str(),
+                         FormatHandle(buffer_a.state->Handle()).c_str(), string_range_hex(range_a).c_str(), loc_b_str.c_str(),
+                         FormatHandle(accel_struct_b.Handle()).c_str(), FormatHandle(buffer_b.state->Handle()).c_str(),
                          string_range_hex(range_b).c_str(), FormatHandle(memory).c_str(), string_range(overlap_range).c_str());
     }
 

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -3149,12 +3149,11 @@ bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(const core::Renderin
     if (enabled_features.tileMemoryHeap && !resolve_view_state.image_state->GetBoundMemoryStates().empty()) {
         for (const auto& bound_memory : resolve_view_state.image_state->GetBoundMemoryStates()) {
             if (bound_memory && HasTileMemoryType(bound_memory->allocate_info.memoryTypeIndex)) {
-                skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveImageView-10728", vvl_attachment.GetObjectList(),
-                                 vvl_attachment.Loc(),
-                                 "was created with %s which is bound to %s created from a VkMemoryHeap with"
-                                 " VK_MEMORY_HEAP_TILE_MEMORY_BIT_QCOM",
-                                 FormatHandle(resolve_view_state.image_state->VkHandle()).c_str(),
-                                 FormatHandle(bound_memory->VkHandle()).c_str());
+                skip |= LogError(
+                    "VUID-VkRenderingAttachmentInfo-resolveImageView-10728", vvl_attachment.GetObjectList(), vvl_attachment.Loc(),
+                    "was created with %s which is bound to %s created from a VkMemoryHeap with"
+                    " VK_MEMORY_HEAP_TILE_MEMORY_BIT_QCOM",
+                    FormatHandle(resolve_view_state.image_state->Handle()).c_str(), FormatHandle(bound_memory->Handle()).c_str());
             }
         }
     }
@@ -5432,13 +5431,12 @@ bool CoreChecks::ValidateTileMemoryAttachments(const VkImageView* image_views, c
                 const char* vuid = is_imageless ? "VUID-VkRenderPassBeginInfo-framebuffer-12328"
                                                 : "VUID-VkFramebufferCreateInfo-pAttachments-12327";
                 LogObjectList objlist(rp_state.VkHandle(), image_views[i], bound_memory->VkHandle());
-                skip |=
-                    LogError(vuid, objlist, attachment_loc,
-                             "%s (corresponding to pResolveAttachment[%" PRIu32
-                             "]"
-                             " is bound to %s created from a VkMemoryHeap with"
-                             " VK_MEMORY_HEAP_TILE_MEMORY_BIT_QCOM.",
-                             FormatHandle(image_view_state->VkHandle()).c_str(), i, FormatHandle(bound_memory->VkHandle()).c_str());
+                skip |= LogError(vuid, objlist, attachment_loc,
+                                 "%s (corresponding to pResolveAttachment[%" PRIu32
+                                 "]"
+                                 " is bound to %s created from a VkMemoryHeap with"
+                                 " VK_MEMORY_HEAP_TILE_MEMORY_BIT_QCOM.",
+                                 FormatHandle(image_view_state->Handle()).c_str(), i, FormatHandle(bound_memory->Handle()).c_str());
             }
         }
     }

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -800,13 +800,13 @@ bool CoreChecks::ValidateDrawShaderObjectFlags(const LastBound& last_bound_state
                << " has flag VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR but the VkPipelineLayout (bound with ";
             ss << vvl::String(last_bound_state.GetDescriptorModeFunc())
                << ") is mixing mesh and non-mesh pre-rasterization shader stages\n";
-            ss << FormatHandle(pre_raster_dsl->VkHandle()) << " at set " << binding_with_pre_rast_stage->first << ", binding "
+            ss << FormatHandle(pre_raster_dsl->Handle()) << " at set " << binding_with_pre_rast_stage->first << ", binding "
                << binding_with_pre_rast_stage->second << " has stageFlags "
                << string_VkShaderStageFlags(
                       pre_raster_dsl->GetDescriptorSetLayoutBindingPtrFromBinding(binding_with_pre_rast_stage->second)->stageFlags)
                << '\n';
             if (!same_binding) {
-                ss << FormatHandle(mesh_dsl->VkHandle()) << " at set " << binding_with_mesh_stage->first << ", binding "
+                ss << FormatHandle(mesh_dsl->Handle()) << " at set " << binding_with_mesh_stage->first << ", binding "
                    << binding_with_mesh_stage->second << " has stageFlags "
                    << string_VkShaderStageFlags(
                           mesh_dsl->GetDescriptorSetLayoutBindingPtrFromBinding(binding_with_mesh_stage->second)->stageFlags)

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -352,11 +352,9 @@ void CommandBufferSubState::RecordCopyBufferCommon(vvl::Buffer& src_buffer_state
                         "Copy source buffer range %s (from buffer %s) and destination buffer range %s (from buffer %s) are "
                         "bound to the same memory (%s), "
                         "and end up overlapping on memory range %s.",
-                        vvl::string_range(src_ranges_it->second).c_str(),
-                        validator.FormatHandle(src_buffer_state.VkHandle()).c_str(),
-                        vvl::string_range(dst_ranges_it->second).c_str(),
-                        validator.FormatHandle(dst_buffer_state.VkHandle()).c_str(), validator.FormatHandle(vk_memory).c_str(),
-                        vvl::string_range(memory_range_overlap).c_str());
+                        vvl::string_range(src_ranges_it->second).c_str(), validator.FormatHandle(src_buffer_state.Handle()).c_str(),
+                        vvl::string_range(dst_ranges_it->second).c_str(), validator.FormatHandle(dst_buffer_state.Handle()).c_str(),
+                        validator.FormatHandle(vk_memory).c_str(), vvl::string_range(memory_range_overlap).c_str());
                 }
 
                 if (src_ranges_it->first < dst_ranges_it->first) {

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -172,7 +172,7 @@ bool SemaphoreSubmitState::ValidateBinaryWait(const Location& loc, const vvl::Se
                 "queue (%s) is waiting on binary semaphore (%s) that has an associated signal but it depends on timeline semaphore "
                 "wait (%s, wait value = %" PRIu64 ") that does not have resolving signal submitted yet.",
                 core.FormatHandle(queue).c_str(), core.FormatHandle(semaphore).c_str(),
-                core.FormatHandle(timeline_wait_info->semaphore->VkHandle()).c_str(), timeline_wait_info->payload);
+                core.FormatHandle(timeline_wait_info->semaphore->Handle()).c_str(), timeline_wait_info->payload);
         } else {
             binary_signaling_state[semaphore] = false;
         }

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -707,7 +707,7 @@ bool DescriptorValidator::ValidateSampledImageDescriptor(const spirv::ResourceIn
             << " is accessed by a OpTypeImage that has a Format operand "
             << string_SpirvImageFormat(resource_variable.info.vk_format) << " (equivalent to "
             << string_VkFormat(resource_variable.info.vk_format) << ") which doesn't match the "
-            << FormatHandle(image_view_state.VkHandle()) << " format (" << string_VkFormat(image_view_ci.format)
+            << FormatHandle(image_view_state.Handle()) << " format (" << string_VkFormat(image_view_ci.format)
             << "). Any loads or stores with the variable will produce undefined values to the whole image (not just the texel "
                "being accessed).";
         if (vkuFormatCompatibilityClass(image_view_ci.format) == vkuFormatCompatibilityClass(resource_variable.info.vk_format)) {

--- a/layers/gpu_dump/gpu_dump_descriptor_buffer.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_buffer.cpp
@@ -287,7 +287,7 @@ bool CommandBufferSubState::DumpDescriptorBuffer(std::ostringstream& ss, const L
     }
 
     const vvl::PipelineLayout& pipeline_layout = *last_bound.desc_set_pipeline_layout;
-    ss << "- vkCmdSetDescriptorBufferOffsetsEXT last bound with " << dev_data.FormatHandle(pipeline_layout.VkHandle()) << "\n";
+    ss << "- vkCmdSetDescriptorBufferOffsetsEXT last bound with " << dev_data.FormatHandle(pipeline_layout.Handle()) << "\n";
 
     ss << "- Shader descriptors:\n";
     for (const ShaderStageState* stage : stages) {
@@ -300,7 +300,7 @@ bool CommandBufferSubState::DumpDescriptorBuffer(std::ostringstream& ss, const L
         ss << "  " << entry_point.Describe();
         // TODO - add util in ShaderStageState to get ShaderObject handle here
         if (stage->module_state && stage->module_state->VkHandle() != VK_NULL_HANDLE) {
-            ss << " " << dev_data.FormatHandle(stage->module_state->VkHandle());
+            ss << " " << dev_data.FormatHandle(stage->module_state->Handle());
         }
         ss << "\n";
 

--- a/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
@@ -2075,7 +2075,7 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
     }
 
     if (last_bound.pipeline_state) {
-        ss << "- Last bound pipeline: " << dev_data.FormatHandle(last_bound.pipeline_state->VkHandle()) << " ("
+        ss << "- Last bound pipeline: " << dev_data.FormatHandle(last_bound.pipeline_state->Handle()) << " ("
            << string_VkPipelineBindPoint(last_bound.pipeline_state->pipeline_type) << ")\n";
     }
 
@@ -2091,7 +2091,7 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         ss << "  " << entry_point.Describe();
         // TODO - add util in ShaderStageState to get ShaderObject handle here
         if (stage->module_state && stage->module_state->VkHandle() != VK_NULL_HANDLE) {
-            ss << " " << dev_data.FormatHandle(stage->module_state->VkHandle());
+            ss << " " << dev_data.FormatHandle(stage->module_state->Handle());
         }
         ss << "\n";
 

--- a/layers/gpuav/instrumentation/trace_ray.cpp
+++ b/layers/gpuav/instrumentation/trace_ray.cpp
@@ -221,10 +221,10 @@ void RegisterTraceRayValidation(Validator& gpuav, CommandBufferSubState& cb) {
                             strm << "(set = " << set_num << ", binding = " << binding_num << ", index " << desc_index << ") ";
                             if (error_sub_code == kErrorSubCode_RayQuery_TlasNotBuilt) {
                                 strm << "OpRayQueryInitializeKHR operand Acceleration structure ("
-                                     << gpuav.FormatHandle(as_state->VkHandle()) << ") has not been built.";
+                                     << gpuav.FormatHandle(as_state->Handle()) << ") has not been built.";
                                 out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06352";
                             } else {
-                                strm << "OpTraceRayKHR operand Acceleration structure (" << gpuav.FormatHandle(as_state->VkHandle())
+                                strm << "OpTraceRayKHR operand Acceleration structure (" << gpuav.FormatHandle(as_state->Handle())
                                      << ") has not been built.";
                                 out_vuid_msg = "VUID-RuntimeSpirv-OpTraceRayKHR-06359";
                             }

--- a/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
@@ -618,9 +618,9 @@ void TLAS(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state
         std::stringstream ss_as;
         std::stringstream ss_as_buffer;
         if (as_found_it != gpuav.device_state->as_with_addresses.array.end()) {
-            ss_as << "Acceleration structure corresponding to reference: " << gpuav.FormatHandle((*as_found_it)->VkHandle());
+            ss_as << "Acceleration structure corresponding to reference: " << gpuav.FormatHandle((*as_found_it)->Handle());
             if (const auto as_buffer = (*as_found_it)->GetFirstValidBuffer(*gpuav.device_state)) {
-                ss_as_buffer << "(" << gpuav.FormatHandle(as_buffer.state->VkHandle()) << ") ";
+                ss_as_buffer << "(" << gpuav.FormatHandle(as_buffer.state->Handle()) << ") ";
             }
         } else {
             ss_as << "Could not map acceleration structure reference to its corresponding handle, " << vvl_bug_msg;
@@ -695,16 +695,15 @@ void TLAS(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state
                             error_ss << "Could not retrieve buffer information, " << vvl_bug_msg;
                         } else {
                             error_ss << "pInfos[" << blas_built_in_cmd.p_info_i << "].dstAccelerationStructure ("
-                                     << gpuav.FormatHandle(blas_built_in_cmd.blas->VkHandle()) << "), backed by buffer ("
-                                     << gpuav.FormatHandle(blas_cmd_as_buffer.state->VkHandle())
+                                     << gpuav.FormatHandle(blas_built_in_cmd.blas->Handle()) << "), backed by buffer ("
+                                     << gpuav.FormatHandle(blas_cmd_as_buffer.state->Handle())
                                      << "), overlaps on buffer address range " << vvl::string_range_hex(overlap) << " with buffer ("
-                                     << gpuav.FormatHandle(blas_tlas_as_buffer.state->VkHandle()) << ") of BLAS ("
-                                     << gpuav.FormatHandle((*as_found_it)->VkHandle()) << "), referenced in "
-                                     << invalid_blas_loc_str;
+                                     << gpuav.FormatHandle(blas_tlas_as_buffer.state->Handle()) << ") of BLAS ("
+                                     << gpuav.FormatHandle((*as_found_it)->Handle()) << "), referenced in " << invalid_blas_loc_str;
                         }
                     } else {
                         error_ss << "pInfos[" << blas_built_in_cmd.p_info_i << "].dstAccelerationStructure ("
-                                 << gpuav.FormatHandle(blas_built_in_cmd.blas->VkHandle())
+                                 << gpuav.FormatHandle(blas_built_in_cmd.blas->Handle())
                                  << ") is also referenced in a TLAS built in the same command, through " << invalid_blas_loc_str;
                     }
                 } else {

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -3130,7 +3130,7 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
                 access_context.DetectHazard(scratch_buffer, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, scratch_buffer.Handle());
-                const std::string resource_description = "scratch buffer " + FormatHandle(scratch_buffer.VkHandle());
+                const std::string resource_description = "scratch buffer " + FormatHandle(scratch_buffer.Handle());
                 const auto error =
                     error_messages_.BufferError(hazard, cb_context, error_obj.location.function, resource_description, range);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
@@ -3144,7 +3144,7 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
                                                           SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_READ, range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, src_as_buffer.state->Handle(), src_accel->Handle());
-                    const std::string resource_description = FormatHandle(src_as_buffer.state->VkHandle());
+                    const std::string resource_description = FormatHandle(src_as_buffer.state->Handle());
                     const std::string error = error_messages_.AccelerationStructureError(
                         hazard, cb_context, error_obj.location.function, resource_description, range, info.srcAccelerationStructure,
                         info_loc.dot(Field::srcAccelerationStructure));
@@ -3160,7 +3160,7 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
                     *dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, dst_range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, dst_as_buffer.state->Handle(), dst_accel->Handle());
-                    const std::string resource_description = FormatHandle(dst_as_buffer.state->VkHandle());
+                    const std::string resource_description = FormatHandle(dst_as_buffer.state->Handle());
                     const std::string error = error_messages_.AccelerationStructureError(
                         hazard, cb_context, error_obj.location.function, resource_description, dst_range,
                         info.dstAccelerationStructure, info_loc.dot(Field::dstAccelerationStructure));
@@ -3326,7 +3326,7 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuff
                                                       SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(cb_state->Handle(), src_as_buffer.state->Handle(), src_accel->Handle());
-                const std::string resource_description = FormatHandle(src_as_buffer.state->VkHandle());
+                const std::string resource_description = FormatHandle(src_as_buffer.state->Handle());
                 const std::string error =
                     error_messages_.AccelerationStructureError(hazard, cb_context, error_obj.location.function,
                                                                resource_description, range, pInfo->src, info_loc.dot(Field::src));
@@ -3341,7 +3341,7 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuff
                                                       SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(cb_state->Handle(), dst_as_buffer.state->Handle(), dst_accel->Handle());
-                const std::string resource_description = FormatHandle(dst_as_buffer.state->VkHandle());
+                const std::string resource_description = FormatHandle(dst_as_buffer.state->Handle());
                 const std::string error =
                     error_messages_.AccelerationStructureError(hazard, cb_context, error_obj.location.function,
                                                                resource_description, range, pInfo->dst, info_loc.dot(Field::dst));
@@ -3396,7 +3396,7 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkCom
                                                       SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(cb_state->Handle(), src_as_buffer.state->Handle(), src_accel->Handle());
-                const std::string resource_description = FormatHandle(src_as_buffer.state->VkHandle());
+                const std::string resource_description = FormatHandle(src_as_buffer.state->Handle());
                 const std::string error =
                     error_messages_.AccelerationStructureError(hazard, cb_context, error_obj.location.function,
                                                                resource_description, range, pInfo->src, info_loc.dot(Field::src));
@@ -3449,7 +3449,7 @@ bool SyncValidator::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkCom
                                                       SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(cb_state->Handle(), dst_as_buffer.state->Handle(), dst_accel->Handle());
-                const std::string resource_description = FormatHandle(dst_as_buffer.state->VkHandle());
+                const std::string resource_description = FormatHandle(dst_as_buffer.state->Handle());
                 const std::string error =
                     error_messages_.AccelerationStructureError(hazard, cb_context, error_obj.location.function,
                                                                resource_description, range, pInfo->dst, info_loc.dot(Field::dst));


### PR DESCRIPTION
doing `VkHandle()` is an extra cast, we mix-and-match this, so here is me trying to unify it to help the future me copy-and-paste this correctly