### PR TITLE
layers: Only save VkRenderingInfo for suspend

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -974,7 +974,12 @@ void CommandBuffer::RecordBeginRendering(const VkRenderingInfo& rendering_info, 
         first_rendering_info = &rendering_info;
         first_rendering_info_loc = std::make_unique<LocationCapture>(loc.dot(vvl::Field::pRenderingInfo));
     }
-    last_rendering_info = &rendering_info;
+
+    if (rendering_info.flags & VK_RENDERING_SUSPENDING_BIT) {
+        last_rendering_info = &rendering_info;
+    } else {
+        last_rendering_info.emplace();  // cheaper than a deep copy
+    }
 
     has_render_pass_instance = true;
 

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -429,6 +429,8 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     // Rendering info from the first/last vkCmdBeginRendering.
     std::optional<vku::safe_VkRenderingInfo> first_rendering_info;
     std::unique_ptr<LocationCapture> first_rendering_info_loc;
+    // The optional means "vkCmdBeginRendering was called at least once (so far)"
+    // The struct content is only used for Suspend/Resume
     std::optional<vku::safe_VkRenderingInfo> last_rendering_info;
 
     // This is null if we are outside a renderPass/rendering

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -2307,3 +2307,30 @@ TEST_F(PositiveDynamicRendering, RenderAreaMipLevelMultipleLevels) {
 
     m_command_buffer.End();
 }
+
+TEST_F(PositiveDynamicRendering, ResumeAfterUnrelatedFinishedInstance) {
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    VkRenderingInfo suspend_info = vku::InitStructHelper();
+    suspend_info.flags = VK_RENDERING_SUSPENDING_BIT;
+    suspend_info.layerCount = 1;
+    suspend_info.renderArea = {{0, 0}, {1, 1}};
+
+    VkRenderingInfo resume_info = suspend_info;
+    resume_info.flags = VK_RENDERING_RESUMING_BIT;
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(suspend_info);
+    m_command_buffer.EndRendering();
+    m_command_buffer.BeginRendering(resume_info);
+    m_command_buffer.EndRendering();
+
+    // Nothing is suspended at this point.
+    VkRenderingInfo unrelated_info = vku::InitStructHelper();
+    unrelated_info.flags = VK_RENDERING_RESUMING_BIT;
+    unrelated_info.layerCount = 1;
+    unrelated_info.renderArea = {{0, 0}, {4, 4}};
+    m_command_buffer.BeginRendering(unrelated_info);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
no reason to do full `safe_VkRenderingInfo` copy vkCmdBeginRendering (which happens a lot) and instead just mark the optional

... honestly the whole resume/suspend stuff is a bit wonky IMO