### PR TITLE
layers: Fix DAC range missing previous region

### DIFF
--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -630,20 +630,26 @@ bool Device::manual_PreCallValidateCmdCopyMemoryKHR(VkCommandBuffer commandBuffe
                          "(%" PRIu64 ") is less than srcRange.size (%" PRIu64 ").", region.dstRange.size, region.srcRange.size);
         }
 
-        vvl::range<VkDeviceAddress> region_src_range = {region.srcRange.address, region.srcRange.address + region.srcRange.size};
-        for (uint32_t j = i; j < pCopyMemoryInfo->regionCount; ++j) {
+        const vvl::range<VkDeviceAddress> region_src_range = {region.srcRange.address,
+                                                              region.srcRange.address + region.srcRange.size};
+        for (uint32_t j = 0; j < pCopyMemoryInfo->regionCount; ++j) {
             const VkDeviceMemoryCopyKHR& other_region = pCopyMemoryInfo->pRegions[j];
-            vvl::range<VkDeviceAddress> next_src_range = {other_region.srcRange.address,
-                                                          other_region.srcRange.address + other_region.srcRange.size};
-            vvl::range<VkDeviceAddress> next_dst_range = {other_region.dstRange.address,
-                                                          other_region.dstRange.address + other_region.dstRange.size};
 
-            // j > i so that the current src range is not compared to itself
-            if (j > i && region_src_range.intersects(next_src_range)) {
-                skip |= LogError("VUID-VkCopyDeviceMemoryInfoKHR-srcRange-13015", commandBuffer, region_loc.dot(Field::srcRange),
+            if (j > i) {
+                const vvl::range<VkDeviceAddress> next_src_range = {other_region.srcRange.address,
+                                                                    other_region.srcRange.address + other_region.srcRange.size};
+                if (region_src_range.intersects(next_src_range)) {
+                    skip |=
+                        LogError("VUID-VkCopyDeviceMemoryInfoKHR-srcRange-13015", commandBuffer, region_loc.dot(Field::srcRange),
                                  "%s overlaps with pRegions[%" PRIu32 "].srcRange %s", string_range_hex(region_src_range).c_str(),
+
                                  j, string_range_hex(next_src_range).c_str());
-            } else if (region_src_range.intersects(next_dst_range)) {
+                }
+            }
+
+            const vvl::range<VkDeviceAddress> next_dst_range = {other_region.dstRange.address,
+                                                                other_region.dstRange.address + other_region.dstRange.size};
+            if (region_src_range.intersects(next_dst_range)) {
                 skip |= LogError("VUID-VkCopyDeviceMemoryInfoKHR-srcRange-13015", commandBuffer, region_loc.dot(Field::srcRange),
                                  "%s overlaps with pRegions[%" PRIu32 "].dstRange %s", string_range_hex(region_src_range).c_str(),
                                  j, string_range_hex(next_dst_range).c_str());

--- a/tests/unit/device_address_commands.cpp
+++ b/tests/unit/device_address_commands.cpp
@@ -2923,6 +2923,36 @@ TEST_F(NegativeDeviceAddressCommands, CopyAddressRangeOverlap) {
     m_command_buffer.End();
 }
 
+TEST_F(NegativeDeviceAddressCommands, CopyDeviceMemoryAddressOverlapRegion) {
+    RETURN_IF_SKIP(InitBasicDeviceAddressCommands());
+
+    vkt::Buffer buffer(*m_device, 4096u, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, vkt::device_address);
+    const VkDeviceAddress base = buffer.Address();
+    constexpr VkDeviceSize r_size = 256u;
+
+    VkDeviceMemoryCopyKHR regions[2];
+    regions[0] = vku::InitStruct<VkDeviceMemoryCopyKHR>();
+    regions[0].srcRange = {base, r_size};
+    regions[0].srcFlags = 0u;
+    regions[0].dstRange = {base + 1024u, r_size};
+    regions[0].dstFlags = 0u;
+    regions[1] = vku::InitStruct<VkDeviceMemoryCopyKHR>();
+    regions[1].srcRange = {base + 1024u, r_size};
+    regions[1].srcFlags = 0u;
+    regions[1].dstRange = {base + 2048u, r_size};
+    regions[1].dstFlags = 0u;
+
+    VkCopyDeviceMemoryInfoKHR copy_memory_info = vku::InitStructHelper();
+    copy_memory_info.regionCount = 2;
+    copy_memory_info.pRegions = regions;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-VkCopyDeviceMemoryInfoKHR-srcRange-13015");
+    vk::CmdCopyMemoryKHR(m_command_buffer, &copy_memory_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeDeviceAddressCommands, CopyDeviceMemoryAddressOverlap) {
     RETURN_IF_SKIP(InitBasicDeviceAddressCommands());
 


### PR DESCRIPTION
Was not reporting errors like 

```
Validation Error: [ VUID-VkCopyDeviceMemoryInfoKHR-srcRange-13015 ] | MessageID = 0x1c1eb7b5
vkCmdCopyMemoryKHR(): pRegions[1].srcRange [0x10000400, 0x10000500) overlaps with pRegions[0].dstRange [0x10000400, 0x10000500).
```