### PR TITLE
layers: Unify BufferAddressValidation range bound check

### DIFF
--- a/layers/core_checks/cc_buffer_address.h
+++ b/layers/core_checks/cc_buffer_address.h
@@ -85,16 +85,20 @@ class BufferAddressValidation {
         ErrorMsgBuffer error_msg_buffer_func;
     };
 
-    // +1 for extra check for "valid generic VkDeviceAddress" check
-    std::array<VuidAndValidation, ChecksCount + 1> vuid_and_validations;
+    // ValidateDeviceAddress has two internal slot it uses:
+    //   [ChecksCount + 0] - "valid generic VkDeviceAddress" check (always)
+    //   [ChecksCount + 1] - "range fits inside the buffer" check (when caller passes a range VUID)
+    std::array<VuidAndValidation, ChecksCount + 2> vuid_and_validations;
     // There are times the caller will want to update state for each buffer object found
     UpdateCallback update_callback = [](const vvl::Buffer&) {};
 
     // We use vvl::DeviceProxy instead of CoreChecks here as a current hack to allow GPU-AV to use this. We still need a better
     // system to share CoreChecks with GPU-AV
+    //
+    // |range_size| and |range_vuid| are passed when caller has a range and wants to do the "does it fit" check
     [[nodiscard]] bool ValidateDeviceAddress(const vvl::DeviceProxy& validator, const Location& device_address_loc,
                                              const LogObjectList& objlist, VkDeviceAddress device_address,
-                                             VkDeviceSize range_size = 0) noexcept {
+                                             VkDeviceSize range_size = 0, std::string_view range_vuid = {}) noexcept {
         bool skip = false;
         // There will be an implicit VU like "must be a valid VkDeviceAddress value" and if can't be zero, stateless validation
         // should have caught this already
@@ -122,6 +126,7 @@ class BufferAddressValidation {
                 }
             }
             skip |= validator.LogError("VUID-VkDeviceAddress-size-11364", objlist, device_address_loc, "%s", ss.str().c_str());
+            return skip;  // Without any buffer nothing left to validate
         }
 
         // Checks if memory is in a completely and contiguously to a single VkDeviceMemory object
@@ -139,20 +144,36 @@ class BufferAddressValidation {
                 return std::string("buffer has not been bound to memory");
             }};
 
-        if (!HasValidBuffer(buffer_list)) {
-            skip |= LogInvalidBuffers(validator, buffer_list, device_address_loc, objlist, device_address, range_size);
+        size_t active_checks = ChecksCount + 1;
+
+        if (!range_vuid.empty() && range_size != 0) {
+            const vvl::range<VkDeviceAddress> required_range(device_address, device_address + range_size);
+            vuid_and_validations[ChecksCount + 1] = {
+                range_vuid,
+                [required_range](const vvl::Buffer& buffer_state) {
+                    // .valid() here ensures any overflow or bad values are ignored
+                    return !required_range.valid() || !buffer_state.DeviceAddressRange().includes(required_range);
+                },
+                []() { return "The following buffers are too small to hold the range"; }, kEmptyErrorMsgBuffer};
+            active_checks = ChecksCount + 2;
+        }
+
+        if (!HasValidBuffer(buffer_list, active_checks)) {
+            skip |=
+                LogInvalidBuffers(validator, buffer_list, device_address_loc, objlist, device_address, range_size, active_checks);
         }
         return skip;
     }
 
   private:
     // Look for a buffer that satisfies all VUIDs
-    [[nodiscard]] bool HasValidBuffer(vvl::span<vvl::Buffer* const> buffer_list) const noexcept;
+    [[nodiscard]] bool HasValidBuffer(vvl::span<vvl::Buffer* const> buffer_list, size_t active_checks) const noexcept;
     // For every vuid, build an error mentioning every buffer from buffer_list that violates it, then log this error
     // using details provided by the other parameters.
     [[nodiscard]] bool LogInvalidBuffers(const vvl::DeviceProxy& validator, vvl::span<vvl::Buffer* const> buffer_list,
                                          const Location& device_address_loc, const LogObjectList& objlist,
-                                         VkDeviceAddress device_address, VkDeviceSize range_size) const noexcept;
+                                         VkDeviceAddress device_address, VkDeviceSize range_size,
+                                         size_t active_checks) const noexcept;
 
     struct Error {
         LogObjectList objlist;
@@ -162,7 +183,8 @@ class BufferAddressValidation {
 };
 
 template <size_t ChecksCount>
-bool BufferAddressValidation<ChecksCount>::HasValidBuffer(vvl::span<vvl::Buffer* const> buffer_list) const noexcept {
+bool BufferAddressValidation<ChecksCount>::HasValidBuffer(vvl::span<vvl::Buffer* const> buffer_list,
+                                                          size_t active_checks) const noexcept {
     bool any_buffer_found = false;
     for (const auto& buffer : buffer_list) {
         ASSERT_AND_CONTINUE(buffer);
@@ -173,8 +195,8 @@ bool BufferAddressValidation<ChecksCount>::HasValidBuffer(vvl::span<vvl::Buffer*
         bool is_buffer_valid = true;
         // Once we find any buffer is valid, can just skip checking
         if (!any_buffer_found) {
-            for (const auto& vav : vuid_and_validations) {
-                if (vav.is_invalid_func(*buffer)) {
+            for (size_t i = 0; i < active_checks; ++i) {
+                if (vuid_and_validations[i].is_invalid_func(*buffer)) {
                     is_buffer_valid = false;
                     break;
                 }
@@ -190,9 +212,9 @@ template <size_t ChecksCount>
 bool BufferAddressValidation<ChecksCount>::LogInvalidBuffers(const vvl::DeviceProxy& validator,
                                                              vvl::span<vvl::Buffer* const> buffer_list,
                                                              const Location& device_address_loc, const LogObjectList& objlist,
-                                                             VkDeviceAddress device_address,
-                                                             VkDeviceSize range_size) const noexcept {
-    std::array<Error, ChecksCount + 1> errors;
+                                                             VkDeviceAddress device_address, VkDeviceSize range_size,
+                                                             size_t active_checks) const noexcept {
+    std::array<Error, ChecksCount + 2> errors;
 
     // Build error message beginning. Then, only per buffer error needs to be appended.
     std::string error_msg_beginning;
@@ -226,7 +248,7 @@ bool BufferAddressValidation<ChecksCount>::LogInvalidBuffers(const vvl::DevicePr
     for (const auto& buffer : buffer_list) {
         ASSERT_AND_CONTINUE(buffer);
 
-        for (size_t i = 0; i < (ChecksCount + 1); ++i) {
+        for (size_t i = 0; i < active_checks; ++i) {
             [[maybe_unused]] const auto& [vuid, is_invalid_func, error_msg_header_func, error_msg_buffer_func] =
                 vuid_and_validations[i];
 
@@ -256,7 +278,7 @@ bool BufferAddressValidation<ChecksCount>::LogInvalidBuffers(const vvl::DevicePr
 
     // Output the error messages
     bool skip = false;
-    for (size_t i = 0; i < (ChecksCount + 1); ++i) {
+    for (size_t i = 0; i < active_checks; ++i) {
         const auto& vav = vuid_and_validations[i];
         auto& error = errors[i];
         if (!error.Empty()) {

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -3322,24 +3322,14 @@ bool CoreChecks::ValidateDescriptorAddressInfoEXT(const VkDescriptorAddressInfoE
         }
     }
 
-    BufferAddressValidation<2> buffer_address_validator = {
-        {{{"VUID-VkDescriptorAddressInfoEXT-range-08045",
-           [&address_info](const vvl::Buffer& buffer_state) {
-               const VkDeviceSize end = buffer_state.GetSize() - (address_info.address - buffer_state.deviceAddress);
-               return address_info.range > end;
-           },
-           [&address_info]() {
-               return "The VkDescriptorAddressInfoEXT::range (" + std::to_string(address_info.range) +
-                      ") bytes does not fit in any buffer";
-           },
-           kEmptyErrorMsgBuffer},
-
-          {usage_vuid, [buffer_usage](const vvl::Buffer& buffer_state) { return (buffer_state.usage & buffer_usage) == 0; },
+    BufferAddressValidation<1> buffer_address_validator = {
+        {{{usage_vuid, [buffer_usage](const vvl::Buffer& buffer_state) { return (buffer_state.usage & buffer_usage) == 0; },
            [buffer_usage]() { return "The following buffers are missing " + string_VkBufferUsageFlags(buffer_usage); },
            kUsageErrorMsgBuffer}}}};
 
     skip |= buffer_address_validator.ValidateDeviceAddress(*this, address_loc.dot(Field::address), LogObjectList(device),
-                                                           address_info.address, address_info.range);
+                                                           address_info.address, address_info.range,
+                                                           "VUID-VkDescriptorAddressInfoEXT-range-08045");
 
     return skip;
 }

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -2938,22 +2938,12 @@ bool CoreChecks::ValidateDeviceAddressRange(VkDeviceAddress address, VkDeviceSiz
     }
 
     vuid = strided ? "VUID-VkStridedDeviceAddressRangeKHR-address-11365" : "VUID-VkDeviceAddressRangeKHR-address-11365";
-    BufferAddressValidation<2> buffer_address_validator = {
-        {{{vuid,
-           [address, size](const vvl::Buffer& buffer_state) {
-               const VkDeviceSize end = buffer_state.GetSize() - (address - buffer_state.deviceAddress);
-               return size > end;
-           },
-           [strided, size]() {
-               std::string s = strided ? "VkStridedDeviceAddressRangeKHR" : "VkDeviceAddressRangeEXT";
-               return "The " + s + "::size (" + std::to_string(size) + ") bytes does not fit in any buffer";
-           },
-           kEmptyErrorMsgBuffer},
-          {usage_vuid, [usage](const vvl::Buffer& buffer_state) { return (buffer_state.usage & usage) == 0; },
+    BufferAddressValidation<1> buffer_address_validator = {
+        {{{usage_vuid, [usage](const vvl::Buffer& buffer_state) { return (buffer_state.usage & usage) == 0; },
            [usage]() { return std::string("The following buffers are missing ") + string_VkBufferUsageFlags2(usage); },
            kUsageErrorMsgBuffer}}}};
 
-    skip |= buffer_address_validator.ValidateDeviceAddress(*this, loc.dot(Field::address), objlist, address, size);
+    skip |= buffer_address_validator.ValidateDeviceAddress(*this, loc.dot(Field::address), objlist, address, size, vuid);
 
     return skip;
 }
@@ -3082,16 +3072,8 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryEXT(VkCommandBuffer commandBu
             const VkDeviceAddress start = region.srcAddress;
             const VkDeviceSize size = region.compressedSize;
 
-            BufferAddressValidation<2> buffer_address_validator = {
-                {{{"VUID-VkDecompressMemoryRegionEXT-srcAddress-07686",
-                   [start, size](const vvl::Buffer& buffer_state) {
-                       const VkDeviceSize end =
-                           buffer_state.GetSize() - static_cast<VkDeviceSize>(start - buffer_state.deviceAddress);
-                       return size > end;
-                   },
-                   [size]() { return "The compressedSize (" + std::to_string(size) + ") does not fit in any buffer"; },
-                   kEmptyErrorMsgBuffer},
-                  {"VUID-VkDecompressMemoryRegionEXT-srcAddress-11764",
+            BufferAddressValidation<1> buffer_address_validator = {
+                {{{"VUID-VkDecompressMemoryRegionEXT-srcAddress-11764",
                    [](const vvl::Buffer& buffer_state) {
                        return (buffer_state.usage & VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT) == 0;
                    },
@@ -3099,22 +3081,15 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryEXT(VkCommandBuffer commandBu
                    kUsageErrorMsgBuffer}}}};
 
             const Location src_loc = region_loc.dot(Field::srcAddress);
-            skip |= buffer_address_validator.ValidateDeviceAddress(*this, src_loc, objlist, start, size);
+            skip |= buffer_address_validator.ValidateDeviceAddress(*this, src_loc, objlist, start, size,
+                                                                   "VUID-VkDecompressMemoryRegionEXT-srcAddress-07686");
         }
 
         if (region.decompressedSize > 0) {
             const VkDeviceAddress start = region.dstAddress;
             const VkDeviceSize size = region.decompressedSize;
-            BufferAddressValidation<2> dst_range_validator = {
-                {{{"VUID-VkDecompressMemoryRegionEXT-dstAddress-07688",
-                   [start, size](const vvl::Buffer& buffer_state) {
-                       const VkDeviceSize end =
-                           buffer_state.GetSize() - static_cast<VkDeviceSize>(start - buffer_state.deviceAddress);
-                       return size > end;
-                   },
-                   [size]() { return "The decompressedSize (" + std::to_string(size) + ") does not fit in any buffer"; },
-                   kEmptyErrorMsgBuffer},
-                  {"VUID-VkDecompressMemoryRegionEXT-dstAddress-11765",
+            BufferAddressValidation<1> dst_range_validator = {
+                {{{"VUID-VkDecompressMemoryRegionEXT-dstAddress-11765",
                    [](const vvl::Buffer& buffer_state) {
                        return (buffer_state.usage & VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT) == 0;
                    },
@@ -3122,7 +3097,8 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryEXT(VkCommandBuffer commandBu
                    kUsageErrorMsgBuffer}}}};
 
             const Location dst_loc = region_loc.dot(Field::dstAddress);
-            skip |= dst_range_validator.ValidateDeviceAddress(*this, dst_loc, objlist, start, size);
+            skip |= dst_range_validator.ValidateDeviceAddress(*this, dst_loc, objlist, start, size,
+                                                              "VUID-VkDecompressMemoryRegionEXT-dstAddress-07688");
         }
     }
 

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -648,22 +648,13 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoDevice(
                 if (micromap_khr->indexType != VK_INDEX_TYPE_NONE_KHR) {
                     const uint64_t index_buffer_size =
                         uint64_t(micromap_khr->indexStride) * uint64_t(geometry_build_range_primitive_count);
-                    const vvl::range<VkDeviceAddress> index_buffer_range(micromap_khr->indexBuffer,
-                                                                         micromap_khr->indexBuffer + index_buffer_size);
-
-                    BufferAddressValidation<1> index_buffer_range_validator = {{{
-                        {"VUID-vkCmdBuildAccelerationStructuresKHR-indexBuffer-11577",
-                         [index_buffer_range](const vvl::Buffer& buffer_state) {
-                             return !buffer_state.DeviceAddressRange().includes(index_buffer_range);
-                         },
-                         []() { return "The opacity micromap indexBuffer does not fit in any buffer"; }, kEmptyErrorMsgBuffer},
-                    }}};
-
+                    BufferAddressValidation<0> index_buffer_range_validator;
                     skip |= index_buffer_range_validator.ValidateDeviceAddress(
                         *this,
                         p_geom_geom_triangles_loc.pNext(Struct::VkAccelerationStructureTrianglesOpacityMicromapKHR,
                                                         Field::indexBuffer),
-                        cb_objlist, micromap_khr->indexBuffer, index_buffer_size);
+                        cb_objlist, micromap_khr->indexBuffer, index_buffer_size,
+                        "VUID-vkCmdBuildAccelerationStructuresKHR-indexBuffer-11577");
                 }
 
                 if (auto micromap = Get<vvl::AccelerationStructureKHR>(micromap_khr->micromap)) {
@@ -970,22 +961,14 @@ bool CoreChecks::ValidateAccelerationStructureBuildScratch(VkCommandBuffer cmd_b
                 : pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12260",
                             "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12260");
 
-        BufferAddressValidation<2> buffer_address_validator = {
+        BufferAddressValidation<1> buffer_address_validator = {
             {{{scratch_buffer_has_storage_flag_vuid,
                [](const vvl::Buffer& buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT) == 0; },
-               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT"; }, kUsageErrorMsgBuffer},
+               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT"; }, kUsageErrorMsgBuffer}}}};
 
-              {scratch_address_range_vuid,
-               [scratch_address_range](const vvl::Buffer& buffer_state) {
-                   const vvl::range<VkDeviceSize> buffer_address_range = buffer_state.DeviceAddressRange();
-                   return !buffer_address_range.includes(scratch_address_range);
-               },
-               [scratch_size]() { return "The scratch size (" + std::to_string(scratch_size) + ") does not fit in any buffer"; },
-               kEmptyErrorMsgBuffer}}}};
-
-        skip |=
-            buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::scratchData).dot(Field::deviceAddress),
-                                                           LogObjectList(cmd_buffer), info.scratchData.deviceAddress, scratch_size);
+        skip |= buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::scratchData).dot(Field::deviceAddress),
+                                                               LogObjectList(cmd_buffer), info.scratchData.deviceAddress,
+                                                               scratch_size, scratch_address_range_vuid);
     }
 
     return skip;
@@ -2053,23 +2036,12 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer& 
     const VkDeviceSize requested_size = binding_table.size - 1;
     const vvl::range<VkDeviceSize> requested_range(binding_table.deviceAddress, binding_table.deviceAddress + requested_size);
 
-    BufferAddressValidation<3> buffer_address_validator = {{{
+    BufferAddressValidation<2> buffer_address_validator = {{{
         {vuid_binding_table_flag,
          [](const vvl::Buffer& buffer_state) {
              return (static_cast<uint32_t>(buffer_state.usage) & VK_BUFFER_USAGE_2_SHADER_BINDING_TABLE_BIT_KHR) == 0;
          },
          []() { return "The following buffers are missing VK_BUFFER_USAGE_2_SHADER_BINDING_TABLE_BIT_KHR"; }, kUsageErrorMsgBuffer},
-
-        {"VUID-VkStridedDeviceAddressRegionKHR-size-04631",
-         [&requested_range](const vvl::Buffer& buffer_state) {
-             const auto buffer_address_range = buffer_state.DeviceAddressRange();
-             return !buffer_address_range.includes(requested_range);
-         },
-         [&table_loc, &binding_table]() {
-             return "The " + table_loc.Fields() + "->size (" + std::to_string(binding_table.size) +
-                    ") - 1 does not fit in any buffer";
-         },
-         kEmptyErrorMsgBuffer},
 
         {"VUID-VkStridedDeviceAddressRegionKHR-size-04632",
          [&binding_table](const vvl::Buffer& buffer_state) { return binding_table.stride > buffer_state.GetSize(); },
@@ -2080,9 +2052,9 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer& 
          kEmptyErrorMsgBuffer},
     }}};
 
-    skip |= buffer_address_validator.ValidateDeviceAddress(*this, table_loc.dot(Field::deviceAddress),
-                                                           cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR),
-                                                           binding_table.deviceAddress, requested_size);
+    skip |= buffer_address_validator.ValidateDeviceAddress(
+        *this, table_loc.dot(Field::deviceAddress), cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR),
+        binding_table.deviceAddress, requested_size, "VUID-VkStridedDeviceAddressRegionKHR-size-04631");
 
     return skip;
 }

--- a/layers/core_checks/cc_ray_tracing_nv.cpp
+++ b/layers/core_checks/cc_ray_tracing_nv.cpp
@@ -430,23 +430,15 @@ bool CoreChecks::PreCallValidateCmdBuildPartitionedAccelerationStructuresNV(
     }
 
     {
-        BufferAddressValidation<2> buffer_address_validator = {
+        BufferAddressValidation<1> buffer_address_validator = {
             {{{"VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10550",
                [](const vvl::Buffer& buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT) == 0; },
-               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT"; }, kUsageErrorMsgBuffer},
-              {"VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10541",
-               [&build_size_info](const vvl::Buffer& buffer_state) {
-                   return buffer_state.requirements.size < build_size_info.buildScratchSize;
-               },
-               [&build_size_info]() {
-                   return "The buildScratchSize (" + std::to_string(build_size_info.buildScratchSize) +
-                          ") does not fit in any buffer";
-               },
-               kEmptyErrorMsgBuffer}}}};
+               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT"; }, kUsageErrorMsgBuffer}}}};
 
         skip |= buffer_address_validator.ValidateDeviceAddress(
             *this, error_obj.location.dot(Field::pBuildInfo).dot(Field::scratchData), LogObjectList(commandBuffer),
-            pBuildInfo->scratchData, build_size_info.buildScratchSize);
+            pBuildInfo->scratchData, build_size_info.buildScratchSize,
+            "VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10541");
     }
 
     {
@@ -520,26 +512,18 @@ bool CoreChecks::PreCallValidateCmdBuildPartitionedAccelerationStructuresNV(
     }
 
     {
-        BufferAddressValidation<2> buffer_address_validator = {
+        BufferAddressValidation<1> buffer_address_validator = {
             {{{"VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10552",
                [](const vvl::Buffer& buffer_state) {
                    return (buffer_state.usage & VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR) == 0;
                },
                []() { return "The following buffers are missing VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR"; },
-               kUsageErrorMsgBuffer},
-              {"VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10543",
-               [&build_size_info](const vvl::Buffer& buffer_state) {
-                   return buffer_state.requirements.size < build_size_info.accelerationStructureSize;
-               },
-               [&build_size_info]() {
-                   return "The accelerationStructureSize (" + std::to_string(build_size_info.accelerationStructureSize) +
-                          ") does not fit in any buffer";
-               },
-               kEmptyErrorMsgBuffer}}}};
+               kUsageErrorMsgBuffer}}}};
 
         skip |= buffer_address_validator.ValidateDeviceAddress(
             *this, error_obj.location.dot(Field::pBuildInfo).dot(Field::dstAccelerationStructureData), LogObjectList(commandBuffer),
-            pBuildInfo->dstAccelerationStructureData, build_size_info.accelerationStructureSize);
+            pBuildInfo->dstAccelerationStructureData, build_size_info.accelerationStructureSize,
+            "VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10543");
     }
 
     if (pBuildInfo->dstAccelerationStructureData && pBuildInfo->scratchData) {
@@ -626,33 +610,17 @@ bool CoreChecks::ValidateBuildPartitionedAccelerationStructureInfoNV(
                              build_info_loc.dot(Field::scratchData), "(0x%" PRIx64 ") must not be NULL", build_info.scratchData);
         }
     } else {
-        BufferAddressValidation<1> buffer_address_validator = {
-            {{{"VUID-VkBuildPartitionedAccelerationStructureInfoNV-scratchData-10559",
-               [&build_scratch_size](const vvl::Buffer& buffer_state) {
-                   return buffer_state.requirements.size < build_scratch_size;
-               },
-               [&build_scratch_size]() {
-                   return "The buildScratchSize (" + std::to_string(build_scratch_size) + ") does not fit in any buffer";
-               },
-               kEmptyErrorMsgBuffer}}}};
-
-        skip |= buffer_address_validator.ValidateDeviceAddress(*this, build_info_loc.dot(Field::scratchData), LogObjectList(device),
-                                                               build_info.scratchData, build_scratch_size);
+        BufferAddressValidation<0> buffer_address_validator;
+        skip |= buffer_address_validator.ValidateDeviceAddress(
+            *this, build_info_loc.dot(Field::scratchData), LogObjectList(device), build_info.scratchData, build_scratch_size,
+            "VUID-VkBuildPartitionedAccelerationStructureInfoNV-scratchData-10559");
     }
     if (build_info.dstAccelerationStructureData != 0) {
-        BufferAddressValidation<1> buffer_address_validator = {
-            {{{"VUID-VkBuildPartitionedAccelerationStructureInfoNV-dstAccelerationStructureData-10562",
-               [&build_acceleration_structure_size](const vvl::Buffer& buffer_state) {
-                   return buffer_state.requirements.size < build_acceleration_structure_size;
-               },
-               [&build_acceleration_structure_size]() {
-                   return "The accelerationStructureSize (" + std::to_string(build_acceleration_structure_size) +
-                          ") does not fit in any buffer";
-               },
-               kEmptyErrorMsgBuffer}}}};
-        skip |= buffer_address_validator.ValidateDeviceAddress(*this, build_info_loc.dot(Field::dstAccelerationStructureData),
-                                                               LogObjectList(device), build_info.dstAccelerationStructureData,
-                                                               build_acceleration_structure_size);
+        BufferAddressValidation<0> buffer_address_validator;
+        skip |= buffer_address_validator.ValidateDeviceAddress(
+            *this, build_info_loc.dot(Field::dstAccelerationStructureData), LogObjectList(device),
+            build_info.dstAccelerationStructureData, build_acceleration_structure_size,
+            "VUID-VkBuildPartitionedAccelerationStructureInfoNV-dstAccelerationStructureData-10562");
     }
 
     if (!IsPointerAligned(build_info.srcInfosCount, 4)) {
@@ -945,22 +913,11 @@ bool CoreChecks::ValidateClusterAccelerationStructureCommandsInfoNV(
         } else {
             if (!invalid_triangle_input &&
                 command_infos.input.opType != VK_CLUSTER_ACCELERATION_STRUCTURE_OP_TYPE_MOVE_OBJECTS_NV) {
-                BufferAddressValidation<1> dst_implicit_size_validator = {{{
-                    {"VUID-VkClusterAccelerationStructureCommandsInfoNV-opMode-12310",
-                     [&accelerationStructure_size](const vvl::Buffer& buffer_state) {
-                         return buffer_state.GetSize() < accelerationStructure_size.accelerationStructureSize;
-                     },
-                     [&accelerationStructure_size]() {
-                         return "The accelerationStructureSize (" +
-                                std::to_string(accelerationStructure_size.accelerationStructureSize) +
-                                ") does not fit in any buffer";
-                     },
-                     kEmptyErrorMsgBuffer},
-                }}};
-
-                skip |= dst_implicit_size_validator.ValidateDeviceAddress(*this, command_infos_loc.dot(Field::dstImplicitData),
-                                                                          objlist, command_infos.dstImplicitData,
-                                                                          accelerationStructure_size.accelerationStructureSize);
+                BufferAddressValidation<0> dst_implicit_size_validator;
+                skip |= dst_implicit_size_validator.ValidateDeviceAddress(
+                    *this, command_infos_loc.dot(Field::dstImplicitData), objlist, command_infos.dstImplicitData,
+                    accelerationStructure_size.accelerationStructureSize,
+                    "VUID-VkClusterAccelerationStructureCommandsInfoNV-opMode-12310");
             }
         }
     }

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -2298,3 +2298,22 @@ TEST_F(NegativeDescriptorBuffer, MaxBufferRange) {
     vk::GetDescriptorEXT(device(), get_info_s, descriptor_buffer_properties.storageBufferDescriptorSize, host_data);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeDescriptorBuffer, DescriptorAddressRangeAtOffset) {
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
+
+    vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, vkt::device_address);
+    VkDescriptorAddressInfoEXT address_info = vku::InitStructHelper();
+    address_info.address = buffer.Address() + 2048;
+    address_info.range = 2560;
+    address_info.format = VK_FORMAT_UNDEFINED;
+
+    VkDescriptorGetInfoEXT get_info = vku::InitStructHelper();
+    get_info.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    get_info.data.pUniformBuffer = &address_info;
+
+    std::vector<uint8_t> descriptor(descriptor_buffer_properties.uniformBufferDescriptorSize);
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorAddressInfoEXT-range-08045");
+    vk::GetDescriptorEXT(device(), &get_info, descriptor.size(), descriptor.data());
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -2317,3 +2317,20 @@ TEST_F(PositiveDescriptorBuffer, MutableDescriptor) {
         ASSERT_EQ(data[2], 20u);
     }
 }
+
+TEST_F(PositiveDescriptorBuffer, DescriptorAddressRangeAtOffset) {
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
+
+    vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, vkt::device_address);
+    VkDescriptorAddressInfoEXT address_info = vku::InitStructHelper();
+    address_info.address = buffer.Address() + 2048;
+    address_info.range = 2048;
+    address_info.format = VK_FORMAT_UNDEFINED;
+
+    VkDescriptorGetInfoEXT get_info = vku::InitStructHelper();
+    get_info.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    get_info.data.pUniformBuffer = &address_info;
+
+    std::vector<uint8_t> descriptor(descriptor_buffer_properties.uniformBufferDescriptorSize);
+    vk::GetDescriptorEXT(device(), &get_info, descriptor.size(), descriptor.data());
+}

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -4509,6 +4509,11 @@ TEST_F(NegativeRayTracing, BuildPartitionedAccelerationStructureInfo) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10542");
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10544");
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10545");
+    // Both buffers are exactly the required size, so starting one byte in means the build no longer fits
+    m_errorMonitor->SetDesiredError("VUID-VkBuildPartitionedAccelerationStructureInfoNV-scratchData-10559");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10541");
+    m_errorMonitor->SetDesiredError("VUID-VkBuildPartitionedAccelerationStructureInfoNV-dstAccelerationStructureData-10562");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10543");
     vk::CmdBuildPartitionedAccelerationStructuresNV(m_command_buffer, &command_info);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();

--- a/tests/unit/ray_tracing_micromap.cpp
+++ b/tests/unit/ray_tracing_micromap.cpp
@@ -789,6 +789,8 @@ TEST_F(NegativeRayTracingMicromap, CmdBuildAccelerationStructureTriangleMicromap
         m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureTrianglesOpacityMicromapKHR-indexStride-11574");
         m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureTrianglesOpacityMicromapKHR-indexStride-11573");
+        // (indexStride * primitiveCount) overflows, so the index buffer cannot fit in any buffer either
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-indexBuffer-11577");
         vk::CmdBuildAccelerationStructuresKHR(m_command_buffer, 1, &build_info, &range_info_ptr);
         m_errorMonitor->VerifyFound();
         m_command_buffer.End();


### PR DESCRIPTION
Move the logic to validate

```
Validation Error: [ VUID-VkDeviceAddressRangeKHR-address-11365 ] | MessageID = 0xd5e113ef
vkWriteResourceDescriptorsEXT(): pResources[0].data.pTexelBuffer->addressRange.address [0x640000000, 0x640000080) (128 bytes) has no buffer(s) associated that are valid.
The following buffers are too small to hold the range:
  VkBuffer 0x30000000003, size: 64 bytes, range: [0x640000000, 0x640000040) 
```

to a single spot inside `cc_buffer_address.h` instead of making every spot try to manually redo it