### PR TITLE
ci: Skip REUSE Compliance Check on pull

### DIFF
--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: REUSE Compliance Check
-on: [push, pull_request]
+on: [pull_request]
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
same idea as https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/13055

we only do PR so only run on the PR, not the PUSH afterwards