### PR TITLE
layers: Add active CB debug labels to messages

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -188,7 +188,8 @@ bool DebugReport::LogMessage(VkFlags msg_flags, std::string_view vuid_text, cons
                 label_iter->second->Export(queue_labels);
             }
             // If this is a command buffer, add any command buffer labels to the callback data.
-        } else if (VK_OBJECT_TYPE_COMMAND_BUFFER == object_name_info.objectType) {
+            // Only consider first found command buffer, to avoid mixing unrelated label stacks
+        } else if (VK_OBJECT_TYPE_COMMAND_BUFFER == object_name_info.objectType && cmd_buf_labels.empty()) {
             auto label_iter = debug_utils_cmd_buffer_labels.find(reinterpret_cast<VkCommandBuffer>(object_name_info.objectHandle));
             if (label_iter != debug_utils_cmd_buffer_labels.end()) {
                 label_iter->second->Export(cmd_buf_labels);

--- a/tests/framework/error_monitor.cpp
+++ b/tests/framework/error_monitor.cpp
@@ -87,9 +87,9 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugCallback(VkDebugUtilsMessageSeverityF
 
         if (callback_data->objectCount > 0) {
             oss << "Objects: " << callback_data->objectCount << '\n';
-            for (uint32_t i = 0; i < callback_data->objectCount; i++) {
-                const auto& debug_object = callback_data->pObjects[i];
-                oss << "    [" << i << "] " << string_VkObjectTypeHandleName(debug_object.objectType);
+            for (uint32_t obj_i = 0; obj_i < callback_data->objectCount; obj_i++) {
+                const auto& debug_object = callback_data->pObjects[obj_i];
+                oss << "    [" << obj_i << "] " << string_VkObjectTypeHandleName(debug_object.objectType);
                 if (debug_object.objectHandle) {
                     oss << " 0x" << std::hex << debug_object.objectHandle;
                 } else {
@@ -97,6 +97,16 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugCallback(VkDebugUtilsMessageSeverityF
                 }
                 if (debug_object.pObjectName) {
                     oss << "[" << debug_object.pObjectName << "]";
+                }
+                if (debug_object.objectType == VK_OBJECT_TYPE_COMMAND_BUFFER && callback_data->cmdBufLabelCount > 0) {
+                    oss << " [ Active debug region: ";
+                    for (uint32_t label_i = 0; label_i < callback_data->cmdBufLabelCount; ++label_i) {
+                        if (label_i > 0) {
+                            oss << "::";
+                        }
+                        oss << callback_data->pCmdBufLabels[(callback_data->cmdBufLabelCount - 1) - label_i].pLabelName;
+                    }
+                    oss << " ]";
                 }
                 oss << '\n';
             }

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -776,6 +776,30 @@ TEST_F(NegativeCommand, DrawOutsideRenderPass) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeCommand, DrawOutsideRenderPassDebugLabels) {
+    TEST_DESCRIPTION("call vkCmdDraw without renderpass - make sure debug labels appear in message");
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    CreatePipelineHelper pipe(*this);
+    pipe.CreateGraphicsPipeline();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+
+    VkDebugUtilsLabelEXT label = vku::InitStructHelper();
+    label.pLabelName = "RegionA";
+    vk::CmdBeginDebugUtilsLabelEXT(m_command_buffer, &label);
+    label.pLabelName = "RegionB";
+    vk::CmdBeginDebugUtilsLabelEXT(m_command_buffer, &label);
+    label.pLabelName = "RegionC";
+    vk::CmdBeginDebugUtilsLabelEXT(m_command_buffer, &label);
+    vk::CmdEndDebugUtilsLabelEXT(m_command_buffer);
+    m_errorMonitor->SetDesiredError("RegionA::RegionB");
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeCommand, DispatchInsideRenderPass) {
     TEST_DESCRIPTION("Only allowed with VK_QCOM_tile_shading");
     RETURN_IF_SKIP(Init());


### PR DESCRIPTION
Add VkDebugUtilsLabelEXT active in the current VkCommandBuffer at the time the callback was triggered in VVL messages

```
[ RUN      ] NegativeCommand.DrawOutsideRenderPassDebugLabels
Validation Error: [ VUID-vkCmdDraw-renderpass ] | MessageID = 0xf58328d8
vkCmdDraw(): This call must be issued inside an active render pass.
The Vulkan spec states: This command must only be called inside of a render pass instance (https://docs.vulkan.org/spec/latest/chapters/drawing.html#VUID-vkCmdDraw-renderpass)
Objects: 1
    [0] VkCommandBuffer 0xc718dc000 [ Active debug region: RegionA::RegionB ]

[       OK ] NegativeCommand.DrawOutsideRenderPassDebugLabels (724 ms)
```

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8985