### PR TITLE
sync: Cleanup and add missing tests

### DIFF
--- a/layers/sync/sync_command.cpp
+++ b/layers/sync/sync_command.cpp
@@ -809,8 +809,8 @@ void DispatchIndirectCommand::Apply(SyncEnvironment& env, ResourceUsageTag tag, 
 }
 
 DrawAttachmentCommand DrawAttachmentCommand::Storage::MakeCommand(RenderPassAccessContext* render_pass_context,
-                                                                  const RenderingInstance* rendering_info) const {
-    return {pipeline, render_pass_context, rendering_info, render_pass_instance_id, depth_write, stencil_write};
+                                                                  const RenderingInstance* rendering_instance) const {
+    return {pipeline, render_pass_context, rendering_instance, render_pass_instance_id, depth_write, stencil_write};
 }
 
 DrawAttachmentCommand::Storage DrawAttachmentCommand::MakeStorage(CommandData& command_data) const {
@@ -881,9 +881,9 @@ void DrawIndirectCountCommand::Apply(SyncEnvironment& env, ResourceUsageTag tag,
 
 DrawMeshTasksCommand DrawMeshTasksCommand::Storage::MakeCommand(const CommandData& command_data,
                                                                 RenderPassAccessContext* render_pass_context,
-                                                                const RenderingInstance* rendering_instanc) const {
+                                                                const RenderingInstance* rendering_instance) const {
     return {shader_access_storage.MakeCommand(command_data),
-            attachment_access_storage.MakeCommand(render_pass_context, rendering_instanc)};
+            attachment_access_storage.MakeCommand(render_pass_context, rendering_instance)};
 }
 
 DrawMeshTasksCommand::Storage DrawMeshTasksCommand::MakeStorage(CommandData& command_data) const {

--- a/layers/sync/sync_command.h
+++ b/layers/sync/sync_command.h
@@ -302,6 +302,20 @@ struct ShaderAccessCommand {
                                    const ImageViewAccess& image_access) const;
 };
 
+// Returned by CommandBufferContext::CollectDescriptorAccesses.
+// The same data as ShaderAccessCommand, but owns the buffer/image access arrays
+struct DescriptorAccesses {
+    const vvl::Pipeline* pipeline = nullptr;
+    std::vector<ShaderAccessCommand::BufferAccess> buffer_accesses;
+    std::vector<ShaderAccessCommand::ImageViewAccess> image_accesses;
+    uint32_t render_pass_instance_id = vvl::kNoIndex32;
+    uint32_t subpass = vvl::kNoIndex32;
+
+    ShaderAccessCommand MakeCommand() const {
+        return {pipeline, buffer_accesses, image_accesses, render_pass_instance_id, subpass};
+    }
+};
+
 struct DispatchIndirectCommand {
     ShaderAccessCommand shader_accesses;
     BufferAccessCommand indirect_access;

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -661,8 +661,7 @@ void CommandBufferContext::RecordDispatchDrawDescriptorSet(VkPipelineBindPoint p
     }
 }
 
-CommandBufferContext::DescriptorAccesses CommandBufferContext::CollectDescriptorAccesses(
-    VkPipelineBindPoint pipelineBindPoint) const {
+DescriptorAccesses CommandBufferContext::CollectDescriptorAccesses(VkPipelineBindPoint pipelineBindPoint) const {
     DescriptorAccesses result;
     if (!sync_state_.syncval_settings.shader_accesses_heuristic) return result;
 
@@ -820,9 +819,7 @@ void CommandBufferContext::RecordShaderAccesses(ResourceUsageTag tag, Descriptor
     for (auto& access : descriptor_accesses.image_accesses) {
         access.handle_index = AddCommandHandle(tag, access.image_view->image_state->Handle()).handle_index;
     }
-    const ShaderAccessCommand command{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses,
-                                      descriptor_accesses.image_accesses, descriptor_accesses.render_pass_instance_id,
-                                      descriptor_accesses.subpass};
+    const ShaderAccessCommand command = descriptor_accesses.MakeCommand();
     const auto& settings = sync_state_.syncval_settings;
     if (settings.IsRecordTimeValidationEnabled()) {
         command.Apply(GetSyncEnvironment(), tag, GetCurrentAccessContext());

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -221,13 +221,6 @@ class CommandBufferContext final : public ResourceUsageInfoProvider, public Debu
     bool ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, const Location& loc) const;
     void RecordDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, ResourceUsageTag tag);
 
-    struct DescriptorAccesses {
-        const vvl::Pipeline* pipeline = nullptr;
-        std::vector<ShaderAccessCommand::BufferAccess> buffer_accesses;
-        std::vector<ShaderAccessCommand::ImageViewAccess> image_accesses;
-        uint32_t render_pass_instance_id = vvl::kNoIndex32;
-        uint32_t subpass = vvl::kNoIndex32;
-    };
     DescriptorAccesses CollectDescriptorAccesses(VkPipelineBindPoint pipelineBindPoint) const;
     void RecordShaderAccesses(ResourceUsageTag tag, DescriptorAccesses& descriptor_accesses);
 

--- a/layers/sync/sync_dynamic_rendering.cpp
+++ b/layers/sync/sync_dynamic_rendering.cpp
@@ -250,7 +250,7 @@ bool RenderingInstance::ValidateEndRendering(const SyncEnvironment& env, const A
         // Resolve/store operations do not happen when suspending
         return skip;
     }
-    for (uint32_t i = 0; i < (uint32_t)attachments.size(); i++) {
+    for (uint32_t i = 0; i < attachments.size(); i++) {
         const RenderingAttachment& attachment = attachments[i];
 
         auto attachment_description = [&validator, &attachment, i](const auto& view, std::ostringstream& ss) {

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1120,10 +1120,8 @@ bool SyncValidator::ValidateDispatch(VkCommandBuffer commandBuffer, const Locati
     }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
-    const auto descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_COMPUTE);
-    const ShaderAccessCommand command{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses,
-                                      descriptor_accesses.image_accesses, descriptor_accesses.render_pass_instance_id,
-                                      descriptor_accesses.subpass};
+    const DescriptorAccesses descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_COMPUTE);
+    const ShaderAccessCommand command = descriptor_accesses.MakeCommand();
     return command.Validate(cb_context, loc);
 }
 
@@ -1183,12 +1181,11 @@ bool SyncValidator::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBu
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
-    const auto descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_COMPUTE);
+    const DescriptorAccesses descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_COMPUTE);
     const AccessRange range = MakeRange(offset, sizeof(VkDispatchIndirectCommand));
 
     const DispatchIndirectCommand command{
-        ShaderAccessCommand{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses, descriptor_accesses.image_accesses,
-                            descriptor_accesses.render_pass_instance_id, descriptor_accesses.subpass},
+        descriptor_accesses.MakeCommand(),
         BufferAccessCommand{*indirect_buffer, range, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, vvl::kNoIndex32, 0,
                             BufferName::kIndirect}};
     return command.Validate(cb_context, error_obj.location);
@@ -1216,8 +1213,7 @@ void SyncValidator::PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuf
     }
 
     const DispatchIndirectCommand command{
-        ShaderAccessCommand{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses, descriptor_accesses.image_accesses,
-                            descriptor_accesses.render_pass_instance_id, descriptor_accesses.subpass},
+        descriptor_accesses.MakeCommand(),
         BufferAccessCommand{*indirect_buffer, range, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, indirect_buffer_tag_ex.handle_index,
                             0, BufferName::kIndirect}};
 
@@ -1503,11 +1499,8 @@ bool SyncValidator::PreCallValidateCmdDrawMeshTasksEXT(VkCommandBuffer commandBu
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
-    const auto descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_GRAPHICS);
-    const DrawMeshTasksCommand command{
-        ShaderAccessCommand{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses, descriptor_accesses.image_accesses,
-                            descriptor_accesses.render_pass_instance_id, descriptor_accesses.subpass},
-        cb_context.GetDrawAttachmentCommand()};
+    const DescriptorAccesses descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_GRAPHICS);
+    const DrawMeshTasksCommand command{descriptor_accesses.MakeCommand(), cb_context.GetDrawAttachmentCommand()};
     return command.Validate(cb_context, error_obj.location);
 }
 
@@ -1524,10 +1517,7 @@ void SyncValidator::PostCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuf
     for (auto& access : descriptor_accesses.image_accesses) {
         access.handle_index = cb_context.AddCommandHandle(tag, access.image_view->image_state->Handle()).handle_index;
     }
-    const DrawMeshTasksCommand command{
-        ShaderAccessCommand{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses, descriptor_accesses.image_accesses,
-                            descriptor_accesses.render_pass_instance_id, descriptor_accesses.subpass},
-        cb_context.GetDrawAttachmentCommand()};
+    const DrawMeshTasksCommand command{descriptor_accesses.MakeCommand(), cb_context.GetDrawAttachmentCommand()};
     if (syncval_settings.IsRecordTimeValidationEnabled()) {
         command.Apply(cb_context.GetSyncEnvironment(), tag, cb_context.GetCurrentAccessContext());
     }
@@ -1660,11 +1650,11 @@ bool SyncValidator::ValidateDrawIndirectCount(VkCommandBuffer commandBuffer, VkB
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const CommandBufferContext& cb_context = GetCommandBufferContext(*cb_state);
 
-    const auto descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_GRAPHICS);
+    const DescriptorAccesses descriptor_accesses = cb_context.CollectDescriptorAccesses(VK_PIPELINE_BIND_POINT_GRAPHICS);
     const AccessRange range = MakeRange(countBufferOffset, sizeof(uint32_t));
+
     const DrawIndirectCountCommand command{
-        ShaderAccessCommand{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses, descriptor_accesses.image_accesses,
-                            descriptor_accesses.render_pass_instance_id, descriptor_accesses.subpass},
+        descriptor_accesses.MakeCommand(),
         cb_context.GetDrawAttachmentCommand(),
         BufferAccessCommand{*count_buffer, range, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, vvl::kNoIndex32, 0, buffer_name}};
     return command.Validate(cb_context, loc);
@@ -1691,8 +1681,7 @@ void SyncValidator::RecordDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuf
     const AccessRange range = MakeRange(countBufferOffset, sizeof(uint32_t));
 
     const DrawIndirectCountCommand command{
-        ShaderAccessCommand{descriptor_accesses.pipeline, descriptor_accesses.buffer_accesses, descriptor_accesses.image_accesses,
-                            descriptor_accesses.render_pass_instance_id, descriptor_accesses.subpass},
+        descriptor_accesses.MakeCommand(),
         cb_context.GetDrawAttachmentCommand(),
         BufferAccessCommand{*count_buffer, range, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, count_tag_ex.handle_index, 0,
                             buffer_name}};

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -7072,3 +7072,87 @@ TEST_F(NegativeSyncVal, WaitEventImageLayoutTransition) {
     m_errorMonitor->VerifyFound();
     m_default_queue->Wait();
 }
+
+TEST_F(NegativeSyncVal, DrawIndirectByteCountSubmitTime) {
+    TEST_DESCRIPTION("Detect a counter buffer hazard at submit time");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::transformFeedback);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT tf_properties = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(tf_properties);
+    if (!tf_properties.transformFeedbackDraw) {
+        GTEST_SKIP() << "transformFeedbackDraw is not supported";
+    }
+
+    VkPipelineRenderingCreateInfo pipeline_rendering = vku::InitStructHelper();
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.renderArea.extent = {64, 64};
+    rendering_info.layerCount = 1;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering);
+    pipe.cb_ci_.attachmentCount = 0;
+    pipe.CreateGraphicsPipeline();
+
+    vkt::Buffer counter_buffer(*m_device, 16, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    vkt::CommandBuffer fill_cb(*m_device, m_command_pool);
+    fill_cb.Begin();
+    vk::CmdFillBuffer(fill_cb, counter_buffer, 4, sizeof(uint32_t), 0);
+    fill_cb.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(rendering_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdDrawIndirectByteCountEXT(m_command_buffer, 1, 0, counter_buffer, 4, 0, 4);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+
+    m_default_queue->Submit(fill_cb);
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-READ-AFTER-WRITE");
+    m_default_queue->Submit(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+    m_default_queue->Wait();
+}
+
+TEST_F(NegativeSyncVal, DrawMeshTasksIndirectCountSubmitTime) {
+    TEST_DESCRIPTION("Detect a count buffer hazard at submit time");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::maintenance4);
+    AddRequiredFeature(vkt::Feature::meshShader);
+    AddRequiredFeature(vkt::Feature::drawIndirectCount);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    VkPipelineRenderingCreateInfo pipeline_rendering = vku::InitStructHelper();
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.renderArea.extent = {64, 64};
+    rendering_info.layerCount = 1;
+    VkShaderObj mesh_shader(*m_device, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
+    CreatePipelineHelper pipe(*this, &pipeline_rendering);
+    pipe.cb_ci_.attachmentCount = 0;
+    pipe.shader_stages_[0] = mesh_shader.GetStageCreateInfo();
+    pipe.CreateGraphicsPipeline();
+
+    vkt::Buffer draw_buffer(*m_device, sizeof(VkDrawMeshTasksIndirectCommandEXT), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT);
+    vkt::Buffer count_buffer(*m_device, 16, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    vkt::CommandBuffer fill_cb(*m_device, m_command_pool);
+    fill_cb.Begin();
+    vk::CmdFillBuffer(fill_cb, count_buffer, 4, sizeof(uint32_t), 0);
+    fill_cb.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(rendering_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdDrawMeshTasksIndirectCountEXT(m_command_buffer, draw_buffer, 0, count_buffer, 4, 1,
+                                         sizeof(VkDrawMeshTasksIndirectCommandEXT));
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+
+    m_default_queue->Submit(fill_cb);
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-READ-AFTER-WRITE");
+    m_default_queue->Submit(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+    m_default_queue->Wait();
+}


### PR DESCRIPTION
Additional cleanup.
Added missing tests for recently updated `DrawIndirectCount` (had to update dynamic rendering first before adding them).