### PR TITLE
layers: Reduce memory for every BufferAddressValidation

### DIFF
--- a/layers/core_checks/cc_buffer_address.h
+++ b/layers/core_checks/cc_buffer_address.h
@@ -89,8 +89,10 @@ class BufferAddressValidation {
     //   [ChecksCount + 0] - "valid generic VkDeviceAddress" check (always)
     //   [ChecksCount + 1] - "range fits inside the buffer" check (when caller passes a range VUID)
     std::array<VuidAndValidation, ChecksCount + 2> vuid_and_validations;
+
     // There are times the caller will want to update state for each buffer object found
-    UpdateCallback update_callback = [](const vvl::Buffer&) {};
+    // Left unset (nullptr) by default since only 1 of like 30 callers need this and was wasting an allocation
+    UpdateCallback update_callback = nullptr;
 
     // We use vvl::DeviceProxy instead of CoreChecks here as a current hack to allow GPU-AV to use this. We still need a better
     // system to share CoreChecks with GPU-AV
@@ -189,21 +191,26 @@ bool BufferAddressValidation<ChecksCount>::HasValidBuffer(vvl::span<vvl::Buffer*
     for (const auto& buffer : buffer_list) {
         ASSERT_AND_CONTINUE(buffer);
 
-        // Call here as we will need to update once for each buffer
-        update_callback(*buffer);
+        // Once a valid buffer is found, the only reason left to keep walking the list is update_callback
+        if (any_buffer_found && !update_callback) {
+            break;
+        }
+        if (update_callback) {
+            update_callback(*buffer);
+        }
+        if (any_buffer_found) {
+            continue;
+        }
 
         bool is_buffer_valid = true;
-        // Once we find any buffer is valid, can just skip checking
-        if (!any_buffer_found) {
-            for (size_t i = 0; i < active_checks; ++i) {
-                if (vuid_and_validations[i].is_invalid_func(*buffer)) {
-                    is_buffer_valid = false;
-                    break;
-                }
+        for (size_t i = 0; i < active_checks; ++i) {
+            if (vuid_and_validations[i].is_invalid_func(*buffer)) {
+                is_buffer_valid = false;
+                break;
             }
         }
 
-        any_buffer_found |= is_buffer_valid;
+        any_buffer_found = is_buffer_valid;
     }
     return any_buffer_found;
 }

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -3123,11 +3123,9 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryIndirectCountEXT(VkCommandBuf
                []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; }, kUsageErrorMsgBuffer},
 
               {"VUID-vkCmdDecompressMemoryIndirectCountEXT-indirectCommandsAddress-11794",
-               [indirectCommandsAddress, stride, maxDecompressionCount](const vvl::Buffer& buffer_state) {
-                   if (maxDecompressionCount == 0 || stride == 0) return false;
-                   const vvl::range<VkDeviceSize> required_range(
-                       indirectCommandsAddress, indirectCommandsAddress + static_cast<VkDeviceSize>(stride) *
-                                                                              static_cast<VkDeviceSize>(maxDecompressionCount));
+               [indirectCommandsAddress, max_range_size](const vvl::Buffer& buffer_state) {
+                   if (max_range_size == 0) return false;
+                   const vvl::range<VkDeviceSize> required_range(indirectCommandsAddress, indirectCommandsAddress + max_range_size);
                    const vvl::range<VkDeviceSize> buffer_address_range = buffer_state.DeviceAddressRange();
                    return !buffer_address_range.includes(required_range);
                },

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -2051,7 +2051,7 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer& 
 
         {"VUID-VkStridedDeviceAddressRegionKHR-size-04632",
          [&binding_table](const vvl::Buffer& buffer_state) { return binding_table.stride > buffer_state.GetSize(); },
-         [table_loc, &binding_table]() {
+         [&table_loc, &binding_table]() {
              return "The " + table_loc.Fields() + "->stride (" + std::to_string(binding_table.stride) +
                     ") does not fit in any buffer";
          },


### PR DESCRIPTION
Found by setting 

```patch
- UpdateCallback update_callback = [](const vvl::Buffer&) {};
+UpdateCallback update_callback = nullptr;
```

inside BufferAddressValidation` the `std::function` doesn't need to allocate it. There was only one check that needed the `update_callback` system 

while looking, found 2 other spots that were using extra memory than needed