### PR TITLE
layers: Improve RT validation

### DIFF
--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -1471,10 +1471,7 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresKHR(
                              "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but srcAccelerationStructure is VK_NULL_HANDLE.");
         }
 
-        for (const auto [other_info_j, other_info] : vvl::enumerate(pInfos, infoCount)) {
-            if (info_i == other_info_j) {
-                continue;
-            }
+        for (const auto [other_info_j, other_info] : vvl::enumerate(pInfos + info_i + 1, infoCount - (info_i + 1))) {
             if (info.dstAccelerationStructure == other_info.dstAccelerationStructure) {
                 const LogObjectList objlist(commandBuffer, info.dstAccelerationStructure);
                 skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03698", objlist,
@@ -1614,10 +1611,7 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(
                          "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but srcAccelerationStructure is VK_NULL_HANDLE.");
         }
 
-        for (const auto [other_info_j, other_info] : vvl::enumerate(pInfos, infoCount)) {
-            if (info_i == other_info_j) {
-                continue;
-            }
+        for (const auto [other_info_j, other_info] : vvl::enumerate(pInfos + info_i + 1, infoCount - (info_i + 1))) {
             if (info.dstAccelerationStructure == other_info.dstAccelerationStructure) {
                 const LogObjectList objlist(commandBuffer, info.dstAccelerationStructure);
                 skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03698", objlist,
@@ -1693,7 +1687,7 @@ bool Device::manual_PreCallValidateBuildAccelerationStructuresKHR(
             }
         }
 
-        for (const auto [other_info_j, other_info] : vvl::enumerate(pInfos, infoCount)) {
+        for (const auto [other_info_j, other_info] : vvl::enumerate(pInfos + info_i + 1, infoCount - (info_i + 1))) {
             if (info_i == other_info_j) {
                 continue;
             }

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -1752,6 +1752,32 @@ TEST_F(NegativeRayTracing, HostCmdBuildAccelerationStructuresKHR) {
     }
 }
 
+TEST_F(NegativeRayTracing, BatchedBuildDuplicateDstAccelerationStructure) {
+    TEST_DESCRIPTION("Two pInfos entries of a single batched build using the same dstAccelerationStructure.");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+    blas.SetupBuild(true);
+
+    // Both entries name the same dstAccelerationStructure, so each one conflicts with the other
+    std::array<VkAccelerationStructureBuildGeometryInfoKHR, 2> infos = {blas.GetInfo(), blas.GetInfo()};
+
+    VkAccelerationStructureBuildRangeInfoKHR range_info = {};
+    range_info.primitiveCount = 1;
+    std::array<const VkAccelerationStructureBuildRangeInfoKHR*, 2> range_infos = {&range_info, &range_info};
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03698");
+    vk::CmdBuildAccelerationStructuresKHR(m_command_buffer, size32(infos), infos.data(), range_infos.data());
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     TEST_DESCRIPTION("Validate acceleration structure building.");
     AddOptionalExtensions(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME);


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/13037

Maybe it's too late and I am completely wrong, if not that's the worst garbage I have seen to get rid of a "validation is actually commutative no need to check both Validate(A,B) and Validate(B, A) only one suffice" issue