### PR TITLE
sync: Use array per command type

### DIFF
--- a/layers/sync/sync_command.cpp
+++ b/layers/sync/sync_command.cpp
@@ -55,37 +55,96 @@ bool ReplayCommands(SyncEnvironment& env, AccessContext& destination_access_cont
     const CommandData& command_data = cb_context.GetCommandData();
     CommandReplayContext replay_context(env, destination_access_context, base_tag);
 
+    auto replay_common = [&skip, &command_data, base_tag, &env, &loc, &cb_context](
+                             const auto& storage, AccessContext& access_context, ResourceUsageTag replay_tag) {
+        const auto command = storage.MakeCommand(command_data);
+        skip |= command.Validate(env, access_context, cb_context, replay_tag, loc);
+        const ResourceUsageTag tag = base_tag + replay_tag;
+        command.Apply(env, tag, access_context);
+    };
+
     for (const CommandEntry& entry : cb_context.GetCommands()) {
-        const ResourceUsageTag tag = base_tag + entry.tag;
-        std::visit(
-            [&](const auto& storage) {
-                bool command_skip = false;
-                const auto& command = storage.MakeCommand(command_data);
-                using CommandType = std::decay_t<decltype(command)>;
+        const ResourceUsageTag replay_tag = entry.tag;
+        const uint32_t index = entry.command_ref.index;
+        AccessContext& access_context = replay_context.CurrentAccessContext();
 
-                AccessContext& access_context = replay_context.CurrentAccessContext();
-
-                if constexpr (std::is_same_v<CommandType, BeginRenderPassCommand>) {
-                    command_skip = command.Validate(env, access_context, cb_context, entry.tag, loc);
-                    replay_context.BeginRenderPass(command);
-                    command.Apply(env, tag, *replay_context.render_pass_context);
-                } else if constexpr (std::is_same_v<CommandType, NextSubpassCommand>) {
-                    command_skip = command.Validate(env, *replay_context.render_pass_context, cb_context, entry.tag, loc);
-                    replay_context.NextSubpass();
-                    command.Apply(env, tag, *replay_context.render_pass_context);
-                } else if constexpr (std::is_same_v<CommandType, EndRenderPassCommand>) {
-                    command_skip = command.Validate(env, *replay_context.render_pass_context, cb_context, entry.tag, loc);
-                    command.Apply(env, tag, *replay_context.render_pass_context, destination_access_context);
-                    replay_context.EndRenderPass();
-                } else {
-                    command_skip = command.Validate(env, access_context, cb_context, entry.tag, loc);
-                    command.Apply(env, tag, access_context);
-                }
-                skip |= command_skip;
-            },
-            entry.storage);
+        switch (entry.command_ref.type) {
+            case CommandType::kBufferCopy: {
+                replay_common(command_data.buffer_copy_commands[index], access_context, replay_tag);
+                continue;
+            }
+            case CommandType::kBufferAccess: {
+                replay_common(command_data.buffer_access_commands[index], access_context, replay_tag);
+                continue;
+            }
+            case CommandType::kImageCopy: {
+                replay_common(command_data.image_copy_commands[index], access_context, replay_tag);
+                continue;
+            }
+            case CommandType::kPipelineBarrier: {
+                replay_common(command_data.barrier_commands[index], access_context, replay_tag);
+                continue;
+            }
+            case CommandType::kBeginRenderPass: {
+                const auto command = command_data.begin_render_pass_commands[index].MakeCommand(command_data);
+                skip |= command.Validate(env, access_context, cb_context, replay_tag, loc);
+                replay_context.BeginRenderPass(command);
+                const ResourceUsageTag tag = base_tag + replay_tag;
+                command.Apply(env, tag, *replay_context.render_pass_context);
+                continue;
+            }
+            case CommandType::kNextSubpass: {
+                const NextSubpassCommand command{};
+                skip |= command.Validate(env, *replay_context.render_pass_context, cb_context, replay_tag, loc);
+                replay_context.NextSubpass();
+                const ResourceUsageTag tag = base_tag + replay_tag;
+                command.Apply(env, tag, *replay_context.render_pass_context);
+                continue;
+            }
+            case CommandType::kEndRenderPass: {
+                const EndRenderPassCommand command{};
+                skip |= command.Validate(env, *replay_context.render_pass_context, cb_context, replay_tag, loc);
+                const ResourceUsageTag tag = base_tag + replay_tag;
+                command.Apply(env, tag, *replay_context.render_pass_context, destination_access_context);
+                replay_context.EndRenderPass();
+                continue;
+            }
+            case CommandType::kShaderAccess: {
+                replay_common(command_data.shader_access_commands[index], access_context, replay_tag);
+                continue;
+            }
+            case CommandType::kDispatchIndirect: {
+                replay_common(command_data.dispatch_indirect_commands[index], access_context, replay_tag);
+                continue;
+            }
+        }
+        assert(false);
     }
     return skip;
+}
+
+void CommandData::Reset() {
+    buffer_copy_commands.clear();
+    buffer_access_commands.clear();
+    image_copy_commands.clear();
+    barrier_commands.clear();
+    begin_render_pass_commands.clear();
+    shader_access_commands.clear();
+    dispatch_indirect_commands.clear();
+
+    buffers.clear();
+    images.clear();
+    image_views.clear();
+    render_passes.clear();
+    pipelines.clear();
+    buffer_copy_regions.clear();
+    image_copy_regions.clear();
+    barrier_sets.clear();
+    descriptor_buffer_accesses.clear();
+    descriptor_image_accesses.clear();
+
+    descriptor_sets.clear();
+    descriptor_set_lookup.clear();
 }
 
 uint32_t CommandData::AddBuffer(const vvl::Buffer& buffer) {

--- a/layers/sync/sync_command.h
+++ b/layers/sync/sync_command.h
@@ -266,11 +266,36 @@ struct DispatchIndirectCommand {
     void Apply(SyncEnvironment& env, ResourceUsageTag tag, AccessContext& access_context) const;
 };
 
-using CommandStorage = std::variant<BufferCopyCommand::Storage, BufferAccessCommand::Storage, ImageCopyCommand::Storage,
-                                    BarrierCommand::Storage, BeginRenderPassCommand::Storage, NextSubpassCommand::Storage,
-                                    EndRenderPassCommand::Storage, ShaderAccessCommand::Storage, DispatchIndirectCommand::Storage>;
+enum class CommandType : uint32_t {
+    kBufferCopy,
+    kBufferAccess,
+    kImageCopy,
+    kPipelineBarrier,
+    kBeginRenderPass,
+    kNextSubpass,
+    kEndRenderPass,
+    kShaderAccess,
+    kDispatchIndirect,
+};
+
+struct CommandRef {
+    CommandType type;
+    uint32_t index;
+};
+static_assert(sizeof(CommandRef) == 8);
 
 struct CommandData {
+    // Command storage data.
+    // NOTE: NextSubpass and EndRenderPass have no storage data
+    std::vector<BufferCopyCommand::Storage> buffer_copy_commands;
+    std::vector<BufferAccessCommand::Storage> buffer_access_commands;
+    std::vector<ImageCopyCommand::Storage> image_copy_commands;
+    std::vector<BarrierCommand::Storage> barrier_commands;
+    std::vector<BeginRenderPassCommand::Storage> begin_render_pass_commands;
+    std::vector<ShaderAccessCommand::Storage> shader_access_commands;
+    std::vector<DispatchIndirectCommand::Storage> dispatch_indirect_commands;
+
+    // Resources and additional data used by the commands
     std::vector<std::shared_ptr<const vvl::Buffer>> buffers;
     std::vector<std::shared_ptr<const vvl::Image>> images;
     std::vector<std::shared_ptr<const vvl::ImageView>> image_views;
@@ -285,21 +310,60 @@ struct CommandData {
     std::vector<std::shared_ptr<const vvl::DescriptorSet>> descriptor_sets;
     vvl::unordered_set<const vvl::DescriptorSet*> descriptor_set_lookup;
 
+    void Reset();  // keeps capacity
+
     uint32_t AddBuffer(const vvl::Buffer& buffer);
     uint32_t AddImage(const vvl::Image& image);
     uint32_t AddRenderPass(const vvl::RenderPass& render_pass);
     void AddImageView(const vvl::ImageView& image_view);
     void AddPipeline(const vvl::Pipeline& pipeline);
     void AddDescriptorSet(const vvl::DescriptorSet& descriptor_set);
+
+    CommandRef Store(const BufferCopyCommand::Storage& storage) {
+        return Store(CommandType::kBufferCopy, buffer_copy_commands, storage);
+    }
+    CommandRef Store(const BufferAccessCommand::Storage& storage) {
+        return Store(CommandType::kBufferAccess, buffer_access_commands, storage);
+    }
+    CommandRef Store(const ImageCopyCommand::Storage& storage) {
+        return Store(CommandType::kImageCopy, image_copy_commands, storage);
+    }
+    CommandRef Store(const BarrierCommand::Storage& storage) {
+        return Store(CommandType::kPipelineBarrier, barrier_commands, storage);
+    }
+    CommandRef Store(const BeginRenderPassCommand::Storage& storage) {
+        return Store(CommandType::kBeginRenderPass, begin_render_pass_commands, storage);
+    }
+    CommandRef Store(const NextSubpassCommand::Storage&) {
+        // No storage data, return the command reference directly. The index is unused.
+        return {CommandType::kNextSubpass, 0};
+    }
+    CommandRef Store(const EndRenderPassCommand::Storage&) {
+        // No storage data, return the command reference directly. The index is unused.
+        return {CommandType::kEndRenderPass, 0};
+    }
+    CommandRef Store(const ShaderAccessCommand::Storage& storage) {
+        return Store(CommandType::kShaderAccess, shader_access_commands, storage);
+    }
+    CommandRef Store(const DispatchIndirectCommand::Storage& storage) {
+        return Store(CommandType::kDispatchIndirect, dispatch_indirect_commands, storage);
+    }
+
+  private:
+    template <typename Storage>
+    static CommandRef Store(CommandType type, std::vector<Storage>& commands, const Storage& storage) {
+        const uint32_t index = static_cast<uint32_t>(commands.size());
+        commands.push_back(storage);
+        return {type, index};
+    }
 };
 
-// TODO: CommandEntry won't be needed after all commands are introduced.
-// Tag could be derived from command index. Remove entry type when and
-// use array of commands instead.
+// TODO: Revisit tag tracking after command conversion.
+// Once tag and tag_count can be derived, store CommandRefs directly
 struct CommandEntry {
+    CommandRef command_ref;
     ResourceUsageTag tag;
     uint32_t tag_count;
-    CommandStorage storage;
 };
 
 bool ReplayCommands(SyncEnvironment& env, AccessContext& access_context, const CommandBufferContext& cb_context,

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -328,7 +328,7 @@ void CommandBufferContext::Reset() {
     }
     replay_entries_.clear();
     commands_.clear();
-    command_data_ = {};
+    command_data_.Reset();
 
     command_number_ = 0;
     reset_count_++;
@@ -1551,21 +1551,53 @@ void CommandBufferContext::RecordExecutedCommandBuffer(const CommandBufferContex
 
     ImportRecordedAccessLog(recorded_cb_context);
 
+    auto import_common = [this](const auto& storage, const CommandData& recorded_command_data, ResourceUsageTag tag,
+                                uint32_t tag_count) {
+        const auto command = storage.MakeCommand(recorded_command_data);
+        command.Apply(environment_, tag, *current_context_);
+        StoreCommand(tag, command, tag_count);
+    };
+
     const auto& settings = GetSyncState().syncval_settings;
     if (settings.full_validation && recorded_cb_context.HasAllCommands()) {
+        const CommandData& command_data = recorded_cb_context.GetCommandData();
         for (const CommandEntry& entry : recorded_cb_context.GetCommands()) {
-            std::visit(
-                [&](const auto& storage) {
-                    const auto command = storage.MakeCommand(recorded_cb_context.GetCommandData());
-                    using CommandType = std::decay_t<decltype(command)>;
-                    if constexpr (!std::is_same_v<CommandType, BeginRenderPassCommand> &&
-                                  !std::is_same_v<CommandType, NextSubpassCommand> &&
-                                  !std::is_same_v<CommandType, EndRenderPassCommand>) {
-                        command.Apply(environment_, base_tag + entry.tag, *current_context_);
-                        StoreCommand(base_tag + entry.tag, command, entry.tag_count);
-                    }
-                },
-                entry.storage);
+            const ResourceUsageTag tag = base_tag + entry.tag;
+            const uint32_t index = entry.command_ref.index;
+
+            switch (entry.command_ref.type) {
+                case CommandType::kBufferCopy: {
+                    import_common(command_data.buffer_copy_commands[index], command_data, tag, entry.tag_count);
+                    continue;
+                }
+                case CommandType::kBufferAccess: {
+                    import_common(command_data.buffer_access_commands[index], command_data, tag, entry.tag_count);
+                    continue;
+                }
+                case CommandType::kImageCopy: {
+                    import_common(command_data.image_copy_commands[index], command_data, tag, entry.tag_count);
+                    continue;
+                }
+                case CommandType::kPipelineBarrier: {
+                    import_common(command_data.barrier_commands[index], command_data, tag, entry.tag_count);
+                    continue;
+                }
+                case CommandType::kBeginRenderPass:
+                case CommandType::kNextSubpass:
+                case CommandType::kEndRenderPass: {
+                    // [core validation check]: these commands are invalid in secondary command buffers
+                    continue;
+                }
+                case CommandType::kShaderAccess: {
+                    import_common(command_data.shader_access_commands[index], command_data, tag, entry.tag_count);
+                    continue;
+                }
+                case CommandType::kDispatchIndirect: {
+                    import_common(command_data.dispatch_indirect_commands[index], command_data, tag, entry.tag_count);
+                    continue;
+                }
+            }
+            assert(false);
         }
     } else {
         // Replay synchronization actions against the current destination state. The

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -270,8 +270,8 @@ class CommandBufferContext final : public ResourceUsageInfoProvider, public Debu
 
     template <typename Command>
     void StoreCommand(ResourceUsageTag tag, const Command& command, uint32_t tag_count = 1) {
-        auto storage = command.MakeStorage(command_data_);
-        commands_.push_back(CommandEntry{tag, tag_count, std::move(storage)});
+        const auto storage = command.MakeStorage(command_data_);
+        commands_.push_back({command_data_.Store(storage), tag, tag_count});
     }
 
     const std::vector<HandleRecord>& GetHandleRecords() const { return handles_; }


### PR DESCRIPTION
`std::variant` wastes space when commands have different sizes.
Recent additions increased the difference in `Storage` sizes.
Use a separate array for each command type instead.