### PR TITLE
layers: Fix VK_EXT_legacy_vertex_attributes 64-bit check

### DIFF
--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -3076,9 +3076,13 @@ bool CoreChecks::ValidateDrawVertexBinding(const LastBound& last_bound, const Lo
         for (const auto& location : binding_description.locations) {
             const auto attr_index = location.second.index;
             const auto& attr_desc = location.second.desc;
+            // TODO - Handle https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/issues/45 for Vertex
+            const VkBuffer vertex_buffer_handle = vertex_buffer_binding->Buffer();
 
-            // TODO - Handle https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/issues/45
-            if (!enabled_features.robustBufferAccess && !robust_pipeline && vertex_buffer_binding->Buffer() != VK_NULL_HANDLE) {
+            // VK_EXT_legacy_vertex_attributes has no alignment requirement, except for 64-bit format (which wasn't in OpenGL)
+            const bool attrib_alignment_required = !enabled_features.legacyVertexAttributes || vkuFormatIs64bit(attr_desc.format);
+            if (attrib_alignment_required && !enabled_features.robustBufferAccess && !robust_pipeline &&
+                vertex_buffer_handle != VK_NULL_HANDLE) {
                 const VkDeviceSize vertex_buffer_offset = vertex_buffer_binding->BufferOffset();
 
                 // Use 1 as vertex/instance index to use buffer stride as well
@@ -3096,7 +3100,7 @@ bool CoreChecks::ValidateDrawVertexBinding(const LastBound& last_bound, const Lo
 
                 if (!IsPointerAligned(attrib_address, vtx_attrib_req_alignment)) {
                     LogObjectList objlist(last_bound.cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS));
-                    objlist.add(vertex_buffer_binding->Buffer());
+                    objlist.add(vertex_buffer_handle);
                     skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::VERTEX_BINDING_ATTRIBUTE_02721), objlist, loc,
                                      "Format %s has an alignment of %" PRIu64 " but the alignment of attribAddress (0x%" PRIx64
                                      ") is not aligned in pVertexAttributeDescriptions[%" PRIu32 "] (binding=%" PRIu32

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -804,6 +804,57 @@ TEST_F(NegativeVertexInput, VertextBindingDynamicState) {
     m_command_buffer.End();
 }
 
+TEST_F(NegativeVertexInput, LegacyVertexAttributesAlignment) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8491");
+    AddRequiredExtensions(VK_EXT_LEGACY_VERTEX_ATTRIBUTES_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::legacyVertexAttributes);
+    AddRequiredFeature(vkt::Feature::shaderFloat64);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    if (!BufferFormatAndFeaturesSupported(Gpu(), VK_FORMAT_R64_SFLOAT, VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT)) {
+        GTEST_SKIP() << "Device does not support VK_FORMAT_R64_SFLOAT vertex buffers";
+    }
+
+    const char* vs_source = R"glsl(
+        #version 450
+        #extension GL_ARB_gpu_shader_fp64 : enable
+        layout(location = 0) in double x;
+        void main(){
+           gl_Position = vec4(float(x));
+        }
+    )glsl";
+    VkShaderObj vs(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
+
+    VkVertexInputBindingDescription input_binding{0, sizeof(double), VK_VERTEX_INPUT_RATE_VERTEX};
+
+    VkVertexInputAttributeDescription input_attrib{0, 0, VK_FORMAT_R64_SFLOAT, 0};
+
+    VkPipelineVertexInputStateCreateInfo vi_state = vku::InitStructHelper();
+    vi_state.vertexBindingDescriptionCount = 1;
+    vi_state.pVertexBindingDescriptions = &input_binding;
+    vi_state.vertexAttributeDescriptionCount = 1;
+    vi_state.pVertexAttributeDescriptions = &input_attrib;
+
+    CreatePipelineHelper pipe(*this);
+    pipe.shader_stages_[0] = vs.GetStageCreateInfo();
+    pipe.vi_ci_ = vi_state;
+    pipe.CreateGraphicsPipeline();
+
+    vkt::Buffer vbo(*m_device, 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    VkDeviceSize offset = 7;
+    vk::CmdBindVertexBuffers(m_command_buffer, 0, 1, &vbo.handle(), &offset);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-02721");
+    vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeVertexInput, AttributeAlignment) {
     TEST_DESCRIPTION("Check for proper aligment of attribAddress which depends on a bound pipeline and on a bound vertex buffer");
 

--- a/tests/unit/vertex_input_positive.cpp
+++ b/tests/unit/vertex_input_positive.cpp
@@ -932,6 +932,50 @@ TEST_F(PositiveVertexInput, LegacyVertexAttributes) {
     m_command_buffer.End();
 }
 
+TEST_F(PositiveVertexInput, LegacyVertexAttributesAlignment) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8491");
+    AddRequiredExtensions(VK_EXT_LEGACY_VERTEX_ATTRIBUTES_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::legacyVertexAttributes);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    const char* vs_source = R"glsl(
+        #version 450
+        layout(location = 0) in vec3 x;
+        void main(){
+           gl_Position = vec4(x, 1.0);
+        }
+    )glsl";
+    VkShaderObj vs(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
+
+    VkVertexInputBindingDescription input_binding{0, sizeof(float) * 3, VK_VERTEX_INPUT_RATE_VERTEX};
+
+    // non-packed, non-64-bit format
+    VkVertexInputAttributeDescription input_attrib{0, 0, VK_FORMAT_R32G32B32_SFLOAT, 0};
+
+    VkPipelineVertexInputStateCreateInfo vi_state = vku::InitStructHelper();
+    vi_state.vertexBindingDescriptionCount = 1;
+    vi_state.pVertexBindingDescriptions = &input_binding;
+    vi_state.vertexAttributeDescriptionCount = 1;
+    vi_state.pVertexAttributeDescriptions = &input_attrib;
+
+    CreatePipelineHelper pipe(*this);
+    pipe.shader_stages_[0] = vs.GetStageCreateInfo();
+    pipe.vi_ci_ = vi_state;
+    pipe.CreateGraphicsPipeline();
+
+    vkt::Buffer vbo(*m_device, 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    VkDeviceSize offset = 7;
+    vk::CmdBindVertexBuffers(m_command_buffer, 0, 1, &vbo.handle(), &offset);
+    vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
 TEST_F(PositiveVertexInput, ResetCmdSetVertexInput) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8523");
     AddRequiredExtensions(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8491
