### PR TITLE
sync: Add DrawAttachmentCommand

### DIFF
--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -385,7 +385,7 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo& alloc
                 {VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, (uint64_t)AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER},
                 {VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, (uint64_t)AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER},
                 {VK_IMAGE_USAGE_STORAGE_BIT, (uint64_t)AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER},
-            };
+            }};
 
             for (const auto& [vk_usage, ahb_usage] : ahb_usage_map_v2a) {
                 if (image_state->usage & vk_usage) {

--- a/layers/sync/sync_command.cpp
+++ b/layers/sync/sync_command.cpp
@@ -117,6 +117,18 @@ bool ReplayCommands(SyncEnvironment& env, AccessContext& destination_access_cont
                 replay_common(command_data.dispatch_indirect_commands[index], access_context, replay_tag);
                 continue;
             }
+            case CommandType::kDrawMeshTasks: {
+                // TODO: Supply DynamicRenderingInfo once Begin/EndRendering replay is implemented.
+                auto command = command_data.draw_mesh_tasks_commands[index].MakeCommand(
+                    command_data, replay_context.render_pass_context ? &*replay_context.render_pass_context : nullptr, nullptr);
+                if (command.shader_accesses.render_pass_instance_id != vvl::kNoIndex32) {
+                    command.shader_accesses.render_pass_instance_id += replay_context.render_pass_instance_offset;
+                }
+                skip |= command.Validate(env, access_context, cb_context, replay_tag, loc);
+                const ResourceUsageTag tag = base_tag + replay_tag;
+                command.Apply(env, tag, access_context);
+                continue;
+            }
         }
         assert(false);
     }
@@ -131,6 +143,7 @@ void CommandData::Reset() {
     begin_render_pass_commands.clear();
     shader_access_commands.clear();
     dispatch_indirect_commands.clear();
+    draw_mesh_tasks_commands.clear();
 
     buffers.clear();
     images.clear();
@@ -676,6 +689,73 @@ bool DispatchIndirectCommand::Validate(const SyncEnvironment& env, const AccessC
 void DispatchIndirectCommand::Apply(SyncEnvironment& env, ResourceUsageTag tag, AccessContext& access_context) const {
     shader_accesses.Apply(env, tag, access_context);
     indirect_access.Apply(env, tag, access_context);
+}
+
+DrawAttachmentCommand DrawAttachmentCommand::Storage::MakeCommand(RenderPassAccessContext* render_pass_context,
+                                                                  const DynamicRenderingInfo* rendering_info) const {
+    return {pipeline, render_pass_context, rendering_info, render_pass_instance_id, depth_write, stencil_write};
+}
+
+DrawAttachmentCommand::Storage DrawAttachmentCommand::MakeStorage(CommandData& command_data) const {
+    if (pipeline) {
+        command_data.AddPipeline(*pipeline);
+    }
+    return {pipeline, render_pass_instance_id, depth_write, stencil_write};
+}
+
+bool DrawAttachmentCommand::Validate(const CommandBufferContext& cb_context, const Location& loc) const {
+    return Validate(cb_context.GetSyncEnvironment(), cb_context.GetCurrentAccessContext(), cb_context, kInvalidTag, loc);
+}
+
+bool DrawAttachmentCommand::Validate(const SyncEnvironment& env, const AccessContext& access_context,
+                                     const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+                                     const Location& loc) const {
+    if (render_pass_context) {
+        return render_pass_context->ValidateDrawSubpassAttachment(env, cb_context, replay_tag, loc, pipeline, depth_write,
+                                                                  stencil_write);
+    } else if (rendering_info) {
+        return rendering_info->ValidateDrawAttachments(env, access_context, cb_context, replay_tag, loc, render_pass_instance_id,
+                                                       pipeline, depth_write, stencil_write);
+    }
+    return false;
+}
+
+void DrawAttachmentCommand::Apply(SyncEnvironment& env, ResourceUsageTag tag, AccessContext& access_context) const {
+    if (render_pass_context) {
+        render_pass_context->RecordDrawSubpassAttachment(pipeline, depth_write, stencil_write, tag, env.queue_id);
+    } else if (rendering_info) {
+        rendering_info->RecordDrawAttachments(access_context, render_pass_instance_id, pipeline, depth_write, stencil_write, tag,
+                                              env.queue_id);
+    }
+}
+
+DrawMeshTasksCommand DrawMeshTasksCommand::Storage::MakeCommand(const CommandData& command_data,
+                                                                RenderPassAccessContext* render_pass_context,
+                                                                const DynamicRenderingInfo* rendering_info) const {
+    return {shader_access_storage.MakeCommand(command_data),
+            attachment_access_storage.MakeCommand(render_pass_context, rendering_info)};
+}
+
+DrawMeshTasksCommand::Storage DrawMeshTasksCommand::MakeStorage(CommandData& command_data) const {
+    return {shader_accesses.MakeStorage(command_data), attachment_accesses.MakeStorage(command_data)};
+}
+
+bool DrawMeshTasksCommand::Validate(const CommandBufferContext& cb_context, const Location& loc) const {
+    return Validate(cb_context.GetSyncEnvironment(), cb_context.GetCurrentAccessContext(), cb_context, kInvalidTag, loc);
+}
+
+bool DrawMeshTasksCommand::Validate(const SyncEnvironment& env, const AccessContext& access_context,
+                                    const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+                                    const Location& loc) const {
+    bool skip = false;
+    skip |= shader_accesses.Validate(env, access_context, cb_context, replay_tag, loc);
+    skip |= attachment_accesses.Validate(env, access_context, cb_context, replay_tag, loc);
+    return skip;
+}
+
+void DrawMeshTasksCommand::Apply(SyncEnvironment& env, ResourceUsageTag tag, AccessContext& access_context) const {
+    shader_accesses.Apply(env, tag, access_context);
+    attachment_accesses.Apply(env, tag, access_context);
 }
 
 }  // namespace syncval

--- a/layers/sync/sync_command.h
+++ b/layers/sync/sync_command.h
@@ -41,6 +41,7 @@ class AccessContext;
 class CommandBufferContext;
 class RenderPassAccessContext;
 struct CommandData;
+struct DynamicRenderingInfo;
 struct SyncEnvironment;
 
 struct BufferCopyRegion {
@@ -266,6 +267,46 @@ struct DispatchIndirectCommand {
     void Apply(SyncEnvironment& env, ResourceUsageTag tag, AccessContext& access_context) const;
 };
 
+struct DrawAttachmentCommand {
+    const vvl::Pipeline* pipeline;
+    RenderPassAccessContext* render_pass_context;
+    const DynamicRenderingInfo* rendering_info;
+    uint32_t render_pass_instance_id;
+    bool depth_write;
+    bool stencil_write;
+
+    struct Storage {
+        const vvl::Pipeline* pipeline;
+        uint32_t render_pass_instance_id;
+        bool depth_write;
+        bool stencil_write;
+        DrawAttachmentCommand MakeCommand(RenderPassAccessContext* render_pass_context,
+                                          const DynamicRenderingInfo* rendering_info) const;
+    };
+    Storage MakeStorage(CommandData& command_data) const;
+    bool Validate(const CommandBufferContext& cb_context, const Location& loc) const;
+    bool Validate(const SyncEnvironment& env, const AccessContext& access_context, const CommandBufferContext& cb_context,
+                  ResourceUsageTag replay_tag, const Location& loc) const;
+    void Apply(SyncEnvironment& env, ResourceUsageTag tag, AccessContext& access_context) const;
+};
+
+struct DrawMeshTasksCommand {
+    ShaderAccessCommand shader_accesses;
+    DrawAttachmentCommand attachment_accesses;
+
+    struct Storage {
+        ShaderAccessCommand::Storage shader_access_storage;
+        DrawAttachmentCommand::Storage attachment_access_storage;
+        DrawMeshTasksCommand MakeCommand(const CommandData& command_data, RenderPassAccessContext* render_pass_context,
+                                         const DynamicRenderingInfo* rendering_info) const;
+    };
+    Storage MakeStorage(CommandData& command_data) const;
+    bool Validate(const CommandBufferContext& cb_context, const Location& loc) const;
+    bool Validate(const SyncEnvironment& env, const AccessContext& access_context, const CommandBufferContext& cb_context,
+                  ResourceUsageTag replay_tag, const Location& loc) const;
+    void Apply(SyncEnvironment& env, ResourceUsageTag tag, AccessContext& access_context) const;
+};
+
 enum class CommandType : uint32_t {
     kBufferCopy,
     kBufferAccess,
@@ -276,6 +317,7 @@ enum class CommandType : uint32_t {
     kEndRenderPass,
     kShaderAccess,
     kDispatchIndirect,
+    kDrawMeshTasks,
 };
 
 struct CommandRef {
@@ -294,6 +336,7 @@ struct CommandData {
     std::vector<BeginRenderPassCommand::Storage> begin_render_pass_commands;
     std::vector<ShaderAccessCommand::Storage> shader_access_commands;
     std::vector<DispatchIndirectCommand::Storage> dispatch_indirect_commands;
+    std::vector<DrawMeshTasksCommand::Storage> draw_mesh_tasks_commands;
 
     // Resources and additional data used by the commands
     std::vector<std::shared_ptr<const vvl::Buffer>> buffers;
@@ -347,6 +390,9 @@ struct CommandData {
     }
     CommandRef Store(const DispatchIndirectCommand::Storage& storage) {
         return Store(CommandType::kDispatchIndirect, dispatch_indirect_commands, storage);
+    }
+    CommandRef Store(const DrawMeshTasksCommand::Storage& storage) {
+        return Store(CommandType::kDrawMeshTasks, draw_mesh_tasks_commands, storage);
     }
 
   private:

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -1121,127 +1121,58 @@ void CommandBufferContext::RecordDrawVertexIndex(uint32_t indexCount, uint32_t f
     // RecordDrawVertex(?, ?, tag);
 }
 
-bool CommandBufferContext::ValidateDrawAttachment(const Location& loc) const {
-    bool skip = false;
-    if (current_renderpass_context_) {
-        skip |= current_renderpass_context_->ValidateDrawSubpassAttachment(*this, loc.function);
-    } else if (dynamic_rendering_info_) {
-        skip |= ValidateDrawDynamicRenderingAttachment(loc);
+static bool IsStencilWriteable(const LastBound& last_bound_state) {
+    if (!last_bound_state.IsStencilTestEnable()) {
+        return false;
     }
-    return skip;
+    auto is_writable = [&last_bound_state](const VkStencilOpState& ops) -> bool {
+        if (ops.writeMask == 0) {
+            return false;
+        }
+        // If compareOp is ALWAYS then failOp never runs (no writes possible)
+        const bool ignore_fail_op = (ops.compareOp == VK_COMPARE_OP_ALWAYS);
+
+        // If compareOp is NEVER then passOp never runs (no writes possible)
+        const bool ignore_pass_op = (ops.compareOp == VK_COMPARE_OP_NEVER);
+
+        // If depth test is not enabled then depthFailOp never runs (no writes possible)
+        const bool ignore_depth_fail_op = !last_bound_state.IsDepthTestEnable();
+
+        const bool is_read = (ops.failOp == VK_STENCIL_OP_KEEP || ignore_fail_op) &&
+                             (ops.passOp == VK_STENCIL_OP_KEEP || ignore_pass_op) &&
+                             (ops.depthFailOp == VK_STENCIL_OP_KEEP || ignore_depth_fail_op);
+        return !is_read;
+    };
+    const VkStencilOpState front_ops = last_bound_state.GetStencilOpStateFront();
+    const VkStencilOpState back_ops = last_bound_state.GetStencilOpStateBack();
+    return is_writable(front_ops) || is_writable(back_ops);
 }
 
-bool CommandBufferContext::ValidateDrawDynamicRenderingAttachment(const Location& location) const {
-    bool skip = false;
+DrawAttachmentCommand CommandBufferContext::GetDrawAttachmentCommand() const {
     const auto& last_bound_state = cb_state_->GetLastBoundGraphics();
-    const auto* pipe = last_bound_state.pipeline_state;
-    if (!pipe || pipe->RasterizationDisabled()) return skip;
+    const auto* pipeline = last_bound_state.pipeline_state;
 
-    const auto& list = pipe->fs_writable_output_location_list;
-    const AccessContext& access_context = GetCbAccessContext();
-
-    const DynamicRenderingInfo& info = *dynamic_rendering_info_;
-    for (const auto output_location : list) {
-        if (output_location >= info.info.colorAttachmentCount) {
-            continue;
-        }
-        const auto& attachment = info.attachments[output_location];
-        if (!attachment.IsWriteable(last_bound_state)) {
-            continue;
-        }
-        const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
-        ImageRangeGen view_gen = attachment.GetRangeGen(info.info.viewMask);
-        HazardResult hazard =
-            access_context.DetectAttachmentHazard(view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access);
-
-        if (hazard.IsHazard()) {
-            LogObjectList obj_list(cb_state_->Handle(), attachment.view->Handle());
-            Location loc = attachment.GetLocation(location, output_location);
-            const std::string error =
-                error_messages_.Error(environment_, hazard, location.function, sync_state_.FormatHandle(*attachment.view),
-                                      "DynamicRenderingAttachmentError");
-            skip |= sync_state_.SyncError(hazard.Hazard(), obj_list, loc.dot(vvl::Field::imageView), error);
-        }
+    // Draws in a secondary command buffer can write to the primary's render-pass attachments.
+    // We don't track those writes yet. Store a null pipeline so replay also skips
+    // tracking them, even when the primary's render-pass context becomes available.
+    if (!current_renderpass_context_ && !dynamic_rendering_info_) {
+        pipeline = nullptr;
     }
 
-    // TODO -- fixup this and Subpass attachment to correct map the various depth stencil enables/reads vs. writes
-    // PHASE1 TODO: Add layout based read/vs. write selection.
-    // PHASE1 TODO: Read operations for both depth and stencil are possible in the future.
-    // PHASE1 TODO: Add EARLY stage detection based on ExecutionMode.
-    for (size_t i = info.info.colorAttachmentCount; i < info.attachments.size(); i++) {
-        const auto& attachment = info.attachments[i];
-        bool writeable = attachment.IsWriteable(last_bound_state);
+    return {pipeline,
+            current_renderpass_context_,
+            dynamic_rendering_info_.get(),
+            current_render_pass_instance_id_,
+            pipeline && last_bound_state.IsDepthWriteEnable(),
+            pipeline && IsStencilWriteable(last_bound_state)};
+}
 
-        if (writeable) {
-            const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
-            ImageRangeGen view_gen = attachment.GetRangeGen(info.info.viewMask);
-            HazardResult hazard = access_context.DetectAttachmentHazard(
-                view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access);
-
-            if (hazard.IsHazard()) {
-                LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
-                Location loc = attachment.GetLocation(location);
-                const std::string error =
-                    error_messages_.Error(environment_, hazard, location.function, sync_state_.FormatHandle(*attachment.view),
-                                          "DynamicRenderingAttachmentError");
-                skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc.dot(vvl::Field::imageView), error);
-            }
-        }
-    }
-
-    return skip;
+bool CommandBufferContext::ValidateDrawAttachment(const Location& loc) const {
+    return GetDrawAttachmentCommand().Validate(*this, loc);
 }
 
 void CommandBufferContext::RecordDrawAttachment(const ResourceUsageTag tag) {
-    if (current_renderpass_context_) {
-        current_renderpass_context_->RecordDrawSubpassAttachment(*cb_state_, tag);
-    } else if (dynamic_rendering_info_) {
-        RecordDrawDynamicRenderingAttachment(tag);
-    }
-}
-
-void CommandBufferContext::RecordDrawDynamicRenderingAttachment(ResourceUsageTag tag) {
-    const auto& last_bound_state = cb_state_->GetLastBoundGraphics();
-    const auto* pipe = last_bound_state.pipeline_state;
-    if (!pipe || pipe->RasterizationDisabled()) {
-        return;
-    }
-
-    const auto& list = pipe->fs_writable_output_location_list;
-    auto& access_context = GetCbAccessContext();
-
-    const DynamicRenderingInfo& info = *dynamic_rendering_info_;
-    for (const auto output_location : list) {
-        if (output_location >= info.info.colorAttachmentCount) {
-            continue;
-        }
-        const auto& attachment = info.attachments[output_location];
-        if (!attachment.IsWriteable(last_bound_state)) {
-            continue;
-        }
-        const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
-        ImageRangeGen view_gen = attachment.GetRangeGen(info.info.viewMask);
-        access_context.UpdateAttachmentAccessState(view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access,
-                                                   ResourceUsageTagEx{tag});
-    }
-
-    // TODO -- fixup this and Subpass attachment to correct map the various depth stencil enables/reads vs. writes
-    // PHASE1 TODO: Add layout based read/vs. write selection.
-    // PHASE1 TODO: Read operations for both depth and stencil are possible in the future.
-    // PHASE1 TODO: Add EARLY stage detection based on ExecutionMode.
-
-    const uint32_t attachment_count = static_cast<uint32_t>(info.attachments.size());
-    for (uint32_t i = info.info.colorAttachmentCount; i < attachment_count; i++) {
-        const auto& attachment = info.attachments[i];
-        bool writeable = attachment.IsWriteable(last_bound_state);
-
-        if (writeable) {
-            const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
-            ImageRangeGen view_gen = attachment.GetRangeGen(info.info.viewMask);
-            access_context.UpdateAttachmentAccessState(view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                                       attachment_access, ResourceUsageTagEx{tag});
-        }
-    }
+    GetDrawAttachmentCommand().Apply(environment_, tag, *current_context_);
 }
 
 VkImageAspectFlags CommandBufferContext::GetAttachmentAspectsToClear(VkImageAspectFlags clear_aspect_mask,
@@ -1594,6 +1525,18 @@ void CommandBufferContext::RecordExecutedCommandBuffer(const CommandBufferContex
                 }
                 case CommandType::kDispatchIndirect: {
                     import_common(command_data.dispatch_indirect_commands[index], command_data, tag, entry.tag_count);
+                    continue;
+                }
+                case CommandType::kDrawMeshTasks: {
+                    auto command = command_data.draw_mesh_tasks_commands[index].MakeCommand(
+                        command_data, current_renderpass_context_, dynamic_rendering_info_.get());
+                    const uint32_t subpass =
+                        current_renderpass_context_ ? current_renderpass_context_->GetCurrentSubpass() : vvl::kNoIndex32;
+                    command.shader_accesses.render_pass_instance_id = current_render_pass_instance_id_;
+                    command.shader_accesses.subpass = subpass;
+                    command.attachment_accesses.render_pass_instance_id = current_render_pass_instance_id_;
+                    command.Apply(environment_, tag, *current_context_);
+                    StoreCommand(tag, command, entry.tag_count);
                     continue;
                 }
             }

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -230,14 +230,14 @@ class CommandBufferContext final : public ResourceUsageInfoProvider, public Debu
     DescriptorAccesses CollectDescriptorAccesses(VkPipelineBindPoint pipelineBindPoint) const;
     void RecordShaderAccesses(ResourceUsageTag tag, DescriptorAccesses& descriptor_accesses);
 
+    DrawAttachmentCommand GetDrawAttachmentCommand() const;
+
     bool ValidateDrawVertex(uint32_t vertexCount, uint32_t firstVertex, const Location& loc) const;
     void RecordDrawVertex(uint32_t vertexCount, uint32_t firstVertex, ResourceUsageTag tag);
     bool ValidateDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, const Location& loc) const;
     void RecordDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, ResourceUsageTag tag);
     bool ValidateDrawAttachment(const Location& loc) const;
-    bool ValidateDrawDynamicRenderingAttachment(const Location& loc) const;
     void RecordDrawAttachment(ResourceUsageTag tag);
-    void RecordDrawDynamicRenderingAttachment(ResourceUsageTag tag);
     bool ValidateClearAttachment(const Location& loc, const VkClearAttachment& clear_attachment, uint32_t clear_rect_index,
                                  const VkClearRect& clear_rect) const;
     void RecordClearAttachment(ResourceUsageTag tag, const VkClearAttachment& clear_attachment, const VkClearRect& clear_rect);

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -332,9 +332,20 @@ std::string ErrorMessages::ClearAttachmentError(const HazardResult& hazard, cons
     return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "ClearAttachmentError", additional_info);
 }
 
-std::string ErrorMessages::RenderPassAttachmentError(const HazardResult& hazard, const CommandBufferContext& cb_context,
-                                                     vvl::Func command, const std::string& resource_description) const {
-    return Error(cb_context.GetSyncEnvironment(), hazard, command, resource_description, "RenderPassAttachmentError");
+std::string ErrorMessages::RenderPassAttachmentError(const SyncEnvironment& env, const HazardResult& hazard,
+                                                     const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+                                                     const Location& loc, const std::string& resource_description) const {
+    AdditionalMessageInfo additional_info;
+    const vvl::Func command = AddReplayInfo(env, hazard, cb_context, replay_tag, loc, additional_info);
+    return Error(env, hazard, command, resource_description, "RenderPassAttachmentError", additional_info);
+}
+
+std::string ErrorMessages::DynamicRenderingAttachmentError(const SyncEnvironment& env, const HazardResult& hazard,
+                                                           const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+                                                           const Location& loc, const std::string& resource_description) const {
+    AdditionalMessageInfo additional_info;
+    const vvl::Func command = AddReplayInfo(env, hazard, cb_context, replay_tag, loc, additional_info);
+    return Error(env, hazard, command, resource_description, "DynamicRenderingAttachmentError", additional_info);
 }
 
 static const char* GetLoadOpActionName(VkAttachmentLoadOp load_op) {

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -111,8 +111,13 @@ class ErrorMessages {
                                      const std::string& resource_description, VkImageAspectFlags clear_aspects,
                                      uint32_t clear_rect_index, const VkClearRect& clear_rect) const;
 
-    std::string RenderPassAttachmentError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
+    std::string RenderPassAttachmentError(const SyncEnvironment& env, const HazardResult& hazard,
+                                          const CommandBufferContext& cb_context, ResourceUsageTag replay_tag, const Location& loc,
                                           const std::string& resource_description) const;
+
+    std::string DynamicRenderingAttachmentError(const SyncEnvironment& env, const HazardResult& hazard,
+                                                const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+                                                const Location& loc, const std::string& resource_description) const;
 
     std::string BeginRenderingError(const HazardResult& hazard, const CommandBufferContext& cb_context, vvl::Func command,
                                     const std::string& resource_description, VkAttachmentLoadOp load_op) const;

--- a/layers/sync/sync_render_pass.cpp
+++ b/layers/sync/sync_render_pass.cpp
@@ -395,42 +395,6 @@ bool RenderPassAccessContext::ValidateStoreOperation(const SyncEnvironment& env,
     return skip;
 }
 
-static bool IsDepthAttachmentWriteable(const LastBound& last_bound_state, const VkFormat format) {
-    const bool depth_write_enable = last_bound_state.IsDepthWriteEnable();
-    return (vkuFormatIsDepthAndStencil(format) || vkuFormatIsDepthOnly(format)) && depth_write_enable;
-}
-
-static bool IsStencilAttachmentWriteable(const LastBound& last_bound_state, const VkFormat format) {
-    if (!vkuFormatIsDepthAndStencil(format) && !vkuFormatIsStencilOnly(format)) {
-        return false;
-    }
-    if (!last_bound_state.IsStencilTestEnable()) {
-        return false;
-    }
-    auto is_writable = [&last_bound_state](const VkStencilOpState& ops) -> bool {
-        if (ops.writeMask == 0) {
-            return false;
-        }
-
-        // If compareOp is ALWAYS then failOp never runs (no writes possible)
-        const bool ignore_fail_op = (ops.compareOp == VK_COMPARE_OP_ALWAYS);
-
-        // If compareOp is NEVER then passOp never runs (no writes possible)
-        const bool ignore_pass_op = (ops.compareOp == VK_COMPARE_OP_NEVER);
-
-        // If depth test is not enabled then depthFailOp never runs (no writes possible)
-        const bool ignore_depth_fail_op = !last_bound_state.IsDepthTestEnable();
-
-        const bool is_read = (ops.failOp == VK_STENCIL_OP_KEEP || ignore_fail_op) &&
-                             (ops.passOp == VK_STENCIL_OP_KEEP || ignore_pass_op) &&
-                             (ops.depthFailOp == VK_STENCIL_OP_KEEP || ignore_depth_fail_op);
-        return !is_read;
-    };
-    const VkStencilOpState front_ops = last_bound_state.GetStencilOpStateFront();
-    const VkStencilOpState back_ops = last_bound_state.GetStencilOpStateBack();
-    return is_writable(front_ops) || is_writable(back_ops);
-}
-
 // Traverse the attachment resolves for this a specific subpass, and do action() to them.
 // Used by both validation and record operations
 //
@@ -588,37 +552,35 @@ static uint32_t GetSubpassDepthStencilAttachmentIndex(const vku::safe_VkPipeline
     return (pipe_ds_ci && depth_stencil_ref) ? depth_stencil_ref->attachment : VK_ATTACHMENT_UNUSED;
 }
 
-bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferContext& cb_context, vvl::Func command) const {
+bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const SyncEnvironment& env, const CommandBufferContext& cb_context,
+                                                            ResourceUsageTag replay_tag, const Location& loc,
+                                                            const vvl::Pipeline* pipeline, bool depth_write_enabled,
+                                                            bool stencil_write_enabled) const {
     bool skip = false;
-    const vvl::CommandBuffer& cmd_buffer = cb_context.GetCBState();
-    const auto& last_bound_state = cmd_buffer.GetLastBoundGraphics();
-    const auto* pipe = last_bound_state.pipeline_state;
-
-    if (!pipe || pipe->RasterizationDisabled()) {
+    if (!pipeline || pipeline->RasterizationDisabled()) {
         return skip;
     }
-
-    const auto& list = pipe->fs_writable_output_location_list;
+    const auto& list = pipeline->fs_writable_output_location_list;
     const auto& subpass = rp_state_->create_info.pSubpasses[current_subpass_];
-    const auto& current_context = CurrentContext();
-    const SyncValidator& sync_state = cb_context.GetSyncState();
+    const AccessContext& current_context = CurrentContext();
 
-    auto report_atachment_hazard = [&sync_state, &cb_context, command](const HazardResult& hazard,
-                                                                       const vvl::ImageView& attachment_view,
-                                                                       std::string_view attachment_description) {
+    auto report_atachment_hazard = [&env, &cb_context, replay_tag, &loc](const HazardResult& hazard,
+                                                                         const vvl::ImageView& attachment_view,
+                                                                         std::string_view attachment_description) {
+        const SyncValidator& validator = env.validator;
         const vvl::Image& attachment_image = *attachment_view.image_state;
-        LogObjectList objlist(cb_context.GetCBState().Handle(), attachment_view.Handle(), attachment_image.Handle());
-        const Location loc(command);
+        LogObjectList objlist = BaseObjectList(env, cb_context, attachment_view.Handle());
+        objlist.add(attachment_image.Handle());
 
         std::ostringstream ss;
         ss << attachment_description;
-        ss << " (" << sync_state.FormatHandle(attachment_view.Handle());
-        ss << ", " << sync_state.FormatHandle(attachment_image.Handle()) << ")";
+        ss << " (" << validator.FormatHandle(attachment_view.Handle());
+        ss << ", " << validator.FormatHandle(attachment_image.Handle()) << ")";
         const std::string resource_description = ss.str();
 
         const std::string error =
-            sync_state.error_messages_.RenderPassAttachmentError(hazard, cb_context, command, resource_description);
-        return sync_state.SyncError(hazard.Hazard(), objlist, loc, error);
+            validator.error_messages_.RenderPassAttachmentError(env, hazard, cb_context, replay_tag, loc, resource_description);
+        return validator.SyncError(hazard.Hazard(), objlist, loc, error);
     };
 
     // Subpass's inputAttachment has been done in ValidateDispatchDrawDescriptorSet
@@ -632,35 +594,35 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferC
             const AttachmentViewGen& view_gen = attachment_views_[subpass.pColorAttachments[location].attachment];
             HazardResult hazard = current_context.DetectAttachmentHazard(view_gen, AttachmentViewGen::Gen::kRenderArea,
                                                                          SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE,
-                                                                         attachment_access, subpass.viewMask);
+                                                                         attachment_access, subpass.viewMask, env.queue_id);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
-                ss << "color attachment " << location << " in subpass " << cmd_buffer.GetActiveSubpass();
+                ss << "color attachment " << location << " in subpass " << current_subpass_;
                 const std::string attachment_description = ss.str();
                 skip |= report_atachment_hazard(hazard, *view_gen.GetViewState(), attachment_description);
             }
         }
     }
 
-    // PHASE1 TODO: Read operations for both depth and stencil are possible in the future.
-    const auto ds_state = pipe->DepthStencilState();
+    // TODO: Read operations for both depth and stencil are possible in the future.
+    const auto ds_state = pipeline->DepthStencilState();
     const uint32_t depth_stencil_attachment = GetSubpassDepthStencilAttachmentIndex(ds_state, subpass.pDepthStencilAttachment);
 
     if (depth_stencil_attachment != VK_ATTACHMENT_UNUSED) {
         const AttachmentViewGen& view_gen = attachment_views_[depth_stencil_attachment];
         const vvl::ImageView& view_state = *view_gen.GetViewState();
         const VkFormat ds_format = view_state.create_info.format;
-        const bool depth_write = IsDepthAttachmentWriteable(last_bound_state, ds_format);
-        const bool stencil_write = IsStencilAttachmentWriteable(last_bound_state, ds_format);
+        const bool depth_write = depth_write_enabled && vkuFormatHasDepth(ds_format);
+        const bool stencil_write = stencil_write_enabled && vkuFormatHasStencil(ds_format);
 
         if (depth_write) {
             const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
             HazardResult hazard = current_context.DetectAttachmentHazard(view_gen, AttachmentViewGen::Gen::kDepthOnlyRenderArea,
                                                                          SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                                                         attachment_access, subpass.viewMask);
+                                                                         attachment_access, subpass.viewMask, env.queue_id);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
-                ss << "depth aspect of depth-stencil attachment in subpass " << cmd_buffer.GetActiveSubpass();
+                ss << "depth aspect of depth-stencil attachment in subpass " << current_subpass_;
                 const std::string attachment_description = ss.str();
                 skip |= report_atachment_hazard(hazard, view_state, attachment_description);
             }
@@ -669,10 +631,10 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferC
             const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
             HazardResult hazard = current_context.DetectAttachmentHazard(view_gen, AttachmentViewGen::Gen::kStencilOnlyRenderArea,
                                                                          SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                                                         attachment_access, subpass.viewMask);
+                                                                         attachment_access, subpass.viewMask, env.queue_id);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
-                ss << "stencil aspect of depth-stencil attachment in subpass " << cmd_buffer.GetActiveSubpass();
+                ss << "stencil aspect of depth-stencil attachment in subpass " << current_subpass_;
                 const std::string attachment_description = ss.str();
                 skip |= report_atachment_hazard(hazard, view_state, attachment_description);
             }
@@ -681,17 +643,15 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferC
     return skip;
 }
 
-void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuffer& cmd_buffer, const ResourceUsageTag tag) {
-    const auto& last_bound_state = cmd_buffer.GetLastBoundGraphics();
-    const auto* pipe = last_bound_state.pipeline_state;
-    if (!pipe || pipe->RasterizationDisabled()) {
+void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::Pipeline* pipeline, bool depth_write_enabled,
+                                                          bool stencil_write_enabled, ResourceUsageTag tag, QueueId queue_id) {
+    if (!pipeline || pipeline->RasterizationDisabled()) {
         return;
     }
-
-    const auto& list = pipe->fs_writable_output_location_list;
+    const auto& list = pipeline->fs_writable_output_location_list;
     const auto& subpass = rp_state_->create_info.pSubpasses[current_subpass_];
+    AccessContext& current_context = CurrentContext();
 
-    auto& current_context = CurrentContext();
     // Subpass's inputAttachment has been done in RecordDispatchDrawDescriptorSet
     if (subpass.pColorAttachments && subpass.colorAttachmentCount && !list.empty()) {
         for (const auto location : list) {
@@ -703,26 +663,26 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
             const AttachmentViewGen& view_gen = attachment_views_[subpass.pColorAttachments[location].attachment];
             current_context.UpdateAttachmentAccessState(view_gen, AttachmentViewGen::Gen::kRenderArea,
                                                         SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access,
-                                                        ResourceUsageTagEx{tag}, subpass.viewMask);
+                                                        ResourceUsageTagEx{tag}, subpass.viewMask, queue_id);
         }
     }
 
-    // PHASE1 TODO: Read operations for both depth and stencil are possible in the future.
-    const auto* ds_state = pipe->DepthStencilState();
+    // TODO: Read operations for both depth and stencil are possible in the future
+    const auto* ds_state = pipeline->DepthStencilState();
     const uint32_t depth_stencil_attachment = GetSubpassDepthStencilAttachmentIndex(ds_state, subpass.pDepthStencilAttachment);
     if (depth_stencil_attachment != VK_ATTACHMENT_UNUSED) {
         const AttachmentViewGen& view_gen = attachment_views_[depth_stencil_attachment];
         const vvl::ImageView& view_state = *view_gen.GetViewState();
         const VkFormat ds_format = view_state.create_info.format;
-        const bool depth_write = IsDepthAttachmentWriteable(last_bound_state, ds_format);
-        const bool stencil_write = IsStencilAttachmentWriteable(last_bound_state, ds_format);
+        const bool depth_write = depth_write_enabled && vkuFormatHasDepth(ds_format);
+        const bool stencil_write = stencil_write_enabled && vkuFormatHasStencil(ds_format);
 
         if (depth_write || stencil_write) {
             const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
             const auto ds_gentype = view_gen.GetDepthStencilRenderAreaGenType(depth_write, stencil_write);
             current_context.UpdateAttachmentAccessState(view_gen, ds_gentype,
                                                         SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access,
-                                                        ResourceUsageTagEx{tag}, subpass.viewMask);
+                                                        ResourceUsageTagEx{tag}, subpass.viewMask, queue_id);
         }
     }
 }
@@ -1096,6 +1056,114 @@ const vvl::ImageView* DynamicRenderingInfo::GetClearAttachmentView(const VkClear
     return attachment_view;
 }
 
+bool DynamicRenderingInfo::ValidateDrawAttachments(const SyncEnvironment& env, const AccessContext& access_context,
+                                                   const CommandBufferContext& cb_context, ResourceUsageTag replay_tag,
+                                                   const Location& loc, uint32_t render_pass_instance_id,
+                                                   const vvl::Pipeline* pipeline, bool depth_write, bool stencil_write) const {
+    bool skip = false;
+    if (!pipeline || pipeline->RasterizationDisabled()) {
+        return skip;
+    }
+
+    const auto& list = pipeline->fs_writable_output_location_list;
+    const SyncValidator& validator = env.validator;
+
+    for (const auto output_location : list) {
+        if (output_location >= info.colorAttachmentCount) {
+            continue;
+        }
+        const auto& attachment = attachments[output_location];
+        if (!attachment.IsWriteable(depth_write, stencil_write)) {
+            continue;
+        }
+        const AttachmentAccess attachment_access{AttachmentAccessType::Access, SyncOrdering::kColorAttachment,
+                                                 render_pass_instance_id, vvl::kNoIndex32};
+        ImageRangeGen view_gen = attachment.GetRangeGen(info.viewMask);
+        HazardResult hazard = access_context.DetectAttachmentHazard(view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE,
+                                                                    attachment_access, env.queue_id);
+
+        if (hazard.IsHazard()) {
+            const LogObjectList objlist = BaseObjectList(env, cb_context, attachment.view->Handle());
+            const Location attachment_loc = attachment.GetLocation(loc, output_location);
+            const Location location = replay_tag == kInvalidTag ? attachment_loc.dot(vvl::Field::imageView) : loc;
+            const std::string error = validator.error_messages_.DynamicRenderingAttachmentError(
+                env, hazard, cb_context, replay_tag, loc, validator.FormatHandle(*attachment.view));
+            skip |= validator.SyncError(hazard.Hazard(), objlist, location, error);
+        }
+    }
+
+    // TODO -- fixup this and Subpass attachment to correct map the various depth stencil enables/reads vs. writes
+    // PHASE1 TODO: Add layout based read/vs. write selection.
+    // PHASE1 TODO: Read operations for both depth and stencil are possible in the future.
+    // PHASE1 TODO: Add EARLY stage detection based on ExecutionMode.
+    for (size_t i = info.colorAttachmentCount; i < attachments.size(); i++) {
+        const auto& attachment = attachments[i];
+        bool writeable = attachment.IsWriteable(depth_write, stencil_write);
+
+        if (writeable) {
+            const AttachmentAccess attachment_access{AttachmentAccessType::Access, SyncOrdering::kDepthStencilAttachment,
+                                                     render_pass_instance_id, vvl::kNoIndex32};
+            ImageRangeGen view_gen = attachment.GetRangeGen(info.viewMask);
+            HazardResult hazard = access_context.DetectAttachmentHazard(
+                view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access, env.queue_id);
+
+            if (hazard.IsHazard()) {
+                const LogObjectList objlist = BaseObjectList(env, cb_context, attachment.view->Handle());
+                const Location attachment_loc = attachment.GetLocation(loc);
+                const Location location = replay_tag == kInvalidTag ? attachment_loc.dot(vvl::Field::imageView) : loc;
+                const std::string error = validator.error_messages_.DynamicRenderingAttachmentError(
+                    env, hazard, cb_context, replay_tag, loc, validator.FormatHandle(*attachment.view));
+                skip |= validator.SyncError(hazard.Hazard(), objlist, location, error);
+            }
+        }
+    }
+    return skip;
+}
+
+void DynamicRenderingInfo::RecordDrawAttachments(AccessContext& access_context, uint32_t render_pass_instance_id,
+                                                 const vvl::Pipeline* pipeline, bool depth_write, bool stencil_write,
+                                                 ResourceUsageTag tag, QueueId queue_id) const {
+    if (!pipeline || pipeline->RasterizationDisabled()) {
+        return;
+    }
+
+    const auto& list = pipeline->fs_writable_output_location_list;
+
+    for (const auto output_location : list) {
+        if (output_location >= info.colorAttachmentCount) {
+            continue;
+        }
+        const auto& attachment = attachments[output_location];
+        if (!attachment.IsWriteable(depth_write, stencil_write)) {
+            continue;
+        }
+        const AttachmentAccess attachment_access{AttachmentAccessType::Access, SyncOrdering::kColorAttachment,
+                                                 render_pass_instance_id, vvl::kNoIndex32};
+        ImageRangeGen view_gen = attachment.GetRangeGen(info.viewMask);
+        access_context.UpdateAttachmentAccessState(view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access,
+                                                   ResourceUsageTagEx{tag}, queue_id);
+    }
+
+    // TODO -- fixup this and Subpass attachment to correct map the various depth stencil enables/reads vs. writes
+    // PHASE1 TODO: Add layout based read/vs. write selection.
+    // PHASE1 TODO: Read operations for both depth and stencil are possible in the future.
+    // PHASE1 TODO: Add EARLY stage detection based on ExecutionMode.
+
+    const uint32_t attachment_count = static_cast<uint32_t>(attachments.size());
+    for (uint32_t i = info.colorAttachmentCount; i < attachment_count; i++) {
+        const auto& attachment = attachments[i];
+        bool writeable = attachment.IsWriteable(depth_write, stencil_write);
+
+        if (writeable) {
+            const AttachmentAccess attachment_access{AttachmentAccessType::Access, SyncOrdering::kDepthStencilAttachment,
+                                                     render_pass_instance_id, vvl::kNoIndex32};
+            ImageRangeGen view_gen = attachment.GetRangeGen(info.viewMask);
+            access_context.UpdateAttachmentAccessState(view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
+                                                       attachment_access, ResourceUsageTagEx{tag}, queue_id);
+        }
+    }
+}
+
 DynamicRenderingInfo::Attachment::Attachment(const SyncValidator& state, const vku::safe_VkRenderingAttachmentInfo& attachment_info,
                                              AttachmentType type_, const VkOffset3D& offset, const VkExtent3D& extent)
     : info(attachment_info), view(state.Get<vvl::ImageView>(attachment_info.imageView)), view_gen(), type(type_) {
@@ -1162,19 +1230,17 @@ Location DynamicRenderingInfo::Attachment::GetLocation(const Location& loc, uint
     }
 }
 
-bool DynamicRenderingInfo::Attachment::IsWriteable(const LastBound& last_bound_state) const {
-    bool writeable = IsValid();
-    if (writeable) {
-        //  Depth and Stencil have additional criteria
-        if (type == AttachmentType::kDepth) {
-            writeable =
-                last_bound_state.IsDepthWriteEnable() && IsDepthAttachmentWriteable(last_bound_state, view->create_info.format);
-        } else if (type == AttachmentType::kStencil) {
-            writeable =
-                last_bound_state.IsStencilTestEnable() && IsStencilAttachmentWriteable(last_bound_state, view->create_info.format);
-        }
+bool DynamicRenderingInfo::Attachment::IsWriteable(bool depth_write, bool stencil_write) const {
+    if (!IsValid()) {
+        return false;
     }
-    return writeable;
+    if (type == AttachmentType::kDepth) {
+        return depth_write && vkuFormatHasDepth(view->create_info.format);
+    } else if (type == AttachmentType::kStencil) {
+        return stencil_write && vkuFormatHasStencil(view->create_info.format);
+    } else {
+        return true;
+    }
 }
 
 }  // namespace syncval

--- a/layers/sync/sync_render_pass.h
+++ b/layers/sync/sync_render_pass.h
@@ -24,10 +24,9 @@
 #include <vulkan/vulkan.h>
 #include <optional>
 
-struct LastBound;
-
 namespace vvl {
 class CommandBuffer;
+class Pipeline;
 class RenderPass;
 }  // namespace vvl
 
@@ -55,7 +54,7 @@ struct DynamicRenderingInfo {
         SyncAccessIndex GetStoreUsage() const;
         SyncOrdering GetOrdering() const;
         Location GetLocation(const Location& loc, uint32_t index = 0) const;
-        bool IsWriteable(const LastBound& last_bound_state) const;
+        bool IsWriteable(bool depth_write, bool stencil_write) const;
         bool IsValid() const { return view.get(); }
     };
 
@@ -68,6 +67,13 @@ struct DynamicRenderingInfo {
     DynamicRenderingInfo(const SyncValidator& state, const VkRenderingInfo& rendering_info);
 
     const vvl::ImageView* GetClearAttachmentView(const VkClearAttachment& clear_attachment) const;
+
+    bool ValidateDrawAttachments(const SyncEnvironment& env, const AccessContext& access_context,
+                                 const CommandBufferContext& cb_context, ResourceUsageTag replay_tag, const Location& loc,
+                                 uint32_t render_pass_instance_id, const vvl::Pipeline* pipeline, bool depth_write,
+                                 bool stencil_write) const;
+    void RecordDrawAttachments(AccessContext& access_context, uint32_t render_pass_instance_id, const vvl::Pipeline* pipeline,
+                               bool depth_write, bool stencil_write, ResourceUsageTag tag, QueueId queue_id) const;
 
     vku::safe_VkRenderingInfo info;
     std::vector<Attachment> attachments;  // All attachments (with internal typing)
@@ -121,8 +127,11 @@ class RenderPassAccessContext {
                                         const AttachmentViewGenVector& attachment_views, const ResourceUsageTag tag,
                                         AccessContext& access_context);
 
-    bool ValidateDrawSubpassAttachment(const CommandBufferContext& cb_context, vvl::Func command) const;
-    void RecordDrawSubpassAttachment(const vvl::CommandBuffer& cmd_buffer, ResourceUsageTag tag);
+    bool ValidateDrawSubpassAttachment(const SyncEnvironment& env, const CommandBufferContext& cb_context,
+                                       ResourceUsageTag replay_tag, const Location& loc, const vvl::Pipeline* pipeline,
+                                       bool depth_write_enabled, bool stencil_write_enabled) const;
+    void RecordDrawSubpassAttachment(const vvl::Pipeline* pipeline, bool depth_write_enabled, bool stencil_write_enabled,
+                                     ResourceUsageTag tag, QueueId queue_id);
 
     const vvl::ImageView* GetClearAttachmentView(const VkClearAttachment& clear_attachment) const;
 

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1456,13 +1456,18 @@ void SyncValidator::PostCallRecordCmdDrawIndexedIndirectCountAMD(VkCommandBuffer
 
 bool SyncValidator::PreCallValidateCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                                        uint32_t groupCountZ, const ErrorObject& error_obj) const {
-    bool skip = false;
+    if (!syncval_settings.IsRecordTimeValidationEnabled()) {
+        return false;
+    }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
-    skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
-    skip |= cb_context.ValidateDrawAttachment(error_obj.location);
-    return skip;
+    const auto descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_GRAPHICS);
+    const DrawMeshTasksCommand command{
+        ShaderAccessCommand{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses, descriptor_accesses.image_accesses,
+                            descriptor_accesses.render_pass_instance_id, descriptor_accesses.subpass},
+        cb_context.GetDrawAttachmentCommand()};
+    return command.Validate(cb_context, error_obj.location);
 }
 
 void SyncValidator::PostCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
@@ -1471,8 +1476,23 @@ void SyncValidator::PostCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuf
     CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
-    cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
-    cb_context.RecordDrawAttachment(tag);
+    auto descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_GRAPHICS);
+    for (auto& access : descriptor_accesses.buffer_accesses) {
+        access.handle_index = cb_context.AddCommandHandle(tag, access.info.resource_handle).handle_index;
+    }
+    for (auto& access : descriptor_accesses.image_accesses) {
+        access.handle_index = cb_context.AddCommandHandle(tag, access.image_view->image_state->Handle()).handle_index;
+    }
+    const DrawMeshTasksCommand command{
+        ShaderAccessCommand{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses, descriptor_accesses.image_accesses,
+                            descriptor_accesses.render_pass_instance_id, descriptor_accesses.subpass},
+        cb_context.GetDrawAttachmentCommand()};
+    if (syncval_settings.IsRecordTimeValidationEnabled()) {
+        command.Apply(cb_context.GetSyncEnvironment(), tag, cb_context.GetCurrentAccessContext());
+    }
+    if (syncval_settings.full_validation) {
+        cb_context.StoreCommand(tag, command);
+    }
 }
 
 bool SyncValidator::PreCallValidateCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,


### PR DESCRIPTION
Adds `DrawAttachmentCommand` that will be used by most draw commands.
For now it is used to implement `vkCmdDrawMeshTasksEXT` (the simplest draw since it does not need to check vertex/index buffers).
