### PR TITLE
utils: add std::forward<Args> to small_vector

### DIFF
--- a/layers/containers/small_vector.h
+++ b/layers/containers/small_vector.h
@@ -201,7 +201,7 @@ class small_vector {
     reference emplace_back(Args &&...args) {
         assert(size_ < kMaxCapacity);
         reserve(size_ + 1);
-        new (GetWorkingStore() + size_) value_type(args...);
+        new (GetWorkingStore() + size_) value_type(std::forward<Args>(args)...);
         size_++;
         return back();
     }


### PR DESCRIPTION
100% only because some AI overlord told me so and smarter C++ people internally agreed to obey the AI overlords