### PR TITLE
layers: Better Pipeline Layout Compatibility message

### DIFF
--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1936,11 +1936,23 @@ bool CoreChecks::ValidateActionStateDescriptorsPipeline(const LastBound& last_bo
             std::string error_string;
             const auto ds_slot = last_bound_state.ds_slots[set_index];
             if (!ds_slot.ds_state) {
-                skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::COMPATIBLE_PIPELINE_08600),
+                if (ds_slot.disturbed_pipeline_layout != VK_NULL_HANDLE) {
+                    skip |= LogError(
+                        CreateActionVuid(loc.function, vvl::ActionVUID::COMPATIBLE_PIPELINE_08600),
+                        cb_state.GetObjectList(bind_point), loc,
+                        "%s uses set %" PRIu32
+                        " but that set is not bound because it was disturbed by a previous call (like vkCmdBindDescriptorSets) "
+                        "that set %s which is not compatible.\nSee "
+                        "https://docs.vulkan.org/spec/latest/chapters/descriptorsets.html#descriptorsets-compatibility",
+                        FormatHandle(pipeline).c_str(), set_index, FormatHandle(ds_slot.disturbed_pipeline_layout).c_str());
+                } else {
+                    skip |=
+                        LogError(CreateActionVuid(loc.function, vvl::ActionVUID::COMPATIBLE_PIPELINE_08600),
                                  cb_state.GetObjectList(bind_point), loc,
                                  "%s uses set %" PRIu32
                                  " but that set is not bound. (Need to use a command like vkCmdBindDescriptorSets to bind the set)",
                                  FormatHandle(pipeline).c_str(), set_index);
+                }
             } else if (pipeline_layout->set_layouts.list[set_index] &&
                        !VerifyDescriptorSetIsCompatibile(*ds_slot.ds_state, *pipeline_layout->set_layouts.list[set_index],
                                                          error_string)) {
@@ -2201,10 +2213,22 @@ bool CoreChecks::ValidateActionStateDescriptorsShaderObject(const LastBound& las
                 std::string error_string;
                 const auto ds_slot = last_bound_state.ds_slots[set_index];
                 if (!ds_slot.ds_state) {
-                    const LogObjectList objlist(cb_state.Handle(), shader_object.Handle());
-                    skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::COMPATIBLE_PIPELINE_08600), objlist, loc,
-                                     "%s uses set %" PRIu32 " but that set is not bound.",
-                                     FormatHandle(shader_object.Handle()).c_str(), set_index);
+                    if (ds_slot.disturbed_pipeline_layout != VK_NULL_HANDLE) {
+                        skip |= LogError(
+                            CreateActionVuid(loc.function, vvl::ActionVUID::COMPATIBLE_PIPELINE_08600),
+                            cb_state.GetObjectList(bind_point), loc,
+                            "%s uses set %" PRIu32
+                            " but that set is not bound because it was disturbed by a previous call (like vkCmdBindDescriptorSets) "
+                            "that set %s which is not compatible\nSee "
+                            "https://docs.vulkan.org/spec/latest/chapters/descriptorsets.html#descriptorsets-compatibility",
+                            FormatHandle(shader_object.Handle()).c_str(), set_index,
+                            FormatHandle(ds_slot.disturbed_pipeline_layout).c_str());
+                    } else {
+                        const LogObjectList objlist(cb_state.Handle(), shader_object.Handle());
+                        skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::COMPATIBLE_PIPELINE_08600), objlist, loc,
+                                         "%s uses set %" PRIu32 " but that set is not bound.",
+                                         FormatHandle(shader_object.Handle()).c_str(), set_index);
+                    }
                 } else if (shader_object.set_layouts.list[set_index] &&
                            !VerifyDescriptorSetIsCompatibile(*ds_slot.ds_state, *shader_object.set_layouts.list[set_index],
                                                              error_string)) {

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1820,8 +1820,12 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
         auto& ds_slot = last_bound.ds_slots[set_idx];
         if (ds_slot.compat_id_for_set != pipe_compat_ids[set_idx]) {
             PushDescriptorCleanup(last_bound, set_idx);
+            const bool was_bound = ds_slot.ds_state != nullptr;
             ds_slot.Reset();
             ds_slot.compat_id_for_set = pipe_compat_ids[set_idx];
+            if (was_bound) {
+                ds_slot.disturbed_pipeline_layout = pipeline_layout->VkHandle();
+            }
         }
     }
 

--- a/layers/state_tracker/last_bound_state.h
+++ b/layers/state_tracker/last_bound_state.h
@@ -84,10 +84,14 @@ struct LastBound {
         uint64_t validated_set_change_count{~0ULL};
         uint64_t validated_set_image_layout_change_count{~0ULL};
 
+        // For better error messages to know if the layout was disturbed
+        VkPipelineLayout disturbed_pipeline_layout{VK_NULL_HANDLE};
+
         void Reset() {
             ds_state.reset();
             descriptor_buffer_binding.reset();
             dynamic_offsets.clear();
+            disturbed_pipeline_layout = VK_NULL_HANDLE;
         }
     };
 

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -5053,6 +5053,52 @@ TEST_F(NegativeDescriptors, DispatchWithUnboundSet) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeDescriptors, DisturbedSetPushConstantRanges) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7307");
+    RETURN_IF_SKIP(Init());
+
+    char const* shader_source = R"glsl(
+        #version 460
+        layout(set = 0, binding = 0) buffer SSBO {
+            uint x;
+        } ssbo;
+
+        void main() {
+            ssbo.x = 1;
+        }
+    )glsl";
+
+    OneOffDescriptorSet descriptor_set_0(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
+    OneOffDescriptorSet descriptor_set_1(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
+    vkt::Buffer ssbo_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
+    descriptor_set_0.WriteDescriptorBufferInfo(0, ssbo_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    descriptor_set_0.UpdateDescriptorSets();
+    descriptor_set_1.WriteDescriptorBufferInfo(0, ssbo_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    descriptor_set_1.UpdateDescriptorSets();
+
+    // different push constant ranges
+    const vkt::PipelineLayout pipeline_layout_a(*m_device, {&descriptor_set_0.layout_, &descriptor_set_1.layout_});
+    VkPushConstantRange pc_range = {VK_SHADER_STAGE_COMPUTE_BIT, 0, 16};
+    const vkt::PipelineLayout pipeline_layout_b(*m_device, {&descriptor_set_0.layout_, &descriptor_set_1.layout_}, {pc_range});
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cs_ = VkShaderObj(*m_device, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
+    pipe.cp_ci_.layout = pipeline_layout_b;
+    pipe.CreateComputePipeline();
+
+    VkDescriptorSet sets[2] = {descriptor_set_0.set_, descriptor_set_1.set_};
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_a, 0u, 2u, sets, 0u, nullptr);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_b, 1u, 1u, &descriptor_set_1.set_,
+                              0u, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-08600");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeDescriptors, CompatiblePushConstantRanges) {
     RETURN_IF_SKIP(Init());
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7307

```
Validation Error: [ VUID-vkCmdDispatch-None-08600 ] | MessageID = 0x3450abd3
vkCmdDispatch(): VkPipeline 0x110000000011 uses set 0 but that set is not bound. (Need to use a command like vkCmdBindDescriptorSets to bind the set).
```

now becomes

```
vkCmdDispatch(): VkPipeline 0x110000000011 uses set 0 but that set is not bound because it was disturbed by a previous call (like vkCmdBindDescriptorSets) that set VkPipelineLayout 0xd000000000d which is not compatible
See https://docs.vulkan.org/spec/latest/chapters/descriptorsets.html#descriptorsets-compatibility.
```