### PR TITLE
sync: Add ShaderAccessCommand

### DIFF
--- a/layers/containers/container_utils.h
+++ b/layers/containers/container_utils.h
@@ -17,6 +17,7 @@
  */
 
 #pragma once
+#include "containers/span.h"
 #include <algorithm>
 #include <memory>
 #include <vector>
@@ -84,6 +85,11 @@ const Value &FindExisting(const Container &container, const Key &key) {
 
 template <typename T>
 void Append(std::vector<T> &dst, const std::vector<T> &src) {
+    dst.insert(dst.end(), src.begin(), src.end());
+}
+
+template <typename T>
+void Append(std::vector<T>& dst, vvl::span<const T> src) {
     dst.insert(dst.end(), src.begin(), src.end());
 }
 

--- a/layers/sync/sync_command.cpp
+++ b/layers/sync/sync_command.cpp
@@ -22,6 +22,7 @@
 #include "sync/sync_validation.h"
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/image_state.h"
+#include "state_tracker/pipeline_state.h"
 #include "state_tracker/render_pass_state.h"
 #include "utils/image_utils.h"
 
@@ -103,6 +104,20 @@ uint32_t CommandData::AddRenderPass(const vvl::RenderPass& render_pass) {
     const uint32_t index = uint32_t(render_passes.size());
     render_passes.emplace_back(std::static_pointer_cast<const vvl::RenderPass>(render_pass.shared_from_this()));
     return index;
+}
+
+void CommandData::AddImageView(const vvl::ImageView& image_view) {
+    image_views.emplace_back(std::static_pointer_cast<const vvl::ImageView>(image_view.shared_from_this()));
+}
+
+void CommandData::AddPipeline(const vvl::Pipeline& pipeline) {
+    pipelines.emplace_back(std::static_pointer_cast<const vvl::Pipeline>(pipeline.shared_from_this()));
+}
+
+void CommandData::AddDescriptorSet(const vvl::DescriptorSet& descriptor_set) {
+    if (descriptor_set_lookup.insert(&descriptor_set).second) {
+        descriptor_sets.emplace_back(std::static_pointer_cast<const vvl::DescriptorSet>(descriptor_set.shared_from_this()));
+    }
 }
 
 BufferCopyCommand BufferCopyCommand::Storage::MakeCommand(const CommandData& command_data) const {
@@ -394,6 +409,130 @@ void EndRenderPassCommand::Apply(SyncEnvironment& env, ResourceUsageTag tag, Ren
     const ResourceUsageTag store_tag = tag;
     const ResourceUsageTag transition_tag = tag + 1;
     rp_context.RecordEndRenderPass(external_context, store_tag, transition_tag, env.queue_id);
+}
+
+ShaderAccessCommand ShaderAccessCommand::Storage::MakeCommand(const CommandData& command_data) const {
+    vvl::span<const BufferAccess> buffer_accesses;
+    if (buffer_access_count != 0) {
+        buffer_accesses = vvl::make_span(&command_data.descriptor_buffer_accesses[first_buffer_access], buffer_access_count);
+    }
+    vvl::span<const ImageViewAccess> image_accesses;
+    if (image_access_count != 0) {
+        image_accesses = vvl::make_span(&command_data.descriptor_image_accesses[first_image_access], image_access_count);
+    }
+    return {pipeline, buffer_accesses, image_accesses, render_pass_instance_id, subpass};
+}
+
+ShaderAccessCommand::Storage ShaderAccessCommand::MakeStorage(CommandData& command_data) const {
+    if (pipeline) {
+        command_data.AddPipeline(*pipeline);
+    }
+    for (const BufferAccess& access : buffer_accesses) {
+        command_data.AddBuffer(*access.buffer);
+        command_data.AddDescriptorSet(*access.info.descriptor_set);
+    }
+    for (const ImageViewAccess& access : image_accesses) {
+        command_data.AddImageView(*access.image_view);
+        command_data.AddDescriptorSet(*access.info.descriptor_set);
+    }
+
+    const uint32_t first_buffer_access = uint32_t(command_data.descriptor_buffer_accesses.size());
+    const uint32_t buffer_access_count = uint32_t(buffer_accesses.size());
+    vvl::Append(command_data.descriptor_buffer_accesses, buffer_accesses);
+
+    const uint32_t first_image_access = uint32_t(command_data.descriptor_image_accesses.size());
+    const uint32_t image_access_count = uint32_t(image_accesses.size());
+    vvl::Append(command_data.descriptor_image_accesses, image_accesses);
+
+    return {pipeline, first_buffer_access, buffer_access_count, first_image_access, image_access_count, render_pass_instance_id,
+            subpass};
+}
+
+bool ShaderAccessCommand::Validate(const CommandBufferContext& cb_context, const Location& loc) const {
+    return Validate(cb_context.GetSyncEnvironment(), cb_context.GetCurrentAccessContext(), cb_context, kInvalidTag, loc);
+}
+
+bool ShaderAccessCommand::Validate(const SyncEnvironment& env, const AccessContext& access_context,
+                                  const CommandBufferContext& cb_context, ResourceUsageTag replay_tag, const Location& loc) const {
+    bool skip = false;
+    const SyncValidator& validator = env.validator;
+    const AttachmentAccess attachment_access{AttachmentAccessType::Access, SyncOrdering::kRaster, render_pass_instance_id, subpass};
+
+    auto validate_access = [&](const auto& value) {
+        using AccessType = std::decay_t<decltype(value)>;
+        HazardResult hazard;
+        if constexpr (std::is_same_v<AccessType, BufferAccess>) {
+            hazard = access_context.DetectHazard(*value.buffer, value.access_index, value.range);
+        } else {
+            if (value.access_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ) {
+                ImageRangeGen range_gen = MakeImageRangeGen(*value.image_view, value.offset, value.extent);
+                hazard = access_context.DetectAttachmentHazard(range_gen, value.access_index, attachment_access, env.queue_id);
+            } else {
+                hazard = access_context.DetectHazard(*value.image_view, value.access_index);
+            }
+        }
+        if (!hazard.IsHazard()) {
+            return;
+        }
+        const DescriptorInfo& info = value.info;
+        VulkanTypedHandle object_handle = info.resource_handle;
+        if constexpr (std::is_same_v<AccessType, BufferAccess>) {
+            if (info.resource_handle.type == kVulkanObjectTypeAccelerationStructureKHR) {
+                object_handle = value.buffer->Handle();
+            }
+        }
+        LogObjectList objlist = BaseObjectList(env, cb_context, object_handle);
+        objlist.add(pipeline->Handle());
+        std::string resource_description = validator.FormatHandle(info.resource_handle);
+        if constexpr (std::is_same_v<AccessType, ImageViewAccess>) {
+            if (replay_tag != kInvalidTag && value.image_view->image_state) {
+                resource_description += " (" + validator.FormatHandle(value.image_view->image_state->Handle()) + ")";
+            }
+        }
+        std::string error;
+        if constexpr (std::is_same_v<AccessType, ImageViewAccess>) {
+            error = validator.error_messages_.ImageDescriptorError(
+                env, hazard, cb_context, replay_tag, loc, resource_description, *pipeline, info.set, *info.descriptor_set,
+                info.descriptor_type, info.binding, info.array_element, info.stage, value.image_layout);
+        } else {
+            if (info.resource_handle.type == kVulkanObjectTypeAccelerationStructureKHR) {
+                error = validator.error_messages_.AccelerationStructureDescriptorError(
+                    env, hazard, cb_context, replay_tag, loc, resource_description, *pipeline, info.set, *info.descriptor_set,
+                    info.descriptor_type, info.binding, info.array_element, info.stage);
+            } else {
+                error = validator.error_messages_.BufferDescriptorError(
+                    env, hazard, cb_context, replay_tag, loc, resource_description, *pipeline, info.set, *info.descriptor_set,
+                    info.descriptor_type, info.binding, info.array_element, info.stage);
+            }
+        }
+        skip |= validator.SyncError(hazard.Hazard(), objlist, loc, error);
+    };
+
+    for (const BufferAccess& access : buffer_accesses) {
+        validate_access(access);
+    }
+    for (const ImageViewAccess& access : image_accesses) {
+        validate_access(access);
+    }
+    return skip;
+}
+
+void ShaderAccessCommand::Apply(SyncEnvironment& env, ResourceUsageTag tag, AccessContext& access_context) const {
+    const AttachmentAccess attachment_access{AttachmentAccessType::Access, SyncOrdering::kRaster, render_pass_instance_id, subpass};
+    for (const BufferAccess& access : buffer_accesses) {
+        const ResourceUsageTagEx tag_ex{tag, access.handle_index};
+        access_context.UpdateAccessState(*access.buffer, access.access_index, access.range, tag_ex, 0, env.queue_id);
+    }
+    for (const ImageViewAccess& access : image_accesses) {
+        const ResourceUsageTagEx tag_ex{tag, access.handle_index};
+        if (access.access_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ) {
+            ImageRangeGen range_gen = MakeImageRangeGen(*access.image_view, access.offset, access.extent);
+            access_context.UpdateAttachmentAccessState(range_gen, access.access_index, attachment_access, tag_ex, env.queue_id);
+        } else {
+            ImageRangeGen range_gen = MakeImageRangeGen(*access.image_view);
+            access_context.UpdateAccessState(range_gen, access.access_index, tag_ex, 0, env.queue_id);
+        }
+    }
 }
 
 }  // namespace syncval

--- a/layers/sync/sync_command.h
+++ b/layers/sync/sync_command.h
@@ -18,15 +18,19 @@
 #pragma once
 
 #include "sync_barrier.h"
+#include "containers/custom_containers.h"
 #include "containers/span.h"
+#include "generated/vk_object_types.h"
 
 struct Location;
 struct VulkanTypedHandle;
 
 namespace vvl {
 class Buffer;
+class DescriptorSet;
 class Image;
 class ImageView;
+class Pipeline;
 class RenderPass;
 enum class Func;
 }  // namespace vvl
@@ -158,21 +162,82 @@ struct EndRenderPassCommand {
                AccessContext& external_context) const;
 };
 
-using CommandStorage = std::variant<BufferCopyCommand::Storage, ImageCopyCommand::Storage, BarrierCommand::Storage,
-                                    BeginRenderPassCommand::Storage, NextSubpassCommand::Storage, EndRenderPassCommand::Storage>;
+struct ShaderAccessCommand {
+    struct DescriptorInfo {
+        const vvl::DescriptorSet* descriptor_set;
+        VkDescriptorType descriptor_type;
+        uint32_t set;
+        uint32_t binding;
+        uint32_t array_element;
+        VkShaderStageFlagBits stage;
+        VulkanTypedHandle resource_handle;
+    };
+    struct BufferAccess {
+        DescriptorInfo info;
+        const vvl::Buffer* buffer;
+        AccessRange range;
+        SyncAccessIndex access_index;
+        uint32_t handle_index = vvl::kNoIndex32;
+    };
+    struct ImageViewAccess {
+        DescriptorInfo info;
+        const vvl::ImageView* image_view;
+        VkImageLayout image_layout;
+        SyncAccessIndex access_index;
+        uint32_t handle_index = vvl::kNoIndex32;
+        // Input attachments use the render area and render-pass attachment ordering
+        VkOffset3D offset{};
+        VkExtent3D extent{};
+    };
+
+    const vvl::Pipeline* pipeline = nullptr;
+    vvl::span<const BufferAccess> buffer_accesses;
+    vvl::span<const ImageViewAccess> image_accesses;
+    uint32_t render_pass_instance_id = vvl::kNoIndex32;
+    uint32_t subpass = vvl::kNoIndex32;
+
+    struct Storage {
+        const vvl::Pipeline* pipeline;
+        uint32_t first_buffer_access;
+        uint32_t buffer_access_count;
+        uint32_t first_image_access;
+        uint32_t image_access_count;
+        uint32_t render_pass_instance_id;
+        uint32_t subpass;
+        ShaderAccessCommand MakeCommand(const CommandData& command_data) const;
+    };
+    Storage MakeStorage(CommandData& command_data) const;
+    bool Validate(const CommandBufferContext& cb_context, const Location& loc) const;
+    bool Validate(const SyncEnvironment& env, const AccessContext& access_context, const CommandBufferContext& cb_context,
+                  ResourceUsageTag replay_tag, const Location& loc) const;
+    void Apply(SyncEnvironment& env, ResourceUsageTag tag, AccessContext& access_context) const;
+};
+
+using CommandStorage =
+    std::variant<BufferCopyCommand::Storage, ImageCopyCommand::Storage, BarrierCommand::Storage, BeginRenderPassCommand::Storage,
+                 NextSubpassCommand::Storage, EndRenderPassCommand::Storage, ShaderAccessCommand::Storage>;
 
 struct CommandData {
     std::vector<std::shared_ptr<const vvl::Buffer>> buffers;
     std::vector<std::shared_ptr<const vvl::Image>> images;
     std::vector<std::shared_ptr<const vvl::ImageView>> image_views;
     std::vector<std::shared_ptr<const vvl::RenderPass>> render_passes;
+    std::vector<std::shared_ptr<const vvl::Pipeline>> pipelines;
     std::vector<BufferCopyRegion> buffer_copy_regions;
     std::vector<VkImageCopy> image_copy_regions;
     std::vector<BarrierSet> barrier_sets;
+    std::vector<ShaderAccessCommand::BufferAccess> descriptor_buffer_accesses;
+    std::vector<ShaderAccessCommand::ImageViewAccess> descriptor_image_accesses;
+
+    std::vector<std::shared_ptr<const vvl::DescriptorSet>> descriptor_sets;
+    vvl::unordered_set<const vvl::DescriptorSet*> descriptor_set_lookup;
 
     uint32_t AddBuffer(const vvl::Buffer& buffer);
     uint32_t AddImage(const vvl::Image& image);
     uint32_t AddRenderPass(const vvl::RenderPass& render_pass);
+    void AddImageView(const vvl::ImageView& image_view);
+    void AddPipeline(const vvl::Pipeline& pipeline);
+    void AddDescriptorSet(const vvl::DescriptorSet& descriptor_set);
 };
 
 // TODO: CommandEntry won't be needed after all commands are introduced.

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -34,6 +34,11 @@
 #include "utils/math_utils.h"
 #include "utils/text_utils.h"
 
+using vvl::BufferDescriptor;
+using vvl::DescriptorClass;
+using vvl::ImageDescriptor;
+using vvl::TexelDescriptor;
+
 namespace syncval {
 
 constexpr VkImageAspectFlags kColorAspects =
@@ -609,9 +614,9 @@ bool CommandBufferContext::ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint
                         if (hazard.IsHazard()) {
                             LogObjectList objlist(cb_state_->Handle(), img_view_state->Handle(), pipe->Handle());
                             const auto error = error_messages_.ImageDescriptorError(
-                                hazard, *this, loc.function, sync_state_.FormatHandle(*img_view_state), *pipe,
-                                variable.decorations.set, *descriptor_set, descriptor_type, variable.decorations.binding, index,
-                                stage_state.GetStage(), image_layout);
+                                GetSyncEnvironment(), hazard, *this, kInvalidTag, loc, sync_state_.FormatHandle(*img_view_state),
+                                *pipe, variable.decorations.set, *descriptor_set, descriptor_type, variable.decorations.binding,
+                                index, stage_state.GetStage(), image_layout);
                             skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc, error);
                         }
                         break;
@@ -628,9 +633,9 @@ bool CommandBufferContext::ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint
                         if (hazard.IsHazard()) {
                             LogObjectList objlist(cb_state_->Handle(), buf_view_state->Handle(), pipe->Handle());
                             const auto error = error_messages_.BufferDescriptorError(
-                                hazard, *this, loc.function, sync_state_.FormatHandle(*buf_view_state), *pipe,
-                                variable.decorations.set, *descriptor_set, descriptor_type, variable.decorations.binding, index,
-                                stage_state.GetStage());
+                                GetSyncEnvironment(), hazard, *this, kInvalidTag, loc, sync_state_.FormatHandle(*buf_view_state),
+                                *pipe, variable.decorations.set, *descriptor_set, descriptor_type, variable.decorations.binding,
+                                index, stage_state.GetStage());
                             skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc, error);
                         }
                         break;
@@ -655,8 +660,9 @@ bool CommandBufferContext::ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint
                         if (hazard.IsHazard()) {
                             LogObjectList objlist(cb_state_->Handle(), buf_state->Handle(), pipe->Handle());
                             const auto error = error_messages_.BufferDescriptorError(
-                                hazard, *this, loc.function, sync_state_.FormatHandle(*buf_state), *pipe, variable.decorations.set,
-                                *descriptor_set, descriptor_type, variable.decorations.binding, index, stage_state.GetStage());
+                                GetSyncEnvironment(), hazard, *this, kInvalidTag, loc, sync_state_.FormatHandle(*buf_state), *pipe,
+                                variable.decorations.set, *descriptor_set, descriptor_type, variable.decorations.binding, index,
+                                stage_state.GetStage());
                             skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc, error);
                         }
                         break;
@@ -677,8 +683,9 @@ bool CommandBufferContext::ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint
                                 LogObjectList objlist(cb_state_->Handle(), as_buffer.state->Handle(), pipe->Handle());
                                 const std::string resource_description = sync_state_.FormatHandle(accel->Handle());
                                 const std::string error = error_messages_.AccelerationStructureDescriptorError(
-                                    hazard, *this, loc.function, resource_description, *pipe, variable.decorations.set,
-                                    *descriptor_set, descriptor_type, variable.decorations.binding, index, stage_state.GetStage());
+                                    GetSyncEnvironment(), hazard, *this, kInvalidTag, loc, resource_description, *pipe,
+                                    variable.decorations.set, *descriptor_set, descriptor_type, variable.decorations.binding, index,
+                                    stage_state.GetStage());
                                 skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc, error);
                             }
                         }
@@ -822,6 +829,177 @@ void CommandBufferContext::RecordDispatchDrawDescriptorSet(VkPipelineBindPoint p
                 }
             }
         }
+    }
+}
+
+CommandBufferContext::DescriptorAccesses CommandBufferContext::CollectDescriptorAccesses(
+    VkPipelineBindPoint pipelineBindPoint) const {
+    DescriptorAccesses result;
+    if (!sync_state_.syncval_settings.shader_accesses_heuristic) return result;
+
+    const auto& last_bound_state = cb_state_->lastBound[ConvertToVvlBindPoint(pipelineBindPoint)];
+    const vvl::Pipeline* pipeline = last_bound_state.pipeline_state;
+    const std::vector<LastBound::DescriptorSetSlot>& ds_slots = last_bound_state.ds_slots;
+    if (!pipeline) {
+        return result;
+    }
+    result.pipeline = pipeline;
+    result.render_pass_instance_id = current_render_pass_instance_id_;
+    result.subpass = current_renderpass_context_ ? current_renderpass_context_->GetCurrentSubpass() : vvl::kNoIndex32;
+
+    for (const auto& stage_state : pipeline->stage_states) {
+        if ((stage_state.GetStage() == VK_SHADER_STAGE_FRAGMENT_BIT && pipeline->RasterizationDisabled()) ||
+            !stage_state.HasSpirv()) {
+            continue;
+        }
+        for (const auto& variable : stage_state.entrypoint->resource_interface_variables) {
+            if (variable.decorations.set >= ds_slots.size()) {
+                continue;  // [core validation error]
+            }
+            const auto& ds_slot = ds_slots[variable.decorations.set];
+            const auto* descriptor_set = ds_slot.ds_state.get();
+            if (!descriptor_set) {
+                continue;
+            }
+            const auto binding = descriptor_set->GetBinding(variable.decorations.binding);
+            if (!binding) {
+                continue;
+            }
+            // Validation based on static analysis of descriptors can produce false-positives.
+            // This workaround disables validation for the descriptor array case.
+            if (binding->count > 1) {
+                continue;
+            }
+            const VkDescriptorType descriptor_type = binding->type;
+            const VkShaderStageFlagBits stage_flag = stage_state.GetStage();
+            const SyncAccessIndex sync_index = GetSyncStageAccessIndexsByDescriptorSet(descriptor_type, variable, stage_flag);
+            if (sync_index == SYNC_ACCESS_INDEX_NONE) {
+                continue;
+            }
+            auto make_descriptor_info = [&](const VulkanTypedHandle& resource_handle, uint32_t index) {
+                ShaderAccessCommand::DescriptorInfo info;
+                info.descriptor_set = descriptor_set;
+                info.resource_handle = resource_handle;
+                info.set = variable.decorations.set;
+                info.descriptor_type = descriptor_type;
+                info.binding = variable.decorations.binding;
+                info.array_element = index;
+                info.stage = stage_flag;
+                return info;
+            };
+            for (uint32_t index = 0; index < binding->count; index++) {
+                const auto* descriptor = binding->GetDescriptor(index);
+                switch (descriptor->GetClass()) {
+                    case DescriptorClass::ImageSampler:
+                    case DescriptorClass::Image: {
+                        // ImageSamplerDescriptor inherits from ImageDescriptor, so this cast works for both types
+                        const auto* image_descriptor = static_cast<const ImageDescriptor*>(descriptor);
+                        if (image_descriptor->Invalid()) {
+                            continue;
+                        }
+                        const auto* image_view = image_descriptor->GetImageViewState();
+                        if (image_view->is_depth_sliced) {
+                            // NOTE: 2D ImageViews of VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT Images are not allowed in
+                            // Descriptors, unless VK_EXT_image_2d_view_of_3d is supported, which it isn't at the moment.
+                            // See: VUID 00343
+                            continue;
+                        }
+                        ShaderAccessCommand::ImageViewAccess access;
+                        access.info = make_descriptor_info(image_view->Handle(), index);
+                        access.image_view = image_view;
+                        access.image_layout = image_descriptor->GetImageLayout();
+                        access.access_index = sync_index;
+                        if (sync_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ) {
+                            access.offset = CastTo3D(cb_state_->render_area.offset);
+                            access.extent = CastTo3D(cb_state_->render_area.extent);
+                        }
+                        result.image_accesses.emplace_back(std::move(access));
+                        break;
+                    }
+                    case DescriptorClass::TexelBuffer: {
+                        const auto* texel_descriptor = static_cast<const TexelDescriptor*>(descriptor);
+                        if (texel_descriptor->Invalid()) {
+                            continue;
+                        }
+                        const auto* buffer_view = texel_descriptor->GetBufferViewState();
+                        const auto* buffer = buffer_view->buffer_state.get();
+                        ShaderAccessCommand::BufferAccess access;
+                        access.info = make_descriptor_info(buffer_view->Handle(), index);
+                        access.buffer = buffer;
+                        access.range = MakeRange(*buffer_view);
+                        access.access_index = sync_index;
+                        result.buffer_accesses.emplace_back(std::move(access));
+                        break;
+                    }
+                    case DescriptorClass::GeneralBuffer: {
+                        const auto* buffer_descriptor = static_cast<const BufferDescriptor*>(descriptor);
+                        if (buffer_descriptor->Invalid()) {
+                            continue;
+                        }
+                        VkDeviceSize offset = buffer_descriptor->GetOffset();
+                        if (vvl::IsDynamicDescriptor(descriptor_type)) {
+                            const uint32_t dynamic_offset_index =
+                                descriptor_set->GetDynamicOffsetIndexFromBinding(binding->binding);
+                            if (dynamic_offset_index >= ds_slot.dynamic_offsets.size()) {
+                                continue;  // [core validation error]
+                            }
+                            offset += ds_slot.dynamic_offsets[dynamic_offset_index];
+                        }
+                        const auto* buffer = buffer_descriptor->GetBufferState();
+                        ShaderAccessCommand::BufferAccess access;
+                        access.info = make_descriptor_info(buffer->Handle(), index);
+                        access.buffer = buffer;
+                        access.range = MakeRange(*buffer, offset, buffer_descriptor->GetRange());
+                        access.access_index = sync_index;
+                        result.buffer_accesses.emplace_back(std::move(access));
+                        break;
+                    }
+                    case DescriptorClass::AccelerationStructure: {
+                        const auto* accel_descriptor = static_cast<const vvl::AccelerationStructureDescriptor*>(descriptor);
+                        if (accel_descriptor->Invalid()) {
+                            continue;
+                        }
+                        const auto* acceleration_structure = accel_descriptor->GetAccelerationStructureStateKHR();
+                        if (!acceleration_structure) {
+                            continue;
+                        }
+                        const vvl::BufferAndOffset as_buffer = acceleration_structure->GetFirstValidBuffer(cb_state_->dev_data);
+                        if (!as_buffer) {
+                            continue;
+                        }
+                        ShaderAccessCommand::BufferAccess access;
+                        access.info = make_descriptor_info(acceleration_structure->Handle(), index);
+                        access.buffer = as_buffer.state;
+                        access.range = MakeRange(*as_buffer.state, as_buffer.offset, acceleration_structure->GetSize());
+                        access.access_index = sync_index;
+                        result.buffer_accesses.emplace_back(std::move(access));
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+void CommandBufferContext::RecordShaderAccesses(ResourceUsageTag tag, DescriptorAccesses& descriptor_accesses) {
+    for (auto& access : descriptor_accesses.buffer_accesses) {
+        access.handle_index = AddCommandHandle(tag, access.info.resource_handle).handle_index;
+    }
+    for (auto& access : descriptor_accesses.image_accesses) {
+        access.handle_index = AddCommandHandle(tag, access.image_view->image_state->Handle()).handle_index;
+    }
+    const ShaderAccessCommand command{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses,
+                                      descriptor_accesses.image_accesses, descriptor_accesses.render_pass_instance_id,
+                                      descriptor_accesses.subpass};
+    const auto& settings = sync_state_.syncval_settings;
+    if (settings.IsRecordTimeValidationEnabled()) {
+        command.Apply(GetSyncEnvironment(), tag, GetCurrentAccessContext());
+    }
+    if (settings.full_validation) {
+        StoreCommand(tag, command);
     }
 }
 

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -219,6 +219,17 @@ class CommandBufferContext final : public ResourceUsageInfoProvider, public Debu
     void RecordEndRendering(const RecordObject& record_obj);
     bool ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, const Location& loc) const;
     void RecordDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, ResourceUsageTag tag);
+
+    struct DescriptorAccesses {
+        const vvl::Pipeline* pipeline = nullptr;
+        std::vector<ShaderAccessCommand::BufferAccess> buffer_accesses;
+        std::vector<ShaderAccessCommand::ImageViewAccess> image_accesses;
+        uint32_t render_pass_instance_id = vvl::kNoIndex32;
+        uint32_t subpass = vvl::kNoIndex32;
+    };
+    DescriptorAccesses CollectDescriptorAccesses(VkPipelineBindPoint pipelineBindPoint) const;
+    void RecordShaderAccesses(ResourceUsageTag tag, DescriptorAccesses& descriptor_accesses);
+
     bool ValidateDrawVertex(uint32_t vertexCount, uint32_t firstVertex, const Location& loc) const;
     void RecordDrawVertex(uint32_t vertexCount, uint32_t firstVertex, ResourceUsageTag tag);
     bool ValidateDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, const Location& loc) const;

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -224,7 +224,12 @@ static void PrepareCommonDescriptorMessage(Logger& logger, const vvl::Pipeline& 
     additional_info.properties.Add(kPropertyDescriptorType, descriptor_type_str);
     additional_info.properties.Add(kPropertyDescriptorBinding, descriptor_binding);
     additional_info.properties.Add(kPropertyDescriptorArrayElement, descriptor_array_element);
-    additional_info.access_initiator = std::string("Shader stage ") + string_VkShaderStageFlagBits(shader_stage);
+    const std::string shader_stage_description = std::string("Shader stage ") + string_VkShaderStageFlagBits(shader_stage);
+    if (additional_info.access_initiator.empty()) {
+        additional_info.access_initiator = shader_stage_description;
+    } else {
+        additional_info.access_initiator = shader_stage_description + " in " + additional_info.access_initiator;
+    }
 
     ss << "\nThe " << resource_type << " is referenced by descriptor binding " << descriptor_binding;
     ss << " (" << descriptor_type_str << ")";
@@ -235,29 +240,35 @@ static void PrepareCommonDescriptorMessage(Logger& logger, const vvl::Pipeline& 
     ss << ", " << logger.FormatHandle(pipeline);
 }
 
-std::string ErrorMessages::BufferDescriptorError(const HazardResult& hazard, const CommandBufferContext& cb_context,
-                                                 vvl::Func command, const std::string& resource_description,
+std::string ErrorMessages::BufferDescriptorError(const SyncEnvironment& env, const HazardResult& hazard,
+                                                 const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+                                                 const Location& loc, const std::string& resource_description,
                                                  const vvl::Pipeline& pipeline, uint32_t set_number,
                                                  const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
                                                  uint32_t descriptor_binding, uint32_t descriptor_array_element,
                                                  VkShaderStageFlagBits shader_stage) const {
     AdditionalMessageInfo additional_info;
+    const vvl::Func command = AddReplayInfo(env, hazard, cb_context, replay_tag, loc, additional_info);
+
     std::ostringstream ss;
     PrepareCommonDescriptorMessage(validator_, pipeline, set_number, descriptor_set, descriptor_type, descriptor_binding,
                                    descriptor_array_element, shader_stage, "buffer", additional_info, ss);
     ss << ".";
 
     additional_info.pre_synchronization_text = ss.str();
-    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "BufferDescriptorError", additional_info);
+    return Error(env, hazard, command, resource_description, "BufferDescriptorError", additional_info);
 }
 
-std::string ErrorMessages::ImageDescriptorError(const HazardResult& hazard, const CommandBufferContext& cb_context,
-                                                vvl::Func command, const std::string& resource_description,
+std::string ErrorMessages::ImageDescriptorError(const SyncEnvironment& env, const HazardResult& hazard,
+                                                const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+                                                const Location& loc, const std::string& resource_description,
                                                 const vvl::Pipeline& pipeline, uint32_t set_number,
                                                 const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
                                                 uint32_t descriptor_binding, uint32_t descriptor_array_element,
                                                 VkShaderStageFlagBits shader_stage, VkImageLayout image_layout) const {
     AdditionalMessageInfo additional_info;
+    const vvl::Func command = AddReplayInfo(env, hazard, cb_context, replay_tag, loc, additional_info);
+
     std::ostringstream ss;
     PrepareCommonDescriptorMessage(validator_, pipeline, set_number, descriptor_set, descriptor_type, descriptor_binding,
                                    descriptor_array_element, shader_stage, "image", additional_info, ss);
@@ -265,24 +276,25 @@ std::string ErrorMessages::ImageDescriptorError(const HazardResult& hazard, cons
 
     additional_info.pre_synchronization_text = ss.str();
     additional_info.properties.Add(kPropertyImageLayout, string_VkImageLayout(image_layout));
-    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "ImageDescriptorError", additional_info);
+    return Error(env, hazard, command, resource_description, "ImageDescriptorError", additional_info);
 }
 
 std::string ErrorMessages::AccelerationStructureDescriptorError(
-    const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command, const std::string& resource_description,
-    const vvl::Pipeline& pipeline, uint32_t set_number, const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
-    uint32_t descriptor_binding, uint32_t descriptor_array_element, VkShaderStageFlagBits shader_stage) const {
+    const SyncEnvironment& env, const HazardResult& hazard, const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+    const Location& loc, const std::string& resource_description, const vvl::Pipeline& pipeline, uint32_t set_number,
+    const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type, uint32_t descriptor_binding,
+    uint32_t descriptor_array_element, VkShaderStageFlagBits shader_stage) const {
     AdditionalMessageInfo additional_info;
-    additional_info.access_action = "traces rays against";
+    const vvl::Func command = AddReplayInfo(env, hazard, cb_context, replay_tag, loc, additional_info);
 
     std::ostringstream ss;
     PrepareCommonDescriptorMessage(validator_, pipeline, set_number, descriptor_set, descriptor_type, descriptor_binding,
                                    descriptor_array_element, shader_stage, "acceleration structure", additional_info, ss);
     ss << ".";
-    additional_info.pre_synchronization_text = ss.str();
 
-    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "AccelerationStructureDescriptorError",
-                 additional_info);
+    additional_info.access_action = "traces rays against";
+    additional_info.pre_synchronization_text = ss.str();
+    return Error(env, hazard, command, resource_description, "AccelerationStructureDescriptorError", additional_info);
 }
 
 std::string ErrorMessages::ClearAttachmentError(const HazardResult& hazard, const CommandBufferContext& cb_context,

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -80,20 +80,23 @@ class ErrorMessages {
                                 const std::string& resource_description, uint32_t subresource_range_index,
                                 const VkImageSubresourceRange& subresource_range) const;
 
-    std::string BufferDescriptorError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
+    std::string BufferDescriptorError(const SyncEnvironment& env, const HazardResult& hazard,
+                                      const CommandBufferContext& cb_context, ResourceUsageTag replay_tag, const Location& loc,
                                       const std::string& resource_description, const vvl::Pipeline& pipeline, uint32_t set_number,
                                       const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
                                       uint32_t descriptor_binding, uint32_t descriptor_array_element,
                                       VkShaderStageFlagBits shader_stage) const;
 
-    std::string ImageDescriptorError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
-                                     const std::string& resource_description, const vvl::Pipeline& pipeline, uint32_t set_number,
-                                     const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
-                                     uint32_t descriptor_binding, uint32_t descriptor_array_element,
-                                     VkShaderStageFlagBits shader_stage, VkImageLayout image_layout) const;
+    std::string ImageDescriptorError(const SyncEnvironment& env, const HazardResult& hazard, const CommandBufferContext& cb_context,
+                                     ResourceUsageTag replay_tag, const Location& loc, const std::string& resource_description,
+                                     const vvl::Pipeline& pipeline, uint32_t set_number, const vvl::DescriptorSet& descriptor_set,
+                                     VkDescriptorType descriptor_type, uint32_t descriptor_binding,
+                                     uint32_t descriptor_array_element, VkShaderStageFlagBits shader_stage,
+                                     VkImageLayout image_layout) const;
 
-    std::string AccelerationStructureDescriptorError(const HazardResult& hazard, const CommandBufferContext& cb_context,
-                                                     vvl::Func command, const std::string& resource_description,
+    std::string AccelerationStructureDescriptorError(const SyncEnvironment& env, const HazardResult& hazard,
+                                                     const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+                                                     const Location& loc, const std::string& resource_description,
                                                      const vvl::Pipeline& pipeline, uint32_t set_number,
                                                      const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
                                                      uint32_t descriptor_binding, uint32_t descriptor_array_element,

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1075,11 +1075,16 @@ void SyncValidator::RecordCountBuffer(CommandBufferContext& cb_context, const Re
 
 bool SyncValidator::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
                                                const ErrorObject& error_obj) const {
-    bool skip = false;
+    if (!syncval_settings.IsRecordTimeValidationEnabled()) {
+        return false;
+    }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    skip |=
-        GetCommandBufferContext(*cb_state).ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
-    return skip;
+    const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
+    const auto descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_COMPUTE);
+    const ShaderAccessCommand command{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses,
+                                      descriptor_accesses.image_accesses, descriptor_accesses.render_pass_instance_id,
+                                      descriptor_accesses.subpass};
+    return command.Validate(cb_context, error_obj.location);
 }
 
 void SyncValidator::PostCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
@@ -1087,7 +1092,8 @@ void SyncValidator::PostCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uin
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
-    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, tag);
+    auto descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_COMPUTE);
+    cb_context.RecordShaderAccesses(tag, descriptor_accesses);
 }
 
 bool SyncValidator::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,


### PR DESCRIPTION
Adds `ShaderAccessCommand` that wraps shader access heuristic code.
Applied it to `vkCmdDispatch`. Other PRs will update other draw/dispatch commands but need to add more functionality before that.