### PR TITLE
layers: VK_VALVE_buffer_device_address_allocation_alignment

### DIFF
--- a/layers/chassis/dispatch_object.h
+++ b/layers/chassis/dispatch_object.h
@@ -128,6 +128,7 @@ struct DeviceExtensionProperties {
     VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props;
     VkPhysicalDeviceImageProcessing2PropertiesQCOM image_processing2_props;
     VkPhysicalDeviceShaderMultipleWaitQueuesPropertiesQCOM shader_multiple_wait_queues_props;
+    VkPhysicalDeviceBufferDeviceAddressAllocationAlignmentPropertiesVALVE buffer_device_address_allocation_alignment_props;
 };
 
 // This object holds all static state for the device (device properties, enabled extensions/features, etc.)

--- a/layers/chassis/dispatch_object_manual.cpp
+++ b/layers/chassis/dispatch_object_manual.cpp
@@ -511,6 +511,8 @@ StatelessDeviceData::StatelessDeviceData(DispatchInstance* instance, VkPhysicalD
                                              &phys_dev_ext_props.image_processing2_props);
     instance->GetPhysicalDeviceExtProperties(physical_device, extensions.vk_qcom_shader_multiple_wait_queues,
                                              &phys_dev_ext_props.shader_multiple_wait_queues_props);
+    instance->GetPhysicalDeviceExtProperties(physical_device, extensions.vk_valve_buffer_device_address_allocation_alignment,
+                                             &phys_dev_ext_props.buffer_device_address_allocation_alignment_props);
 
     // None of these "check if supported" features are possible without first having gpdp2 first
     if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {

--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -112,6 +112,7 @@ bool Device::manual_PreCallValidateCreateBuffer(VkDevice device, const VkBufferC
     skip |= ValidateCreateBufferFlags(pCreateInfo->flags, create_info_loc.dot(Field::flags));
     skip |= ValidateCreateBufferBufferDeviceAddress(*pCreateInfo, create_info_loc);
     skip |= ValidateCreateBufferTileMemory(*pCreateInfo, create_info_loc);
+    skip |= ValidateCreateBufferDeviceAddressAllocationAlignment(*pCreateInfo, create_info_loc);
 
     return skip;
 }
@@ -252,6 +253,76 @@ bool Device::ValidateCreateBufferBufferDeviceAddress(const VkBufferCreateInfo& c
                          "device feature is not enabled.");
     }
 
+    return skip;
+}
+
+bool Device::ValidateCreateBufferDeviceAddressAllocationAlignment(const VkBufferCreateInfo& create_info,
+                                                                  const Location& create_info_loc) const {
+    bool skip = false;
+
+    const auto* alignment_info = vku::FindStructInPNextChain<VkBufferDeviceAddressAlignmentAllocateInfoVALVE>(create_info.pNext);
+    if (!alignment_info) {
+        return skip;
+    }
+    const Location alignment_loc = create_info_loc.pNext(Struct::VkBufferDeviceAddressAlignmentAllocateInfoVALVE, Field::alignment);
+    skip |= ValidateBufferDeviceAddressAlignmentAllocateInfo(*alignment_info, alignment_loc);
+
+    if (alignment_info->alignment == 0) {
+        return skip;  // "If alignment is 0, this alignment request is ignored"
+    }
+
+    if ((create_info.flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) == 0) {
+        skip |= LogError("VUID-VkBufferCreateInfo-flags-12515", device, alignment_loc,
+                         "is %" PRIu32
+                         " (not zero), but VkBufferCreateInfo::flags (%s) does not include VK_BUFFER_CREATE_SPARSE_BINDING_BIT.",
+                         alignment_info->alignment, string_VkBufferCreateFlags(create_info.flags).c_str());
+    }
+
+    const auto* usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(create_info.pNext);
+    const VkBufferUsageFlags2 usage = usage_flags2 ? usage_flags2->usage : create_info.usage;
+    if ((usage & VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT) == 0) {
+        skip |=
+            LogError("VUID-VkBufferCreateInfo-alignment-12516", device, alignment_loc,
+                     "is %" PRIu32
+                     " (not zero), but the effective usage flags (%s) do not include VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT.",
+                     alignment_info->alignment, string_VkBufferUsageFlags2(usage).c_str());
+    }
+
+    if (const auto* opaque_addr_info = vku::FindStructInPNextChain<VkBufferOpaqueCaptureAddressCreateInfo>(create_info.pNext)) {
+        if (opaque_addr_info->opaqueCaptureAddress != 0) {
+            skip |= LogError("VUID-VkBufferCreateInfo-alignment-12517", device, alignment_loc,
+                             "is %" PRIu32 " (not zero), but VkBufferOpaqueCaptureAddressCreateInfo::opaqueCaptureAddress (%" PRIu64
+                             ") is not 0.",
+                             alignment_info->alignment, opaque_addr_info->opaqueCaptureAddress);
+        }
+    }
+
+    return skip;
+}
+
+bool Device::ValidateBufferDeviceAddressAlignmentAllocateInfo(const VkBufferDeviceAddressAlignmentAllocateInfoVALVE& alignment_info,
+                                                              const Location& alignment_loc) const {
+    bool skip = false;
+    if (alignment_info.alignment == 0) {
+        return skip;  // "If alignment is 0, this alignment request is ignored"
+    }
+    if (!IsPowerOfTwo(alignment_info.alignment)) {
+        skip |= LogError("VUID-VkBufferDeviceAddressAlignmentAllocateInfoVALVE-alignment-12512", device, alignment_loc,
+                         "(%" PRIu32 ") is not a power of two.", alignment_info.alignment);
+    }
+    if (!enabled_features.bufferDeviceAddressAllocationAlignment) {
+        skip |= LogError("VUID-VkBufferDeviceAddressAlignmentAllocateInfoVALVE-alignment-12513", device, alignment_loc,
+                         "is %" PRIu32 " (not zero), but the bufferDeviceAddressAllocationAlignment feature is not enabled.",
+                         alignment_info.alignment);
+    } else {
+        const uint32_t max_alignment =
+            phys_dev_ext_props.buffer_device_address_allocation_alignment_props.maxBufferDeviceAddressAllocationAlignment;
+        if (alignment_info.alignment > max_alignment) {
+            skip |= LogError("VUID-VkBufferDeviceAddressAlignmentAllocateInfoVALVE-alignment-12514", device, alignment_loc,
+                             "(%" PRIu32 ") is greater than maxBufferDeviceAddressAllocationAlignment (%" PRIu32 ").",
+                             alignment_info.alignment, max_alignment);
+        }
+    }
     return skip;
 }
 

--- a/layers/stateless/sl_device_memory.cpp
+++ b/layers/stateless/sl_device_memory.cpp
@@ -59,6 +59,32 @@ bool Device::manual_PreCallValidateAllocateMemory(VkDevice device, const VkMemor
                              "has VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT set, but bufferDeviceAddress feature is not enabled.");
         }
     }
+
+    if (const auto* alignment_info =
+            vku::FindStructInPNextChain<VkBufferDeviceAddressAlignmentAllocateInfoVALVE>(pAllocateInfo->pNext)) {
+        const Location alignment_loc =
+            allocate_info_loc.pNext(Struct::VkBufferDeviceAddressAlignmentAllocateInfoVALVE, Field::alignment);
+        skip |= ValidateBufferDeviceAddressAlignmentAllocateInfo(*alignment_info, alignment_loc);
+
+        if (alignment_info->alignment != 0) {
+            if ((flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT) == 0) {
+                skip |= LogError("VUID-VkMemoryAllocateInfo-flags-12510", device, alignment_loc,
+                                 "is %" PRIu32
+                                 " (not zero), but VkMemoryAllocateFlagsInfo::flags (%s) does not include "
+                                 "VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT.",
+                                 alignment_info->alignment, string_VkMemoryAllocateFlags(flags).c_str());
+            }
+            if (const auto* opaque_addr_info =
+                    vku::FindStructInPNextChain<VkMemoryOpaqueCaptureAddressAllocateInfo>(pAllocateInfo->pNext);
+                opaque_addr_info && opaque_addr_info->opaqueCaptureAddress != 0) {
+                skip |= LogError("VUID-VkMemoryAllocateInfo-alignment-12511", device, alignment_loc,
+                                 "is %" PRIu32
+                                 " (not zero), but VkMemoryOpaqueCaptureAddressAllocateInfo::opaqueCaptureAddress (%" PRIu64
+                                 ") is not 0.",
+                                 alignment_info->alignment, opaque_addr_info->opaqueCaptureAddress);
+            }
+        }
+    }
     return skip;
 }
 

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -659,6 +659,10 @@ class Device : public vvl::BaseDevice {
     bool ValidateCreateBufferFlags(const VkBufferCreateFlags flags, const Location &flag_loc) const;
     bool ValidateCreateBufferBufferDeviceAddress(const VkBufferCreateInfo &create_info, const Location &create_info_loc) const;
     bool ValidateCreateBufferTileMemory(const VkBufferCreateInfo &create_info, const Location &create_info_loc) const;
+    bool ValidateCreateBufferDeviceAddressAllocationAlignment(const VkBufferCreateInfo& create_info,
+                                                              const Location& create_info_loc) const;
+    bool ValidateBufferDeviceAddressAlignmentAllocateInfo(const VkBufferDeviceAddressAlignmentAllocateInfoVALVE& alignment_info,
+                                                          const Location& alignment_loc) const;
 
     bool ValidateDependencyInfo(const Context &context, const VkDependencyInfo &dep_info, const Location &loc) const;
     bool manual_PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo *pDependencyInfo,

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -993,3 +993,96 @@ TEST_F(NegativeBuffer, ZeroQueueFamilyIndexCountMaintenance11) {
     vkt::Buffer buffer(*m_device, buff_ci, vkt::no_mem);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeBuffer, BufferDeviceAddressAllocationAlignmentFeature) {
+    AddRequiredExtensions(VK_VALVE_BUFFER_DEVICE_ADDRESS_ALLOCATION_ALIGNMENT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::sparseBinding);
+    RETURN_IF_SKIP(Init());
+
+    VkBufferDeviceAddressAlignmentAllocateInfoVALVE alignment_info = vku::InitStructHelper();
+    alignment_info.alignment = 4;
+
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&alignment_info);
+    buffer_ci.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
+    buffer_ci.size = 4096;
+    buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    CreateBufferTest(buffer_ci, "VUID-VkBufferDeviceAddressAlignmentAllocateInfoVALVE-alignment-12513");
+}
+
+TEST_F(NegativeBuffer, BufferDeviceAddressAllocationAlignmentLimit) {
+    AddRequiredExtensions(VK_VALVE_BUFFER_DEVICE_ADDRESS_ALLOCATION_ALIGNMENT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddressAllocationAlignment);
+    AddRequiredFeature(vkt::Feature::sparseBinding);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceBufferDeviceAddressAllocationAlignmentPropertiesVALVE alignment_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&alignment_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+    if (alignment_props.maxBufferDeviceAddressAllocationAlignment >= (UINT32_MAX / 2)) {
+        GTEST_SKIP() << "maxBufferDeviceAddressAllocationAlignment is too large to safely exceed with a uint32_t";
+    }
+
+    VkBufferDeviceAddressAlignmentAllocateInfoVALVE alignment_info = vku::InitStructHelper();
+    alignment_info.alignment = alignment_props.maxBufferDeviceAddressAllocationAlignment * 2;
+
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&alignment_info);
+    buffer_ci.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
+    buffer_ci.size = 4096;
+    buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    CreateBufferTest(buffer_ci, "VUID-VkBufferDeviceAddressAlignmentAllocateInfoVALVE-alignment-12514");
+}
+
+TEST_F(NegativeBuffer, BufferDeviceAddressAllocationAlignment) {
+    AddRequiredExtensions(VK_VALVE_BUFFER_DEVICE_ADDRESS_ALLOCATION_ALIGNMENT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddressAllocationAlignment);
+    AddRequiredFeature(vkt::Feature::sparseBinding);
+    RETURN_IF_SKIP(Init());
+
+    VkBufferDeviceAddressAlignmentAllocateInfoVALVE alignment_info = vku::InitStructHelper();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&alignment_info);
+
+    {
+        alignment_info.alignment = 3;
+        buffer_ci.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
+        buffer_ci.size = 4096;
+        buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+        CreateBufferTest(buffer_ci, "VUID-VkBufferDeviceAddressAlignmentAllocateInfoVALVE-alignment-12512");
+    }
+    {
+        alignment_info.alignment = 4;
+        buffer_ci.flags = 0;
+        buffer_ci.size = 4096;
+        buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+        CreateBufferTest(buffer_ci, "VUID-VkBufferCreateInfo-flags-12515");
+    }
+    {
+        alignment_info.alignment = 4;
+        buffer_ci.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
+        buffer_ci.size = 4096;
+        buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+        CreateBufferTest(buffer_ci, "VUID-VkBufferCreateInfo-alignment-12516");
+    }
+}
+
+TEST_F(NegativeBuffer, BufferDeviceAddressAllocationAlignmentCapture) {
+    AddRequiredExtensions(VK_VALVE_BUFFER_DEVICE_ADDRESS_ALLOCATION_ALIGNMENT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddressAllocationAlignment);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddressCaptureReplay);
+    AddRequiredFeature(vkt::Feature::sparseBinding);
+    RETURN_IF_SKIP(Init());
+
+    VkBufferOpaqueCaptureAddressCreateInfo opaque_addr_info = vku::InitStructHelper();
+    opaque_addr_info.opaqueCaptureAddress = 1024;
+    VkBufferDeviceAddressAlignmentAllocateInfoVALVE alignment_info = vku::InitStructHelper(&opaque_addr_info);
+    alignment_info.alignment = 4;
+
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&alignment_info);
+    buffer_ci.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT | VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT;
+    buffer_ci.size = 4096;
+    buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    CreateBufferTest(buffer_ci, "VUID-VkBufferCreateInfo-alignment-12517");
+}

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -2321,6 +2321,54 @@ TEST_F(NegativeMemory, BufferDeviceAddressKHRDisabled) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeMemory, BufferDeviceAddressAllocationAlignment) {
+    AddRequiredExtensions(VK_VALVE_BUFFER_DEVICE_ADDRESS_ALLOCATION_ALIGNMENT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddressAllocationAlignment);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddressCaptureReplay);
+    RETURN_IF_SKIP(Init());
+
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
+    buffer_create_info.size = 4096;
+    buffer_create_info.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
+
+    VkMemoryRequirements buffer_mem_reqs = {};
+    vk::GetBufferMemoryRequirements(device(), buffer, &buffer_mem_reqs);
+
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    {
+        VkBufferDeviceAddressAlignmentAllocateInfoVALVE alignment_info = vku::InitStructHelper();
+        alignment_info.alignment = 4;
+
+        VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alignment_info);
+        alloc_info.allocationSize = buffer_mem_reqs.size;
+        m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &alloc_info, 0);
+
+        m_errorMonitor->SetDesiredError("VUID-VkMemoryAllocateInfo-flags-12510");
+        vk::AllocateMemory(device(), &alloc_info, NULL, &memory);
+        m_errorMonitor->VerifyFound();
+    }
+    {
+        VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
+        alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT | VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT;
+
+        VkMemoryOpaqueCaptureAddressAllocateInfo opaque_addr_info = vku::InitStructHelper(&alloc_flags);
+        opaque_addr_info.opaqueCaptureAddress = 1024;
+
+        VkBufferDeviceAddressAlignmentAllocateInfoVALVE alignment_info = vku::InitStructHelper(&opaque_addr_info);
+        alignment_info.alignment = 4;
+
+        VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alignment_info);
+        alloc_info.allocationSize = buffer_mem_reqs.size;
+        m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &alloc_info, 0);
+
+        m_errorMonitor->SetDesiredError("VUID-VkMemoryAllocateInfo-alignment-12511");
+        vk::AllocateMemory(device(), &alloc_info, NULL, &memory);
+        m_errorMonitor->VerifyFound();
+    }
+}
+
 TEST_F(NegativeMemory, MemoryType) {
     // Attempts to allocate from a memory type that doesn't exist
 

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -777,3 +777,40 @@ TEST_F(PositiveMemory, ZeroInitializeDeviceMemory) {
     vkt::DeviceMemory memory(*m_device, alloc_info);
     vk::BindImageMemory(device(), image, memory, 0);
 }
+
+TEST_F(PositiveMemory, BufferDeviceAddressAllocationAlignment) {
+    AddRequiredExtensions(VK_VALVE_BUFFER_DEVICE_ADDRESS_ALLOCATION_ALIGNMENT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddressAllocationAlignment);
+    AddRequiredFeature(vkt::Feature::sparseBinding);
+    RETURN_IF_SKIP(Init());
+
+    VkBufferDeviceAddressAlignmentAllocateInfoVALVE alignment_info = vku::InitStructHelper();
+    alignment_info.alignment = 4;
+
+    {
+        VkBufferCreateInfo sparse_buffer_ci = vku::InitStructHelper(&alignment_info);
+        sparse_buffer_ci.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
+        sparse_buffer_ci.size = 4096;
+        sparse_buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+        vkt::Buffer sparse_buffer(*m_device, sparse_buffer_ci, vkt::no_mem);
+    }
+
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
+    buffer_create_info.size = 4096;
+    buffer_create_info.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
+
+    VkMemoryRequirements buffer_mem_reqs = {};
+    vk::GetBufferMemoryRequirements(device(), buffer, &buffer_mem_reqs);
+
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper(&alignment_info);
+    alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
+    alloc_info.allocationSize = buffer_mem_reqs.size;
+    m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &alloc_info, 0);
+
+    vkt::DeviceMemory memory(*m_device, alloc_info);
+    vk::BindBufferMemory(device(), buffer, memory, 0);
+}


### PR DESCRIPTION
adds

- VUID-VkMemoryAllocateInfo-flags-12510
- VUID-VkMemoryAllocateInfo-alignment-12511
- VUID-VkBufferDeviceAddressAlignmentAllocateInfoVALVE-alignment-12512
- VUID-VkBufferDeviceAddressAlignmentAllocateInfoVALVE-alignment-12513
- VUID-VkBufferDeviceAddressAlignmentAllocateInfoVALVE-alignment-12514
- VUID-VkBufferCreateInfo-flags-12515
- VUID-VkBufferCreateInfo-alignment-12516
- VUID-VkBufferCreateInfo-alignment-12517