### PR TITLE
gpuav: Rework internal desc heap alloc

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -551,11 +551,9 @@ void PreCallSetupShaderInstrumentationResourcesDescriptorHeap(Validator& gpuav, 
         return;
     }
 
-    const VkDeviceSize indirect_buffer_offset = gpuav.heap_indirect_buffer_stride_ * common_error_info.total_action_commands;
-
-    const auto& indirect_buffer = cb_state.GetInternalDescriptorHeap();
-    uint8_t* indirect_buffer_ptr = static_cast<uint8_t*>(indirect_buffer.GetMappedPtr());
-    indirect_buffer_ptr += indirect_buffer_offset;
+    const vko::BufferRange& cb_local_desc_heap =
+        cb_state.gpu_resources_manager.GetHostCoherentBufferRange(gpuav.heap_indirect_buffer_stride_);
+    uint8_t* cb_local_desc_heap_ptr = static_cast<uint8_t*>(cb_local_desc_heap.offset_mapped_ptr);
 
     const uint32_t error_logger_index = cb_state.GetErrorLoggerIndex();
 
@@ -564,10 +562,10 @@ void PreCallSetupShaderInstrumentationResourcesDescriptorHeap(Validator& gpuav, 
     const uint32_t action_command_index_offset = common_error_info.action_command_index * gpuav.indices_buffer_alignment_;
     const uint32_t resource_index_offset = error_logger_index * gpuav.indices_buffer_alignment_;
 
-    UpdateInstrumentationDescHeap(gpuav, cb_state, last_bound, (VkDeviceAddress*)indirect_buffer_ptr, action_command_index_offset,
-                                  resource_index_offset, loc);
+    UpdateInstrumentationDescHeap(gpuav, cb_state, last_bound, (VkDeviceAddress*)cb_local_desc_heap_ptr,
+                                  action_command_index_offset, resource_index_offset, loc);
 
-    VkDeviceAddress gpuav_data_address = indirect_buffer.Address() + indirect_buffer_offset;
+    VkDeviceAddress gpuav_data_address = cb_local_desc_heap.offset_address;
     VkPushDataInfoEXT push_data_info = vku::InitStructHelper();
     push_data_info.offset = gpuav.push_data_offset_;
     push_data_info.data.address = &gpuav_data_address;

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1342,8 +1342,8 @@ void GpuShaderInstrumentor::AddDescriptorHeapMappings(VkBaseOutStructure* create
         mapping.bindingCount = 1;
         mapping.resourceMask = VK_SPIRV_RESOURCE_TYPE_ALL_EXT;
         mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT;
-        mapping.sourceData.indirectAddress.addressOffset = sizeof(VkDeviceAddress) * i;
         mapping.sourceData.indirectAddress.pushOffset = push_data_offset_;
+        mapping.sourceData.indirectAddress.addressOffset = sizeof(VkDeviceAddress) * i;
     }
 
     if (mapping_info) {

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -260,25 +260,6 @@ vko::Buffer& CommandBufferSubState::GetInternalDescriptorBuffer() {
     return internal_descriptor_buffer_;
 }
 
-// This buffer is going to be the indirect buffer for a VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT mapping.
-vko::Buffer& CommandBufferSubState::GetInternalDescriptorHeap() {
-    if (internal_descriptor_heap_.IsDestroyed()) {
-        VkBufferCreateInfo buffer_info = vku::InitStructHelper();
-        buffer_info.size = gpuav_.heap_indirect_buffer_stride_ * gpuav_.gpuav_settings.indices_buffer_count;
-        // Note that maxUniformBufferRange is smaller likely to what we need here, but this buffer doesn't need to worry because we
-        // are not "binding" this, so we can use maxBufferSize instead
-        buffer_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-        VmaAllocationCreateInfo alloc_info = {};
-        alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-        alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-        const VkResult result = internal_descriptor_heap_.Create(&buffer_info, &alloc_info);
-        if (result != VK_SUCCESS) {
-            gpuav_.InternalVmaError(base.Handle(), result, "Failed to create an internal resource Descriptor Heap.");
-        }
-    }
-    return internal_descriptor_heap_;
-}
-
 struct FenceWaiter {
     // FenceWaiter is accessed by PostSubmit and by queue thread's Retire at the same time.
     std::mutex lock;

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -161,7 +161,6 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     uint32_t GetErrorLoggerIndex() { return (uint32_t)command_error_loggers_.size(); }
     const CommandErrorLogger &GetErrorLogger(uint32_t i) { return command_error_loggers_[i]; }
 
-    vko::Buffer& GetInternalDescriptorHeap();
     vko::Buffer& GetInternalDescriptorBuffer();
 
     // Buffer storing GPU-AV errors

--- a/layers/gpuav/resources/gpuav_vulkan_objects.cpp
+++ b/layers/gpuav/resources/gpuav_vulkan_objects.cpp
@@ -278,7 +278,8 @@ GpuResourcesManager::GpuResourcesManager(Validator& gpuav, bool thread_safe_buff
         alloc_ci.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
         alloc_ci.requiredFlags = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
         buffer_caches_.host_coherent.Create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
-                                                VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                                                VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+                                                VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                                             alloc_ci);
     }
 


### PR DESCRIPTION
The needed GPU memory really has its lifespan tied to that of the command buffer, so just use the relevant allocator